### PR TITLE
init,toc: move all define-library related to macro

### DIFF
--- a/init.c
+++ b/init.c
@@ -84,6 +84,7 @@ static Obj symintern;
 static Obj symsymbol_45cooked_63;
 static Obj symcora_47init_35var_45with_45ns;
 static Obj sym_42ns_45export_42;
+static Obj symns;
 static Obj symdefine_45library;
 static Obj symcora_47init_35parse_45define_45library;
 static Obj symimport;
@@ -96,7 +97,6 @@ static Obj symbegin;
 static Obj symdo;
 static Obj symcora_47init_35rewrite_45begin;
 static Obj symcora_47init_35parse;
-static Obj symns;
 static Obj symcora_47init_35rewrite_45namespace;
 static Obj symcora_47init_35propagate_45boolean;
 static Obj symnot;
@@ -244,6 +244,7 @@ symintern = intern("intern");
 symsymbol_45cooked_63 = intern("symbol-cooked?");
 symcora_47init_35var_45with_45ns = intern("cora/init#var-with-ns");
 sym_42ns_45export_42 = intern("*ns-export*");
+symns = intern("ns");
 symdefine_45library = intern("define-library");
 symcora_47init_35parse_45define_45library = intern("cora/init#parse-define-library");
 symimport = intern("import");
@@ -256,7 +257,6 @@ symbegin = intern("begin");
 symdo = intern("do");
 symcora_47init_35rewrite_45begin = intern("cora/init#rewrite-begin");
 symcora_47init_35parse = intern("cora/init#parse");
-symns = intern("ns");
 symcora_47init_35rewrite_45namespace = intern("cora/init#rewrite-namespace");
 symcora_47init_35propagate_45boolean = intern("cora/init#propagate-boolean");
 symnot = intern("not");
@@ -343,17 +343,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140246339622983 = primSet(co, symnull_63, makeNative(32, clofun5, 1, 0));
-Obj x140246339623719 = primSet(co, symcadr, makeNative(31, clofun5, 1, 0));
-Obj x140246339624455 = primSet(co, symcaar, makeNative(30, clofun5, 1, 0));
-Obj x140246339371239 = primSet(co, symcdar, makeNative(29, clofun5, 1, 0));
-Obj x140246339371975 = primSet(co, symcddr, makeNative(28, clofun5, 1, 0));
-Obj x140246339372903 = primSet(co, symcaddr, makeNative(27, clofun5, 1, 0));
-Obj x140246339374023 = primSet(co, symcadddr, makeNative(26, clofun5, 1, 0));
-Obj x140246339374951 = primSet(co, symcdddr, makeNative(25, clofun5, 1, 0));
-Obj x140246339319463 = primSet(co, symrcons, makeNative(23, clofun5, 1, 0));
-Obj x140246339320007 = primSet(co, sympair_63, makeNative(22, clofun5, 1, 0));
-Obj x140246339321415 = primSet(co, symcora_47init_35reverse_45h, makeNative(21, clofun5, 2, 0));
+Obj x140166664293415 = primSet(co, symnull_63, makeNative(32, clofun5, 1, 0));
+Obj x140166664294375 = primSet(co, symcadr, makeNative(31, clofun5, 1, 0));
+Obj x140166664131559 = primSet(co, symcaar, makeNative(30, clofun5, 1, 0));
+Obj x140166664132551 = primSet(co, symcdar, makeNative(29, clofun5, 1, 0));
+Obj x140166664133383 = primSet(co, symcddr, makeNative(28, clofun5, 1, 0));
+Obj x140166664134535 = primSet(co, symcaddr, makeNative(27, clofun5, 1, 0));
+Obj x140166664115271 = primSet(co, symcadddr, makeNative(26, clofun5, 1, 0));
+Obj x140166664116231 = primSet(co, symcdddr, makeNative(25, clofun5, 1, 0));
+Obj x140166664118151 = primSet(co, symrcons, makeNative(23, clofun5, 1, 0));
+Obj x140166664085959 = primSet(co, sympair_63, makeNative(22, clofun5, 1, 0));
+Obj x140166664087399 = primSet(co, symcora_47init_35reverse_45h, makeNative(21, clofun5, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
@@ -367,19 +367,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140246338969639 = __arg1;
-Obj x140246338969703 = primSet(co, symreverse, x140246338969639);
-Obj x140246338972327 = primSet(co, symmap_45h, makeNative(19, clofun5, 3, 0));
-Obj x140246338973031 = primSet(co, symmap, makeNative(18, clofun5, 2, 0));
-Obj x140246338973383 = primSet(co, sym_42macros_42, Nil);
-Obj x140246338949543 = primGenSym();
-Obj x140246338949607 = primSet(co, sym_42protect_45symbol_42, x140246338949543);
-Obj x140246338950855 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(17, clofun5, 2, 0));
-Obj x140246338824519 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(15, clofun5, 2, 0));
-Obj x140246338825063 = primSet(co, symcora_47init_35macroexpand1, makeNative(14, clofun5, 1, 0));
-Obj x140246338702727 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(8, clofun5, 1, 0));
-Obj x140246338703015 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj x140246338627719 = primSet(co, symdefmacro_45macro, makeNative(4, clofun5, 1, 0));
+Obj x140166664087847 = __arg1;
+Obj x140166664087879 = primSet(co, symreverse, x140166664087847);
+Obj x140166664081479 = primSet(co, symmap_45h, makeNative(19, clofun5, 3, 0));
+Obj x140166664082055 = primSet(co, symmap, makeNative(18, clofun5, 2, 0));
+Obj x140166664082343 = primSet(co, sym_42macros_42, Nil);
+Obj x140166664082759 = primGenSym();
+Obj x140166664082791 = primSet(co, sym_42protect_45symbol_42, x140166664082759);
+Obj x140166664083815 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(17, clofun5, 2, 0));
+Obj x140166664075783 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(15, clofun5, 2, 0));
+Obj x140166664076327 = primSet(co, symcora_47init_35macroexpand1, makeNative(14, clofun5, 1, 0));
+Obj x140166665232103 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(8, clofun5, 1, 0));
+Obj x140166665162759 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
+Obj x140166665165255 = primSet(co, symdefmacro_45macro, makeNative(4, clofun5, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -394,7 +394,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140246338628007 = __arg1;
+Obj x140166665165543 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -409,7 +409,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140246338628711 = __arg1;
+Obj x140166665166247 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -424,10 +424,10 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140246338602311 = __arg1;
-Obj x140246338603783 = primSet(co, symelem_63, makeNative(48, clofun4, 2, 0));
-Obj x140246338551975 = primSet(co, symatom_63, makeNative(47, clofun4, 1, 0));
-Obj x140246339748807 = primSet(co, symcora_47init_35rewrite_45let, makeNative(42, clofun4, 1, 0));
+Obj x140166665045639 = __arg1;
+Obj x140166665047111 = primSet(co, symelem_63, makeNative(48, clofun4, 2, 0));
+Obj x140166665047879 = primSet(co, symatom_63, makeNative(47, clofun4, 1, 0));
+Obj x140166664833447 = primSet(co, symcora_47init_35rewrite_45let, makeNative(42, clofun4, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -442,7 +442,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140246339749511 = __arg1;
+Obj x140166664834151 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -457,8 +457,8 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140246339711783 = __arg1;
-Obj x140246339714727 = primSet(co, symcora_47init_35rewrite_45or, makeNative(35, clofun4, 1, 0));
+Obj x140166664694023 = __arg1;
+Obj x140166664471687 = primSet(co, symcora_47init_35rewrite_45or, makeNative(35, clofun4, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -473,8 +473,8 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140246339621223 = __arg1;
-Obj x140246339624327 = primSet(co, symcora_47init_35rewrite_45and, makeNative(32, clofun4, 1, 0));
+Obj x140166664472391 = __arg1;
+Obj x140166664291463 = primSet(co, symcora_47init_35rewrite_45and, makeNative(32, clofun4, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -489,9 +489,9 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140246339371271 = __arg1;
-Obj x140246339372295 = primSet(co, symboolean_63, makeNative(30, clofun4, 1, 0));
-Obj x140246339374823 = primSet(co, symcora_47init_35rcons1, makeNative(27, clofun4, 1, 0));
+Obj x140166664292455 = __arg1;
+Obj x140166664293607 = primSet(co, symboolean_63, makeNative(30, clofun4, 1, 0));
+Obj x140166664133159 = primSet(co, symcora_47init_35rcons1, makeNative(27, clofun4, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -506,12 +506,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140246339318343 = __arg1;
-Obj x140246338701447 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(8, clofun4, 4, 0));
-Obj x140246338552135 = primSet(co, symcora_47init_35match1, makeNative(2, clofun4, 4, 0));
-Obj x140246338497895 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(44, clofun3, 2, 0));
-Obj x140246339750119 = primSet(co, symcora_47init_35match_45helper, makeNative(28, clofun3, 2, 0));
-Obj x140246339622599 = primSet(co, symcora_47init_35rewrite_45match, makeNative(21, clofun3, 1, 0));
+Obj x140166664134183 = __arg1;
+Obj x140166663950887 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(8, clofun4, 4, 0));
+Obj x140166663758855 = primSet(co, symcora_47init_35match1, makeNative(2, clofun4, 4, 0));
+Obj x140166665228583 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(44, clofun3, 2, 0));
+Obj x140166664833895 = primSet(co, symcora_47init_35match_45helper, makeNative(28, clofun3, 2, 0));
+Obj x140166664472871 = primSet(co, symcora_47init_35rewrite_45match, makeNative(21, clofun3, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -526,17 +526,17 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140246339623271 = __arg1;
-Obj x140246338825255 = primSet(co, symcora_47init_35extract_45rules1, makeNative(13, clofun3, 3, 0));
-Obj x140246338825959 = primSet(co, symcora_47init_35extract_45rules, makeNative(12, clofun3, 1, 0));
-Obj x140246338701063 = primSet(co, symcora_47init_35rules_45patterns, makeNative(9, clofun3, 2, 0));
-Obj x140246338702855 = primSet(co, symcora_47init_35length_45h, makeNative(8, clofun3, 2, 0));
-Obj x140246338625671 = primSet(co, symlength, makeNative(7, clofun3, 1, 0));
-Obj x140246338629031 = primSet(co, symcora_47init_35filter_45h, makeNative(5, clofun3, 3, 0));
-Obj x140246338601063 = primSet(co, symfilter, makeNative(4, clofun3, 2, 0));
-Obj x140246338602951 = primSet(co, symappend, makeNative(2, clofun3, 2, 0));
-Obj x140246338554567 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(45, clofun2, 1, 0));
-Obj x140246338494727 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(43, clofun2, 1, 0));
+Obj x140166664473447 = __arg1;
+Obj x140166664084871 = primSet(co, symcora_47init_35extract_45rules1, makeNative(13, clofun3, 3, 0));
+Obj x140166664073255 = primSet(co, symcora_47init_35extract_45rules, makeNative(12, clofun3, 1, 0));
+Obj x140166664075175 = primSet(co, symcora_47init_35rules_45patterns, makeNative(9, clofun3, 2, 0));
+Obj x140166664076743 = primSet(co, symcora_47init_35length_45h, makeNative(8, clofun3, 2, 0));
+Obj x140166663951367 = primSet(co, symlength, makeNative(7, clofun3, 1, 0));
+Obj x140166663954087 = primSet(co, symcora_47init_35filter_45h, makeNative(5, clofun3, 3, 0));
+Obj x140166663926183 = primSet(co, symfilter, makeNative(4, clofun3, 2, 0));
+Obj x140166663927879 = primSet(co, symappend, makeNative(2, clofun3, 2, 0));
+Obj x140166663759463 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(45, clofun2, 1, 0));
+Obj x140166663761095 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(43, clofun2, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -551,12 +551,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246338498407 = __arg1;
-Obj x140246338168039 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(25, clofun2, 1, 0));
-Obj x140246338495975 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(2, clofun2, 1, 0));
-Obj x140246338449831 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(1, clofun2, 1, 0));
-Obj x140246338451047 = primSet(co, symmacroexpand, makeNative(48, clofun1, 1, 0));
-Obj x140246338252295 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(43, clofun1, 1, 0));
+Obj x140166663577287 = __arg1;
+Obj x140166665230343 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(25, clofun2, 1, 0));
+Obj x140166663558887 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(2, clofun2, 1, 0));
+Obj x140166663559623 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(1, clofun2, 1, 0));
+Obj x140166663560679 = primSet(co, symmacroexpand, makeNative(48, clofun1, 1, 0));
+Obj x140166663366343 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(43, clofun1, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -571,8 +571,8 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140246338228743 = __arg1;
-Obj x140246338166887 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(36, clofun1, 1, 0));
+Obj x140166663367047 = __arg1;
+Obj x140166665093575 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(36, clofun1, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -587,9 +587,9 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140246338167591 = __arg1;
-Obj x140246337888199 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(29, clofun1, 4, 0));
-Obj x140246339850791 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(28, clofun1, 2, 0));
+Obj x140166665273735 = __arg1;
+Obj x140166665096071 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(29, clofun1, 4, 0));
+Obj x140166665096679 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(28, clofun1, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -604,159 +604,159 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140246339859751 = __arg1;
-Obj x140246339861447 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(15, clofun1, 2, 0));
-Obj x140246339873767 = primSet(co, symcora_47init_35lookup_45var, makeNative(5, clofun1, 3, 0));
-Obj x140246339874791 = makeCons(makeCString("primSet"), Nil);
-Obj x140246339858439 = makeCons(MAKE_NUMBER(2), x140246339874791);
-Obj x140246339858471 = makeCons(symset, x140246339858439);
-Obj x140246339859335 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x140246339859463 = makeCons(MAKE_NUMBER(1), x140246339859335);
-Obj x140246339859591 = makeCons(symcar, x140246339859463);
-Obj x140246339860583 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x140246339860647 = makeCons(MAKE_NUMBER(1), x140246339860583);
-Obj x140246339860679 = makeCons(symcdr, x140246339860647);
-Obj x140246339861607 = makeCons(makeCString("makeCons"), Nil);
-Obj x140246339861639 = makeCons(MAKE_NUMBER(2), x140246339861607);
-Obj x140246339861671 = makeCons(symcons, x140246339861639);
-Obj x140246339862471 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x140246339862503 = makeCons(MAKE_NUMBER(1), x140246339862471);
-Obj x140246339850247 = makeCons(symcons_63, x140246339862503);
-Obj x140246339851079 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x140246339851111 = makeCons(MAKE_NUMBER(2), x140246339851079);
-Obj x140246339851143 = makeCons(sym_43, x140246339851111);
-Obj x140246339852039 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x140246339852071 = makeCons(MAKE_NUMBER(2), x140246339852039);
-Obj x140246339852103 = makeCons(sym_45, x140246339852071);
-Obj x140246339852935 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x140246339852967 = makeCons(MAKE_NUMBER(2), x140246339852935);
-Obj x140246339852999 = makeCons(sym_42, x140246339852967);
-Obj x140246339853799 = makeCons(makeCString("primDiv"), Nil);
-Obj x140246339853831 = makeCons(MAKE_NUMBER(2), x140246339853799);
-Obj x140246339853863 = makeCons(sym_47, x140246339853831);
-Obj x140246339789223 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x140246339789255 = makeCons(MAKE_NUMBER(2), x140246339789223);
-Obj x140246339789287 = makeCons(sym_61, x140246339789255);
-Obj x140246339790279 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x140246339790311 = makeCons(MAKE_NUMBER(2), x140246339790279);
-Obj x140246339790343 = makeCons(sym_62, x140246339790311);
-Obj x140246339791399 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x140246339791431 = makeCons(MAKE_NUMBER(2), x140246339791399);
-Obj x140246339791463 = makeCons(sym_60, x140246339791431);
-Obj x140246339792263 = makeCons(makeCString("primGenSym"), Nil);
-Obj x140246339792455 = makeCons(MAKE_NUMBER(0), x140246339792263);
-Obj x140246339792487 = makeCons(symgensym, x140246339792455);
-Obj x140246339748455 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x140246339748487 = makeCons(MAKE_NUMBER(1), x140246339748455);
-Obj x140246339748519 = makeCons(symsymbol_63, x140246339748487);
-Obj x140246339750151 = makeCons(makeCString("primNot"), Nil);
-Obj x140246339750183 = makeCons(MAKE_NUMBER(1), x140246339750151);
-Obj x140246339750215 = makeCons(symnot, x140246339750183);
-Obj x140246339751367 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x140246339751431 = makeCons(MAKE_NUMBER(1), x140246339751367);
-Obj x140246339751463 = makeCons(syminteger_63, x140246339751431);
-Obj x140246339711975 = makeCons(makeCString("primIsString"), Nil);
-Obj x140246339712007 = makeCons(MAKE_NUMBER(1), x140246339711975);
-Obj x140246339712039 = makeCons(symstring_63, x140246339712007);
-Obj x140246339712135 = makeCons(x140246339712039, Nil);
-Obj x140246339712167 = makeCons(x140246339751463, x140246339712135);
-Obj x140246339712199 = makeCons(x140246339750215, x140246339712167);
-Obj x140246339712231 = makeCons(x140246339748519, x140246339712199);
-Obj x140246339712263 = makeCons(x140246339792487, x140246339712231);
-Obj x140246339712295 = makeCons(x140246339791463, x140246339712263);
-Obj x140246339712327 = makeCons(x140246339790343, x140246339712295);
-Obj x140246339712455 = makeCons(x140246339789287, x140246339712327);
-Obj x140246339712487 = makeCons(x140246339853863, x140246339712455);
-Obj x140246339712519 = makeCons(x140246339852999, x140246339712487);
-Obj x140246339712551 = makeCons(x140246339852103, x140246339712519);
-Obj x140246339712647 = makeCons(x140246339851143, x140246339712551);
-Obj x140246339712679 = makeCons(x140246339850247, x140246339712647);
-Obj x140246339712711 = makeCons(x140246339861671, x140246339712679);
-Obj x140246339712743 = makeCons(x140246339860679, x140246339712711);
-Obj x140246339712775 = makeCons(x140246339859591, x140246339712743);
-Obj x140246339712839 = makeCons(x140246339858471, x140246339712775);
-Obj x140246339712935 = primSet(co, symcora_47init_35_42builtin_45prims_42, x140246339712839);
-Obj x140246339374503 = primSet(co, symassq, makeNative(1, clofun1, 2, 0));
-Obj x140246339319015 = primSet(co, symcora_47init_35builtin_63, makeNative(48, clofun0, 1, 0));
-Obj x140246339960615 = primSet(co, symcora_47init_35parse, makeNative(15, clofun0, 4, 0));
-Obj x140246339988231 = makeCons(symappend, Nil);
-Obj x140246339988263 = makeCons(symfilter, x140246339988231);
-Obj x140246339988295 = makeCons(symlength, x140246339988263);
-Obj x140246339988327 = makeCons(symelem_63, x140246339988295);
-Obj x140246339988359 = makeCons(symmacroexpand, x140246339988327);
-Obj x140246339988391 = makeCons(symmap, x140246339988359);
-Obj x140246339988423 = makeCons(symreverse, x140246339988391);
-Obj x140246339988455 = makeCons(symthrow, x140246339988423);
-Obj x140246339988487 = makeCons(symtry, x140246339988455);
-Obj x140246339988519 = makeCons(symload, x140246339988487);
-Obj x140246339988551 = makeCons(symimport, x140246339988519);
-Obj x140246339988583 = makeCons(symload_45so, x140246339988551);
-Obj x140246339988615 = makeCons(symapply, x140246339988583);
-Obj x140246339988647 = makeCons(symvalue_45or, x140246339988615);
-Obj x140246339988679 = makeCons(symvalue, x140246339988647);
-Obj x140246339988711 = makeCons(symread_45file_45as_45sexp, x140246339988679);
-Obj x140246339988743 = makeCons(symbytes_45length, x140246339988711);
-Obj x140246339988775 = makeCons(symbytes, x140246339988743);
-Obj x140246339988807 = makeCons(symvector_45length, x140246339988775);
-Obj x140246339988839 = makeCons(symvector_45ref, x140246339988807);
-Obj x140246339988871 = makeCons(symvector_45set_33, x140246339988839);
-Obj x140246339988903 = makeCons(symvector, x140246339988871);
-Obj x140246339988935 = makeCons(symsymbol_45_62string, x140246339988903);
-Obj x140246339988967 = makeCons(symintern, x140246339988935);
-Obj x140246339988999 = makeCons(symstring_45append, x140246339988967);
-Obj x140246339989031 = makeCons(symnull_63, x140246339988999);
-Obj x140246339989063 = makeCons(symnumber_63, x140246339989031);
-Obj x140246339989095 = makeCons(symboolean_63, x140246339989063);
-Obj x140246339989127 = makeCons(symatom_63, x140246339989095);
-Obj x140246339989159 = makeCons(sympair_63, x140246339989127);
-Obj x140246339989191 = makeCons(symcdddr, x140246339989159);
-Obj x140246339989223 = makeCons(symcadddr, x140246339989191);
-Obj x140246339989255 = makeCons(symcaddr, x140246339989223);
-Obj x140246339989287 = makeCons(symcddr, x140246339989255);
-Obj x140246339989319 = makeCons(symcdar, x140246339989287);
-Obj x140246339989351 = makeCons(symcaar, x140246339989319);
-Obj x140246339989383 = makeCons(symcadr, x140246339989351);
-Obj x140246339989415 = primSet(co, symcora_47init_35_42ns_45export_42, x140246339989383);
-Obj x140246339956999 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj x140246339957287 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj x140246339957671 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj x140246339957959 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj x140246339958311 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj x140246339958599 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj x140246339958887 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj x140246339959207 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj x140246339959495 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj x140246339959815 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj x140246339960135 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj x140246339960455 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj x140246339960775 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj x140246339940583 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj x140246339940903 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj x140246339941319 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj x140246339941607 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj x140246339941895 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj x140246339942183 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj x140246339942535 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj x140246339942823 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj x140246339943111 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj x140246339943431 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj x140246339943719 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj x140246339944071 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj x140246339944423 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj x140246339928359 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj x140246339928711 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj x140246339928999 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj x140246339929351 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj x140246339929703 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj x140246339929991 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj x140246339930375 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj x140246339930663 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj x140246339931047 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj x140246339931335 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj x140246339931751 = primSet(co, symcora_47init_35append, globalRef(symappend));
-Obj x140246339931975 = primSet(co, symcora_47init_35assq, globalRef(symassq));
+Obj x140166664834247 = __arg1;
+Obj x140166664693639 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(15, clofun1, 2, 0));
+Obj x140166664292807 = primSet(co, symcora_47init_35lookup_45var, makeNative(5, clofun1, 3, 0));
+Obj x140166664131431 = makeCons(makeCString("primSet"), Nil);
+Obj x140166664131463 = makeCons(MAKE_NUMBER(2), x140166664131431);
+Obj x140166664131591 = makeCons(symset, x140166664131463);
+Obj x140166664133543 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x140166664133575 = makeCons(MAKE_NUMBER(1), x140166664133543);
+Obj x140166664133639 = makeCons(symcar, x140166664133575);
+Obj x140166664114823 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x140166664114855 = makeCons(MAKE_NUMBER(1), x140166664114823);
+Obj x140166664114919 = makeCons(symcdr, x140166664114855);
+Obj x140166664116647 = makeCons(makeCString("makeCons"), Nil);
+Obj x140166664116679 = makeCons(MAKE_NUMBER(2), x140166664116647);
+Obj x140166664116711 = makeCons(symcons, x140166664116679);
+Obj x140166664117927 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x140166664118215 = makeCons(MAKE_NUMBER(1), x140166664117927);
+Obj x140166664118247 = makeCons(symcons_63, x140166664118215);
+Obj x140166664087111 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x140166664087207 = makeCons(MAKE_NUMBER(2), x140166664087111);
+Obj x140166664087239 = makeCons(sym_43, x140166664087207);
+Obj x140166664088999 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x140166664089031 = makeCons(MAKE_NUMBER(2), x140166664088999);
+Obj x140166664089063 = makeCons(sym_45, x140166664089031);
+Obj x140166664082151 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x140166664082183 = makeCons(MAKE_NUMBER(2), x140166664082151);
+Obj x140166664082215 = makeCons(sym_42, x140166664082183);
+Obj x140166664083943 = makeCons(makeCString("primDiv"), Nil);
+Obj x140166664083975 = makeCons(MAKE_NUMBER(2), x140166664083943);
+Obj x140166664084007 = makeCons(sym_47, x140166664083975);
+Obj x140166664085383 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x140166664085415 = makeCons(MAKE_NUMBER(2), x140166664085383);
+Obj x140166664085447 = makeCons(sym_61, x140166664085415);
+Obj x140166664074567 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x140166664074599 = makeCons(MAKE_NUMBER(2), x140166664074567);
+Obj x140166664074631 = makeCons(sym_62, x140166664074599);
+Obj x140166664076167 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x140166664076359 = makeCons(MAKE_NUMBER(2), x140166664076167);
+Obj x140166664076519 = makeCons(sym_60, x140166664076359);
+Obj x140166663951655 = makeCons(makeCString("primGenSym"), Nil);
+Obj x140166663951687 = makeCons(MAKE_NUMBER(0), x140166663951655);
+Obj x140166663951719 = makeCons(symgensym, x140166663951687);
+Obj x140166663952999 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x140166663953031 = makeCons(MAKE_NUMBER(1), x140166663952999);
+Obj x140166663953095 = makeCons(symsymbol_63, x140166663953031);
+Obj x140166663954375 = makeCons(makeCString("primNot"), Nil);
+Obj x140166663925767 = makeCons(MAKE_NUMBER(1), x140166663954375);
+Obj x140166663925927 = makeCons(symnot, x140166663925767);
+Obj x140166663927239 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x140166663927335 = makeCons(MAKE_NUMBER(1), x140166663927239);
+Obj x140166663927367 = makeCons(syminteger_63, x140166663927335);
+Obj x140166663928903 = makeCons(makeCString("primIsString"), Nil);
+Obj x140166663928935 = makeCons(MAKE_NUMBER(1), x140166663928903);
+Obj x140166663928967 = makeCons(symstring_63, x140166663928935);
+Obj x140166663929127 = makeCons(x140166663928967, Nil);
+Obj x140166663929159 = makeCons(x140166663927367, x140166663929127);
+Obj x140166663929191 = makeCons(x140166663925927, x140166663929159);
+Obj x140166663929223 = makeCons(x140166663953095, x140166663929191);
+Obj x140166663929255 = makeCons(x140166663951719, x140166663929223);
+Obj x140166663929287 = makeCons(x140166664076519, x140166663929255);
+Obj x140166663929319 = makeCons(x140166664074631, x140166663929287);
+Obj x140166663929383 = makeCons(x140166664085447, x140166663929319);
+Obj x140166663929447 = makeCons(x140166664084007, x140166663929383);
+Obj x140166663929607 = makeCons(x140166664082215, x140166663929447);
+Obj x140166663929639 = makeCons(x140166664089063, x140166663929607);
+Obj x140166663929671 = makeCons(x140166664087239, x140166663929639);
+Obj x140166663929703 = makeCons(x140166664118247, x140166663929671);
+Obj x140166663929735 = makeCons(x140166664116711, x140166663929703);
+Obj x140166663929799 = makeCons(x140166664114919, x140166663929735);
+Obj x140166663929831 = makeCons(x140166664133639, x140166663929799);
+Obj x140166663757831 = makeCons(x140166664131591, x140166663929831);
+Obj x140166663757863 = primSet(co, symcora_47init_35_42builtin_45prims_42, x140166663757831);
+Obj x140166663561735 = primSet(co, symassq, makeNative(1, clofun1, 2, 0));
+Obj x140166663562983 = primSet(co, symcora_47init_35builtin_63, makeNative(48, clofun0, 1, 0));
+Obj x140166664834631 = primSet(co, symcora_47init_35parse, makeNative(15, clofun0, 4, 0));
+Obj x140166664473607 = makeCons(symappend, Nil);
+Obj x140166664473639 = makeCons(symfilter, x140166664473607);
+Obj x140166664473671 = makeCons(symlength, x140166664473639);
+Obj x140166664473703 = makeCons(symelem_63, x140166664473671);
+Obj x140166664473735 = makeCons(symmacroexpand, x140166664473703);
+Obj x140166664473767 = makeCons(symmap, x140166664473735);
+Obj x140166664473831 = makeCons(symreverse, x140166664473767);
+Obj x140166664473863 = makeCons(symthrow, x140166664473831);
+Obj x140166664473959 = makeCons(symtry, x140166664473863);
+Obj x140166664473991 = makeCons(symload, x140166664473959);
+Obj x140166664474023 = makeCons(symimport, x140166664473991);
+Obj x140166664474055 = makeCons(symload_45so, x140166664474023);
+Obj x140166664474087 = makeCons(symapply, x140166664474055);
+Obj x140166664474151 = makeCons(symvalue_45or, x140166664474087);
+Obj x140166664474183 = makeCons(symvalue, x140166664474151);
+Obj x140166664474247 = makeCons(symread_45file_45as_45sexp, x140166664474183);
+Obj x140166664474279 = makeCons(symbytes_45length, x140166664474247);
+Obj x140166664474599 = makeCons(symbytes, x140166664474279);
+Obj x140166664290343 = makeCons(symvector_45length, x140166664474599);
+Obj x140166664290407 = makeCons(symvector_45ref, x140166664290343);
+Obj x140166664290471 = makeCons(symvector_45set_33, x140166664290407);
+Obj x140166664290503 = makeCons(symvector, x140166664290471);
+Obj x140166664290631 = makeCons(symsymbol_45_62string, x140166664290503);
+Obj x140166664290663 = makeCons(symintern, x140166664290631);
+Obj x140166664290791 = makeCons(symstring_45append, x140166664290663);
+Obj x140166664290887 = makeCons(symnull_63, x140166664290791);
+Obj x140166664290919 = makeCons(symnumber_63, x140166664290887);
+Obj x140166664290951 = makeCons(symboolean_63, x140166664290919);
+Obj x140166664290983 = makeCons(symatom_63, x140166664290951);
+Obj x140166664291047 = makeCons(sympair_63, x140166664290983);
+Obj x140166664291111 = makeCons(symcdddr, x140166664291047);
+Obj x140166664291207 = makeCons(symcadddr, x140166664291111);
+Obj x140166664291239 = makeCons(symcaddr, x140166664291207);
+Obj x140166664291527 = makeCons(symcddr, x140166664291239);
+Obj x140166664291559 = makeCons(symcdar, x140166664291527);
+Obj x140166664291591 = makeCons(symcaar, x140166664291559);
+Obj x140166664291655 = makeCons(symcadr, x140166664291591);
+Obj x140166664291687 = primSet(co, symcora_47init_35_42ns_45export_42, x140166664291655);
+Obj x140166664292679 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
+Obj x140166664293095 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
+Obj x140166664293703 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
+Obj x140166664130887 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
+Obj x140166664131847 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
+Obj x140166664132391 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
+Obj x140166664133255 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
+Obj x140166664133959 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
+Obj x140166664134631 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
+Obj x140166664114727 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
+Obj x140166664115495 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
+Obj x140166664116039 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
+Obj x140166664116775 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
+Obj x140166664117223 = primSet(co, symcora_47init_35intern, globalRef(symintern));
+Obj x140166664117703 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
+Obj x140166664085799 = primSet(co, symcora_47init_35vector, globalRef(symvector));
+Obj x140166664086311 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
+Obj x140166664086983 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
+Obj x140166664087623 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
+Obj x140166664088423 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
+Obj x140166664089191 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
+Obj x140166664081607 = primSet(co, symcora_47init_35value, globalRef(symvalue));
+Obj x140166664081959 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
+Obj x140166664082695 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
+Obj x140166664083143 = primSet(co, symcora_47init_35apply, globalRef(symapply));
+Obj x140166664083879 = primSet(co, symcora_47init_35load, globalRef(symload));
+Obj x140166664084583 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
+Obj x140166664085031 = primSet(co, symcora_47init_35import, globalRef(symimport));
+Obj x140166664073223 = primSet(co, symcora_47init_35try, globalRef(symtry));
+Obj x140166664073799 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
+Obj x140166664074279 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
+Obj x140166664074951 = primSet(co, symcora_47init_35map, globalRef(symmap));
+Obj x140166664075431 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
+Obj x140166664076103 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
+Obj x140166663950599 = primSet(co, symcora_47init_35length, globalRef(symlength));
+Obj x140166663951047 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
+Obj x140166663951815 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj x140166663952167 = primSet(co, symcora_47init_35assq, globalRef(symassq));
 __nargs = 2;
-__arg1 = x140246339931975;
+__arg1 = x140166663952167;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -764,16 +764,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj x140246338949383 = __arg1;
-Obj x140246338949415 = __arg2;
-Obj x140246338949447 = __arg3;
-Obj x140246338949479 = co->args[4];
-Obj x140246338949831 = makeNative(19, clofun0, 0, 4, x140246338949383, x140246338949415, x140246338949447, x140246338949479);
-Obj __ = x140246338949383;
-__ = x140246338949415;
-__ = x140246338949447;
-Obj x = x140246338949479;
-pushCont(co, 16, clofun0, 2, x, x140246338949831);
+Obj x140166664130727 = __arg1;
+Obj x140166664130759 = __arg2;
+Obj x140166664130791 = __arg3;
+Obj x140166664130823 = co->args[4];
+Obj x140166664131175 = makeNative(19, clofun0, 0, 4, x140166664130727, x140166664130759, x140166664130791, x140166664130823);
+Obj __ = x140166664130727;
+__ = x140166664130759;
+__ = x140166664130791;
+Obj x = x140166664130823;
+pushCont(co, 16, clofun0, 2, x, x140166664131175);
 __nargs = 2;
 __arg0 = globalRef(symnumber_63);
 __arg1 = x;
@@ -786,10 +786,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140246339959175 = __arg1;
+Obj x140166664831623 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246339959175) {
+Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140166664831623) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -798,7 +798,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949831;
+__arg0 = x140166664131175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -806,8 +806,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140246339959559 = primIsString(x);
-if (True == x140246339959559) {
+Obj x140166664832135 = primIsString(x);
+if (True == x140166664832135) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -816,7 +816,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949831;
+__arg0 = x140166664131175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -824,7 +824,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 17, clofun0, 2, x, x140246338949831);
+pushCont(co, 17, clofun0, 2, x, x140166664131175);
 __nargs = 2;
 __arg0 = globalRef(symboolean_63);
 __arg1 = x;
@@ -839,10 +839,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140246339959943 = __arg1;
+Obj x140166664832807 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246339959943) {
+Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140166664832807) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -851,7 +851,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949831;
+__arg0 = x140166664131175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -859,7 +859,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 18, clofun0, 2, x, x140246338949831);
+pushCont(co, 18, clofun0, 2, x, x140166664131175);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
 __arg1 = x;
@@ -873,10 +873,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140246339960327 = __arg1;
+Obj x140166664833991 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246339960327) {
+Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140166664833991) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -885,7 +885,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949831;
+__arg0 = x140166664131175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -901,7 +901,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949831;
+__arg0 = x140166664131175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -913,35 +913,35 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140246338950535 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664131911 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj x140246339943303 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246339943303) {
-Obj x140246339943751 = PRIM_CAR(closureRef(co, 3));
-Obj x140246339943783 = PRIM_EQ(symquote, x140246339943751);
-if (True == x140246339943783) {
-Obj x140246339944199 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339944231 = PRIM_ISCONS(x140246339944199);
-if (True == x140246339944231) {
-Obj x140246339956935 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339956967 = PRIM_CAR(x140246339956935);
-Obj x = x140246339956967;
-Obj x140246339957575 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339957607 = PRIM_CDR(x140246339957575);
-Obj x140246339957639 = PRIM_EQ(Nil, x140246339957607);
-if (True == x140246339957639) {
-Obj x140246339958055 = makeCons(x, Nil);
-Obj x140246339958087 = makeCons(symquote, x140246339958055);
+Obj x140166665091847 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166665091847) {
+Obj x140166665092423 = PRIM_CAR(closureRef(co, 3));
+Obj x140166665092455 = PRIM_EQ(symquote, x140166665092423);
+if (True == x140166665092455) {
+Obj x140166665092871 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665092903 = PRIM_ISCONS(x140166665092871);
+if (True == x140166665092903) {
+Obj x140166665044391 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665044423 = PRIM_CAR(x140166665044391);
+Obj x = x140166665044423;
+Obj x140166665045511 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665045671 = PRIM_CDR(x140166665045511);
+Obj x140166665045703 = PRIM_EQ(Nil, x140166665045671);
+if (True == x140166665045703) {
+Obj x140166665046663 = makeCons(x, Nil);
+Obj x140166665046727 = makeCons(symquote, x140166665046663);
 __nargs = 2;
-__arg1 = x140246339958087;
+__arg1 = x140166665046727;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338950535;
+__arg0 = x140166664131911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -950,7 +950,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950535;
+__arg0 = x140166664131911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -959,7 +959,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950535;
+__arg0 = x140166664131911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -968,7 +968,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950535;
+__arg0 = x140166664131911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -979,13 +979,13 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140246338951495 = makeNative(22, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664132903 = makeNative(22, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj x = closureRef(co, 3);
-Obj x140246339942215 = primIsSymbol(x);
-if (True == x140246339942215) {
+Obj x140166665090663 = primIsSymbol(x);
+if (True == x140166665090663) {
 pushCont(co, 21, clofun0, 3, x, ns, import);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
@@ -998,7 +998,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338951495;
+__arg0 = x140166664132903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1009,11 +1009,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140246339942503 = __arg1;
+Obj x140166665090951 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140246339942503) {
+if (True == x140166665090951) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1035,34 +1035,34 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140246338952167 = makeNative(25, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664133607 = makeNative(25, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140246339928167 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246339928167) {
-Obj x140246339928615 = PRIM_CAR(closureRef(co, 3));
-Obj x140246339928647 = PRIM_EQ(symlambda, x140246339928615);
-if (True == x140246339928647) {
-Obj x140246339929063 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339929095 = PRIM_ISCONS(x140246339929063);
-if (True == x140246339929095) {
-Obj x140246339929511 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339929543 = PRIM_CAR(x140246339929511);
-Obj args = x140246339929543;
-Obj x140246339930119 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339930151 = PRIM_CDR(x140246339930119);
-Obj x140246339930183 = PRIM_ISCONS(x140246339930151);
-if (True == x140246339930183) {
-Obj x140246339930759 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339930791 = PRIM_CDR(x140246339930759);
-Obj x140246339930823 = PRIM_CAR(x140246339930791);
-Obj body = x140246339930823;
-Obj x140246339931591 = PRIM_CDR(closureRef(co, 3));
-Obj x140246339931623 = PRIM_CDR(x140246339931591);
-Obj x140246339931655 = PRIM_CDR(x140246339931623);
-Obj x140246339931687 = PRIM_EQ(Nil, x140246339931655);
-if (True == x140246339931687) {
+Obj x140166665165735 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166665165735) {
+Obj x140166665166631 = PRIM_CAR(closureRef(co, 3));
+Obj x140166665166663 = PRIM_EQ(symlambda, x140166665166631);
+if (True == x140166665166663) {
+Obj x140166665093447 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665093479 = PRIM_ISCONS(x140166665093447);
+if (True == x140166665093479) {
+Obj x140166665093927 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665093959 = PRIM_CAR(x140166665093927);
+Obj args = x140166665093959;
+Obj x140166665094663 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665094695 = PRIM_CDR(x140166665094663);
+Obj x140166665094759 = PRIM_ISCONS(x140166665094695);
+if (True == x140166665094759) {
+Obj x140166665095367 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665095399 = PRIM_CDR(x140166665095367);
+Obj x140166665095431 = PRIM_CAR(x140166665095399);
+Obj body = x140166665095431;
+Obj x140166665096231 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665096263 = PRIM_CDR(x140166665096231);
+Obj x140166665096295 = PRIM_CDR(x140166665096263);
+Obj x140166665096327 = PRIM_EQ(Nil, x140166665096295);
+if (True == x140166665096327) {
 pushCont(co, 23, clofun0, 4, ns, import, body, args);
 __nargs = 3;
 __arg0 = globalRef(symappend);
@@ -1075,7 +1075,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338952167;
+__arg0 = x140166664133607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1084,7 +1084,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338952167;
+__arg0 = x140166664133607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1093,7 +1093,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338952167;
+__arg0 = x140166664133607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1102,7 +1102,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338952167;
+__arg0 = x140166664133607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1111,7 +1111,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338952167;
+__arg0 = x140166664133607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1122,7 +1122,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140246339940807 = __arg1;
+Obj x140166665089095 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1130,7 +1130,7 @@ Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 24, clofun0, 1, args);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140246339940807;
+__arg1 = x140166665089095;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = body;
@@ -1143,13 +1143,13 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140246339940935 = __arg1;
+Obj x140166665089223 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339940999 = makeCons(x140246339940935, Nil);
-Obj x140246339941031 = makeCons(args, x140246339940999);
-Obj x140246339941063 = makeCons(symlambda, x140246339941031);
+Obj x140166665089287 = makeCons(x140166665089223, Nil);
+Obj x140166665089319 = makeCons(args, x140166665089287);
+Obj x140166665089351 = makeCons(symlambda, x140166665089319);
 __nargs = 2;
-__arg1 = x140246339941063;
+__arg1 = x140166665089351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1157,67 +1157,67 @@ goto *jumpTable[co->ctx.pc.label];
 
 label25:
 {
-Obj x140246338822279 = makeNative(28, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664114311 = makeNative(28, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140246338205447 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246338205447) {
-Obj x140246338206023 = PRIM_CAR(closureRef(co, 3));
-Obj x140246338206151 = PRIM_EQ(symdo, x140246338206023);
-if (True == x140246338206151) {
-Obj x140246338206567 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338206695 = PRIM_ISCONS(x140246338206567);
-if (True == x140246338206695) {
-Obj x140246338207399 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338207431 = PRIM_CAR(x140246338207399);
-Obj x140246338207463 = PRIM_ISCONS(x140246338207431);
-if (True == x140246338207463) {
-Obj x140246338167463 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338167495 = PRIM_CAR(x140246338167463);
-Obj x140246338167527 = PRIM_CAR(x140246338167495);
-Obj x140246338167623 = PRIM_EQ(symimport, x140246338167527);
-if (True == x140246338167623) {
-Obj x140246338168391 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338168423 = PRIM_CAR(x140246338168391);
-Obj x140246338168455 = PRIM_CDR(x140246338168423);
-Obj x140246338168487 = PRIM_ISCONS(x140246338168455);
-if (True == x140246338168487) {
-Obj x140246338169255 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338169287 = PRIM_CAR(x140246338169255);
-Obj x140246338169319 = PRIM_CDR(x140246338169287);
-Obj x140246338169351 = PRIM_CAR(x140246338169319);
-Obj pkg = x140246338169351;
-Obj x140246338170407 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338170439 = PRIM_CAR(x140246338170407);
-Obj x140246338170471 = PRIM_CDR(x140246338170439);
-Obj x140246338170631 = PRIM_CDR(x140246338170471);
-Obj x140246338170663 = PRIM_EQ(Nil, x140246338170631);
-if (True == x140246338170663) {
-Obj x140246337970695 = PRIM_CDR(closureRef(co, 3));
-Obj x140246337970727 = PRIM_CDR(x140246337970695);
-Obj x140246337970759 = PRIM_ISCONS(x140246337970727);
-if (True == x140246337970759) {
-Obj x140246337971431 = PRIM_CDR(closureRef(co, 3));
-Obj x140246337971463 = PRIM_CDR(x140246337971431);
-Obj x140246337971495 = PRIM_CAR(x140246337971463);
-Obj y = x140246337971495;
-Obj x140246337972487 = PRIM_CDR(closureRef(co, 3));
-Obj x140246337972519 = PRIM_CDR(x140246337972487);
-Obj x140246337972551 = PRIM_CDR(x140246337972519);
-Obj x140246337972583 = PRIM_EQ(Nil, x140246337972551);
-if (True == x140246337972583) {
-Obj x140246337972935 = primIsString(pkg);
-if (True == x140246337972935) {
-Obj x140246337974247 = makeCons(pkg, Nil);
-Obj x140246337885159 = makeCons(symimport, x140246337974247);
+Obj x140166665354471 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166665354471) {
+Obj x140166665354919 = PRIM_CAR(closureRef(co, 3));
+Obj x140166665354951 = PRIM_EQ(symdo, x140166665354919);
+if (True == x140166665354951) {
+Obj x140166665334919 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665334951 = PRIM_ISCONS(x140166665334919);
+if (True == x140166665334951) {
+Obj x140166665335719 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665335751 = PRIM_CAR(x140166665335719);
+Obj x140166665335783 = PRIM_ISCONS(x140166665335751);
+if (True == x140166665335783) {
+Obj x140166665336551 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665336583 = PRIM_CAR(x140166665336551);
+Obj x140166665336615 = PRIM_CAR(x140166665336583);
+Obj x140166665336647 = PRIM_EQ(symimport, x140166665336615);
+if (True == x140166665336647) {
+Obj x140166665337479 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665337511 = PRIM_CAR(x140166665337479);
+Obj x140166665337543 = PRIM_CDR(x140166665337511);
+Obj x140166665337575 = PRIM_ISCONS(x140166665337543);
+if (True == x140166665337575) {
+Obj x140166665273415 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665273447 = PRIM_CAR(x140166665273415);
+Obj x140166665273479 = PRIM_CDR(x140166665273447);
+Obj x140166665273511 = PRIM_CAR(x140166665273479);
+Obj pkg = x140166665273511;
+Obj x140166665274631 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665274663 = PRIM_CAR(x140166665274631);
+Obj x140166665274695 = PRIM_CDR(x140166665274663);
+Obj x140166665274727 = PRIM_CDR(x140166665274695);
+Obj x140166665274759 = PRIM_EQ(Nil, x140166665274727);
+if (True == x140166665274759) {
+Obj x140166665275495 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665275527 = PRIM_CDR(x140166665275495);
+Obj x140166665275559 = PRIM_ISCONS(x140166665275527);
+if (True == x140166665275559) {
+Obj x140166665276231 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665276327 = PRIM_CDR(x140166665276231);
+Obj x140166665276359 = PRIM_CAR(x140166665276327);
+Obj y = x140166665276359;
+Obj x140166665277223 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665277255 = PRIM_CDR(x140166665277223);
+Obj x140166665277319 = PRIM_CDR(x140166665277255);
+Obj x140166665277351 = PRIM_EQ(Nil, x140166665277319);
+if (True == x140166665277351) {
+Obj x140166665228839 = primIsString(pkg);
+if (True == x140166665228839) {
+Obj x140166665230631 = makeCons(pkg, Nil);
+Obj x140166665230727 = makeCons(symimport, x140166665230631);
 pushCont(co, 26, clofun0, 5, pkg, import, env, ns, y);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
-co->args[4] = x140246337885159;
+co->args[4] = x140166665230727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1225,16 +1225,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1243,7 +1234,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1252,7 +1243,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1261,7 +1252,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1270,7 +1261,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1279,7 +1270,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1288,7 +1279,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1297,7 +1288,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1306,7 +1297,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338822279;
+__arg0 = x140166664114311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140166664114311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1317,19 +1317,19 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140246337885191 = __arg1;
+Obj x140166665230759 = __arg1;
 Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140246337886055 = makeCons(pkg, import);
-pushCont(co, 27, clofun0, 1, x140246337885191);
+Obj x140166665231687 = makeCons(pkg, import);
+pushCont(co, 27, clofun0, 1, x140166665230759);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
 __arg2 = ns;
-__arg3 = x140246337886055;
+__arg3 = x140166665231687;
 co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1340,13 +1340,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x140246337886119 = __arg1;
-Obj x140246337885191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246337886183 = makeCons(x140246337886119, Nil);
-Obj x140246337886215 = makeCons(x140246337885191, x140246337886183);
-Obj x140246337886247 = makeCons(symdo, x140246337886215);
+Obj x140166665231847 = __arg1;
+Obj x140166665230759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166665231911 = makeCons(x140166665231847, Nil);
+Obj x140166665231943 = makeCons(x140166665230759, x140166665231911);
+Obj x140166665232007 = makeCons(symdo, x140166665231943);
 __nargs = 2;
-__arg1 = x140246337886247;
+__arg1 = x140166665232007;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1354,17 +1354,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label28:
 {
-Obj x140246338823463 = makeNative(38, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664115527 = makeNative(38, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140246338251239 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246338251239) {
-Obj x140246338251527 = PRIM_CAR(closureRef(co, 3));
-Obj op = x140246338251527;
-Obj x140246338252071 = PRIM_CDR(closureRef(co, 3));
-Obj args = x140246338252071;
-pushCont(co, 29, clofun0, 6, env, ns, import, args, op, x140246338823463);
+Obj x140166665336871 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166665336871) {
+Obj x140166665337127 = PRIM_CAR(closureRef(co, 3));
+Obj op = x140166665337127;
+Obj x140166665337383 = PRIM_CDR(closureRef(co, 3));
+Obj args = x140166665337383;
+pushCont(co, 29, clofun0, 6, env, ns, import, args, op, x140166664115527);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35builtin_63);
 __arg1 = op;
@@ -1375,7 +1375,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338823463;
+__arg0 = x140166664115527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1386,14 +1386,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140246338252423 = __arg1;
+Obj x140166665337703 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140246338823463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-if (True == x140246338252423) {
+Obj x140166664115527= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+if (True == x140166665337703) {
 if (True == True) {
 pushCont(co, 36, clofun0, 2, args, op);
 __nargs = 4;
@@ -1408,7 +1408,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338823463;
+__arg0 = x140166664115527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1416,8 +1416,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140246338229607 = PRIM_EQ(op, symif);
-if (True == x140246338229607) {
+Obj x140166665338823 = PRIM_EQ(op, symif);
+if (True == x140166665338823) {
 if (True == True) {
 pushCont(co, 34, clofun0, 2, args, op);
 __nargs = 4;
@@ -1432,7 +1432,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338823463;
+__arg0 = x140166664115527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1440,8 +1440,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140246338231207 = PRIM_EQ(op, symdo);
-if (True == x140246338231207) {
+Obj x140166665352231 = PRIM_EQ(op, symdo);
+if (True == x140166665352231) {
 if (True == True) {
 pushCont(co, 32, clofun0, 2, args, op);
 __nargs = 4;
@@ -1456,7 +1456,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338823463;
+__arg0 = x140166664115527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1478,7 +1478,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338823463;
+__arg0 = x140166664115527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1492,13 +1492,13 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140246338204487 = __arg1;
+Obj x140166665353671 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 31, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140246338204487;
+__arg1 = x140166665353671;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1509,11 +1509,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140246338204551 = __arg1;
+Obj x140166665353735 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338204583 = makeCons(op, x140246338204551);
+Obj x140166665353767 = makeCons(op, x140166665353735);
 __nargs = 2;
-__arg1 = x140246338204583;
+__arg1 = x140166665353767;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1521,13 +1521,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label32:
 {
-Obj x140246338232071 = __arg1;
+Obj x140166665352839 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 33, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140246338232071;
+__arg1 = x140166665352839;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1538,11 +1538,11 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140246338232135 = __arg1;
+Obj x140166665352903 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338232167 = makeCons(op, x140246338232135);
+Obj x140166665352935 = makeCons(op, x140166665352903);
 __nargs = 2;
-__arg1 = x140246338232167;
+__arg1 = x140166665352935;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1550,13 +1550,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj x140246338230311 = __arg1;
+Obj x140166665351719 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 35, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140246338230311;
+__arg1 = x140166665351719;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1567,11 +1567,11 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140246338230375 = __arg1;
+Obj x140166665351783 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338230439 = makeCons(op, x140246338230375);
+Obj x140166665351815 = makeCons(op, x140166665351783);
 __nargs = 2;
-__arg1 = x140246338230439;
+__arg1 = x140166665351815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1579,13 +1579,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label36:
 {
-Obj x140246338228839 = __arg1;
+Obj x140166665338311 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 37, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140246338228839;
+__arg1 = x140166665338311;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1596,11 +1596,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140246338228903 = __arg1;
+Obj x140166665338375 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338228935 = makeCons(op, x140246338228903);
+Obj x140166665338407 = makeCons(op, x140166665338375);
 __nargs = 2;
-__arg1 = x140246338228935;
+__arg1 = x140166665338407;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1608,45 +1608,45 @@ goto *jumpTable[co->ctx.pc.label];
 
 label38:
 {
-Obj x140246338824199 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664116263 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140246338495751 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246338495751) {
-Obj x140246338496487 = PRIM_CAR(closureRef(co, 3));
-Obj x140246338496519 = PRIM_EQ(symlet, x140246338496487);
-if (True == x140246338496519) {
-Obj x140246338497159 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338497191 = PRIM_ISCONS(x140246338497159);
-if (True == x140246338497191) {
-Obj x140246338498023 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338498055 = PRIM_CAR(x140246338498023);
-Obj a = x140246338498055;
-Obj x140246338449863 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338449895 = PRIM_CDR(x140246338449863);
-Obj x140246338449927 = PRIM_ISCONS(x140246338449895);
-if (True == x140246338449927) {
-Obj x140246338450759 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338450823 = PRIM_CDR(x140246338450759);
-Obj x140246338450855 = PRIM_CAR(x140246338450823);
-Obj b = x140246338450855;
-Obj x140246338452007 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338452039 = PRIM_CDR(x140246338452007);
-Obj x140246338452071 = PRIM_CDR(x140246338452039);
-Obj x140246338452103 = PRIM_ISCONS(x140246338452071);
-if (True == x140246338452103) {
-Obj x140246338453319 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338453351 = PRIM_CDR(x140246338453319);
-Obj x140246338453415 = PRIM_CDR(x140246338453351);
-Obj x140246338351143 = PRIM_CAR(x140246338453415);
-Obj c = x140246338351143;
-Obj x140246338352807 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338352839 = PRIM_CDR(x140246338352807);
-Obj x140246338352871 = PRIM_CDR(x140246338352839);
-Obj x140246338352903 = PRIM_CDR(x140246338352871);
-Obj x140246338352967 = PRIM_EQ(Nil, x140246338352903);
-if (True == x140246338352967) {
+Obj x140166665091015 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166665091015) {
+Obj x140166665091463 = PRIM_CAR(closureRef(co, 3));
+Obj x140166665091495 = PRIM_EQ(symlet, x140166665091463);
+if (True == x140166665091495) {
+Obj x140166665091911 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665091943 = PRIM_ISCONS(x140166665091911);
+if (True == x140166665091943) {
+Obj x140166665092359 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665092391 = PRIM_CAR(x140166665092359);
+Obj a = x140166665092391;
+Obj x140166665092967 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665092999 = PRIM_CDR(x140166665092967);
+Obj x140166665093031 = PRIM_ISCONS(x140166665092999);
+if (True == x140166665093031) {
+Obj x140166664655335 = PRIM_CDR(closureRef(co, 3));
+Obj x140166664655367 = PRIM_CDR(x140166664655335);
+Obj x140166664655399 = PRIM_CAR(x140166664655367);
+Obj b = x140166664655399;
+Obj x140166664656135 = PRIM_CDR(closureRef(co, 3));
+Obj x140166664656167 = PRIM_CDR(x140166664656135);
+Obj x140166664656199 = PRIM_CDR(x140166664656167);
+Obj x140166664656231 = PRIM_ISCONS(x140166664656199);
+if (True == x140166664656231) {
+Obj x140166664656967 = PRIM_CDR(closureRef(co, 3));
+Obj x140166664656999 = PRIM_CDR(x140166664656967);
+Obj x140166664657031 = PRIM_CDR(x140166664656999);
+Obj x140166664657063 = PRIM_CAR(x140166664657031);
+Obj c = x140166664657063;
+Obj x140166664657991 = PRIM_CDR(closureRef(co, 3));
+Obj x140166664658023 = PRIM_CDR(x140166664657991);
+Obj x140166664658055 = PRIM_CDR(x140166664658023);
+Obj x140166664658087 = PRIM_CDR(x140166664658055);
+Obj x140166664658119 = PRIM_EQ(Nil, x140166664658087);
+if (True == x140166664658119) {
 pushCont(co, 39, clofun0, 5, env, ns, import, c, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
@@ -1661,7 +1661,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1670,7 +1670,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1679,7 +1679,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1688,7 +1688,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1697,7 +1697,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1706,7 +1706,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338824199;
+__arg0 = x140166664116263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1717,17 +1717,17 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140246338354279 = __arg1;
+Obj x140166665334791 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140246338248935 = makeCons(a, env);
-pushCont(co, 40, clofun0, 2, x140246338354279, a);
+Obj x140166665335367 = makeCons(a, env);
+pushCont(co, 40, clofun0, 2, x140166665334791, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140246338248935;
+__arg1 = x140166665335367;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = c;
@@ -1740,15 +1740,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140246338249063 = __arg1;
-Obj x140246338354279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166665335495 = __arg1;
+Obj x140166665334791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338249415 = makeCons(x140246338249063, Nil);
-Obj x140246338249447 = makeCons(x140246338354279, x140246338249415);
-Obj x140246338249479 = makeCons(a, x140246338249447);
-Obj x140246338249511 = makeCons(symlet, x140246338249479);
+Obj x140166665335559 = makeCons(x140166665335495, Nil);
+Obj x140166665335591 = makeCons(x140166665334791, x140166665335559);
+Obj x140166665335623 = makeCons(a, x140166665335591);
+Obj x140166665335655 = makeCons(symlet, x140166665335623);
 __nargs = 2;
-__arg1 = x140246338249511;
+__arg1 = x140166665335655;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1756,45 +1756,45 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj x140246338825287 = makeNative(42, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664117351 = makeNative(42, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj x140246338625703 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246338625703) {
-Obj x140246338626375 = PRIM_CAR(closureRef(co, 3));
-Obj x140246338626439 = PRIM_EQ(symns, x140246338626375);
-if (True == x140246338626439) {
-Obj x140246338627207 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338627239 = PRIM_ISCONS(x140246338627207);
-if (True == x140246338627239) {
-Obj x140246338628263 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338628295 = PRIM_CAR(x140246338628263);
-Obj path = x140246338628295;
-Obj x140246338629447 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338629479 = PRIM_CDR(x140246338629447);
-Obj x140246338629511 = PRIM_ISCONS(x140246338629479);
-if (True == x140246338629511) {
-Obj x140246338601831 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338601863 = PRIM_CDR(x140246338601831);
-Obj x140246338601895 = PRIM_CAR(x140246338601863);
-Obj import = x140246338601895;
-Obj x140246338603847 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338603879 = PRIM_CDR(x140246338603847);
-Obj x140246338603943 = PRIM_CDR(x140246338603879);
-Obj x140246338603975 = PRIM_ISCONS(x140246338603943);
-if (True == x140246338603975) {
-Obj x140246338552775 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338552807 = PRIM_CDR(x140246338552775);
-Obj x140246338552839 = PRIM_CDR(x140246338552807);
-Obj x140246338552871 = PRIM_CAR(x140246338552839);
-Obj body = x140246338552871;
-Obj x140246338554407 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338554439 = PRIM_CDR(x140246338554407);
-Obj x140246338554471 = PRIM_CDR(x140246338554439);
-Obj x140246338554599 = PRIM_CDR(x140246338554471);
-Obj x140246338554631 = PRIM_EQ(Nil, x140246338554599);
-if (True == x140246338554631) {
+Obj x140166663472711 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166663472711) {
+Obj x140166663473159 = PRIM_CAR(closureRef(co, 3));
+Obj x140166663473191 = PRIM_EQ(symns, x140166663473159);
+if (True == x140166663473191) {
+Obj x140166663473831 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663473863 = PRIM_ISCONS(x140166663473831);
+if (True == x140166663473863) {
+Obj x140166663474279 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663474311 = PRIM_CAR(x140166663474279);
+Obj path = x140166663474311;
+Obj x140166663475079 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663475111 = PRIM_CDR(x140166663475079);
+Obj x140166663475143 = PRIM_ISCONS(x140166663475111);
+if (True == x140166663475143) {
+Obj x140166663366471 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663366503 = PRIM_CDR(x140166663366471);
+Obj x140166663366535 = PRIM_CAR(x140166663366503);
+Obj import = x140166663366535;
+Obj x140166663367335 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663367367 = PRIM_CDR(x140166663367335);
+Obj x140166663367399 = PRIM_CDR(x140166663367367);
+Obj x140166663367431 = PRIM_ISCONS(x140166663367399);
+if (True == x140166663367431) {
+Obj x140166663368167 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663368199 = PRIM_CDR(x140166663368167);
+Obj x140166663368231 = PRIM_CDR(x140166663368199);
+Obj x140166663368263 = PRIM_CAR(x140166663368231);
+Obj body = x140166663368263;
+Obj x140166665089415 = PRIM_CDR(closureRef(co, 3));
+Obj x140166665089447 = PRIM_CDR(x140166665089415);
+Obj x140166665089479 = PRIM_CDR(x140166665089447);
+Obj x140166665089511 = PRIM_CDR(x140166665089479);
+Obj x140166665089543 = PRIM_EQ(Nil, x140166665089511);
+if (True == x140166665089543) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
@@ -1808,7 +1808,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1817,7 +1817,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1826,7 +1826,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1835,7 +1835,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1844,7 +1844,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1853,7 +1853,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338825287;
+__arg0 = x140166664117351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1864,34 +1864,34 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140246338699399 = makeNative(45, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166664085671 = makeNative(45, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140246338973255 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140246338973255) {
-Obj x140246338950151 = PRIM_CAR(closureRef(co, 3));
-Obj x140246338950183 = PRIM_EQ(symdef, x140246338950151);
-if (True == x140246338950183) {
-Obj x140246338951175 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338951207 = PRIM_ISCONS(x140246338951175);
-if (True == x140246338951207) {
-Obj x140246338952103 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338952199 = PRIM_CAR(x140246338952103);
-Obj var = x140246338952199;
-Obj x140246338822343 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338822375 = PRIM_CDR(x140246338822343);
-Obj x140246338822407 = PRIM_ISCONS(x140246338822375);
-if (True == x140246338822407) {
-Obj x140246338823751 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338823943 = PRIM_CDR(x140246338823751);
-Obj x140246338823975 = PRIM_CAR(x140246338823943);
-Obj val = x140246338823975;
-Obj x140246338825223 = PRIM_CDR(closureRef(co, 3));
-Obj x140246338825319 = PRIM_CDR(x140246338825223);
-Obj x140246338825351 = PRIM_CDR(x140246338825319);
-Obj x140246338825383 = PRIM_EQ(Nil, x140246338825351);
-if (True == x140246338825383) {
+Obj x140166663558759 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140166663558759) {
+Obj x140166663559239 = PRIM_CAR(closureRef(co, 3));
+Obj x140166663559271 = PRIM_EQ(symdef, x140166663559239);
+if (True == x140166663559271) {
+Obj x140166663559847 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663559879 = PRIM_ISCONS(x140166663559847);
+if (True == x140166663559879) {
+Obj x140166663560295 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663560327 = PRIM_CAR(x140166663560295);
+Obj var = x140166663560327;
+Obj x140166663561159 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663561191 = PRIM_CDR(x140166663561159);
+Obj x140166663532551 = PRIM_ISCONS(x140166663561191);
+if (True == x140166663532551) {
+Obj x140166663533191 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663533223 = PRIM_CDR(x140166663533191);
+Obj x140166663533255 = PRIM_CAR(x140166663533223);
+Obj val = x140166663533255;
+Obj x140166663534215 = PRIM_CDR(closureRef(co, 3));
+Obj x140166663534247 = PRIM_CDR(x140166663534215);
+Obj x140166663534279 = PRIM_CDR(x140166663534247);
+Obj x140166663534311 = PRIM_EQ(Nil, x140166663534279);
+if (True == x140166663534311) {
 pushCont(co, 43, clofun0, 4, env, ns, import, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35var_45with_45ns);
@@ -1904,7 +1904,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338699399;
+__arg0 = x140166664085671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1913,7 +1913,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338699399;
+__arg0 = x140166664085671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1922,7 +1922,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338699399;
+__arg0 = x140166664085671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1931,7 +1931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338699399;
+__arg0 = x140166664085671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1940,7 +1940,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338699399;
+__arg0 = x140166664085671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1951,15 +1951,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140246338825767 = __arg1;
+Obj x140166663534823 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj var1 = x140246338825767;
-Obj x140246338700071 = makeCons(var1, Nil);
-Obj x140246338700103 = makeCons(symquote, x140246338700071);
-pushCont(co, 44, clofun0, 1, x140246338700103);
+Obj var1 = x140166663534823;
+Obj x140166663535783 = makeCons(var1, Nil);
+Obj x140166663535815 = makeCons(symquote, x140166663535783);
+pushCont(co, 44, clofun0, 1, x140166663535815);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
@@ -1975,13 +1975,13 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140246338701191 = __arg1;
-Obj x140246338700103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338701287 = makeCons(x140246338701191, Nil);
-Obj x140246338701607 = makeCons(x140246338700103, x140246338701287);
-Obj x140246338701671 = makeCons(symset, x140246338701607);
+Obj x140166663536487 = __arg1;
+Obj x140166663535815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166663536615 = makeCons(x140166663536487, Nil);
+Obj x140166663471111 = makeCons(x140166663535815, x140166663536615);
+Obj x140166663471143 = makeCons(symset, x140166663471111);
 __nargs = 2;
-__arg1 = x140246338701671;
+__arg1 = x140166663471143;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1989,7 +1989,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label45:
 {
-Obj x140246338700359 = makeNative(47, clofun0, 0, 0);
+Obj x140166664086631 = makeNative(47, clofun0, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -2009,11 +2009,11 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140246338972167 = __arg1;
+Obj x140166663558087 = __arg1;
 Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140246338972167;
+__arg1 = x140166663558087;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2051,11 +2051,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140246339318887 = __arg1;
+Obj x140166663562887 = __arg1;
 PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140246339318887;
+__arg1 = x140166663562887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2085,10 +2085,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140246339318919 = __arg1;
-Obj x140246339318983 = primNot(x140246339318919);
+Obj x140166663562919 = __arg1;
+Obj x140166663562951 = primNot(x140166663562919);
 __nargs = 2;
-__arg1 = x140246339318983;
+__arg1 = x140166663562951;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2096,12 +2096,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label1:
 {
-Obj x140246338970055 = __arg1;
-Obj x140246338970087 = __arg2;
-Obj x140246338970439 = makeNative(2, clofun1, 0, 2, x140246338970055, x140246338970087);
-Obj var = x140246338970055;
-Obj x140246339374279 = PRIM_EQ(Nil, x140246338970087);
-if (True == x140246339374279) {
+Obj x140166664290727 = __arg1;
+Obj x140166664290759 = __arg2;
+Obj x140166664291015 = makeNative(2, clofun1, 0, 2, x140166664290727, x140166664290759);
+Obj var = x140166664290727;
+Obj x140166663561575 = PRIM_EQ(Nil, x140166664290759);
+if (True == x140166663561575) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2109,7 +2109,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970439;
+__arg0 = x140166664291015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2120,32 +2120,32 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140246338970887 = makeNative(3, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140166664291495 = makeNative(3, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj x140246339622823 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140246339622823) {
-Obj x140246339623559 = PRIM_CAR(closureRef(co, 1));
-Obj x140246339623591 = PRIM_ISCONS(x140246339623559);
-if (True == x140246339623591) {
-Obj x140246339624359 = PRIM_CAR(closureRef(co, 1));
-Obj x140246339624487 = PRIM_CAR(x140246339624359);
-Obj x = x140246339624487;
-Obj x140246339371431 = PRIM_CAR(closureRef(co, 1));
-Obj x140246339371463 = PRIM_CDR(x140246339371431);
-Obj y = x140246339371463;
-Obj x140246339371783 = PRIM_CDR(closureRef(co, 1));
-Obj __ = x140246339371783;
-Obj x140246339372455 = PRIM_EQ(var, x);
-if (True == x140246339372455) {
-Obj x140246339372775 = makeCons(x, y);
+Obj x140166663761703 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140166663761703) {
+Obj x140166663574023 = PRIM_CAR(closureRef(co, 1));
+Obj x140166663574087 = PRIM_ISCONS(x140166663574023);
+if (True == x140166663574087) {
+Obj x140166663574695 = PRIM_CAR(closureRef(co, 1));
+Obj x140166663574727 = PRIM_CAR(x140166663574695);
+Obj x = x140166663574727;
+Obj x140166663575495 = PRIM_CAR(closureRef(co, 1));
+Obj x140166663575527 = PRIM_CDR(x140166663575495);
+Obj y = x140166663575527;
+Obj x140166663575879 = PRIM_CDR(closureRef(co, 1));
+Obj __ = x140166663575879;
+Obj x140166663576263 = PRIM_EQ(var, x);
+if (True == x140166663576263) {
+Obj x140166663576647 = makeCons(x, y);
 __nargs = 2;
-__arg1 = x140246339372775;
+__arg1 = x140166663576647;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970887;
+__arg0 = x140166664291495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2154,7 +2154,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970887;
+__arg0 = x140166664291495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2163,7 +2163,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970887;
+__arg0 = x140166664291495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2174,14 +2174,14 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140246338971591 = makeNative(4, clofun1, 0, 0);
+Obj x140166664292295 = makeNative(4, clofun1, 0, 0);
 Obj var = closureRef(co, 0);
-Obj x140246339620871 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140246339620871) {
-Obj x140246339621351 = PRIM_CAR(closureRef(co, 1));
-Obj __ = x140246339621351;
-Obj x140246339621607 = PRIM_CDR(closureRef(co, 1));
-Obj y = x140246339621607;
+Obj x140166663759719 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140166663759719) {
+Obj x140166663760135 = PRIM_CAR(closureRef(co, 1));
+Obj __ = x140166663760135;
+Obj x140166663760487 = PRIM_CDR(closureRef(co, 1));
+Obj y = x140166663760487;
 __nargs = 3;
 __arg0 = globalRef(symassq);
 __arg1 = var;
@@ -2193,7 +2193,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971591;
+__arg0 = x140166664292295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2216,14 +2216,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140246338952487 = __arg1;
-Obj x140246338952519 = __arg2;
-Obj x140246338952551 = __arg3;
-Obj x140246338952807 = makeNative(6, clofun1, 0, 3, x140246338952487, x140246338952519, x140246338952551);
-Obj s = x140246338952487;
-Obj ns = x140246338952519;
-Obj x140246339873415 = PRIM_EQ(Nil, x140246338952551);
-if (True == x140246339873415) {
+Obj x140166664133767 = __arg1;
+Obj x140166664133799 = __arg2;
+Obj x140166664133831 = __arg3;
+Obj x140166664134087 = makeNative(6, clofun1, 0, 3, x140166664133767, x140166664133799, x140166664133831);
+Obj s = x140166664133767;
+Obj ns = x140166664133799;
+Obj x140166664292039 = PRIM_EQ(Nil, x140166664133831);
+if (True == x140166664292039) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35var_45with_45ns);
 __arg1 = s;
@@ -2235,7 +2235,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338952807;
+__arg0 = x140166664134087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2246,15 +2246,15 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140246338822215 = makeNative(14, clofun1, 0, 0);
+Obj x140166664134599 = makeNative(14, clofun1, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
-Obj x140246339870759 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x140246339870759) {
-Obj x140246339871015 = PRIM_CAR(closureRef(co, 2));
-Obj import = x140246339871015;
-Obj x140246339871271 = PRIM_CDR(closureRef(co, 2));
-Obj more = x140246339871271;
+Obj x140166664695591 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140166664695591) {
+Obj x140166664470887 = PRIM_CAR(closureRef(co, 2));
+Obj import = x140166664470887;
+Obj x140166664471335 = PRIM_CDR(closureRef(co, 2));
+Obj more = x140166664471335;
 pushCont(co, 7, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
@@ -2267,7 +2267,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338822215;
+__arg0 = x140166664134599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2278,7 +2278,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140246339871879 = __arg1;
+Obj x140166664472423 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2286,7 +2286,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 8, clofun1, 4, import, s, ns, more);
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140246339871879;
+__arg1 = x140166664472423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2296,7 +2296,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140246339871911 = __arg1;
+Obj x140166664472455 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2304,7 +2304,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 9, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symvalue_45or);
-__arg1 = x140246339871911;
+__arg1 = x140166664472455;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2315,12 +2315,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140246339871975 = __arg1;
+Obj x140166664472679 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = x140246339871975;
+Obj export = x140166664472679;
 pushCont(co, 10, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
@@ -2335,12 +2335,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140246339872263 = __arg1;
+Obj x140166664473031 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140246339872263) {
+if (True == x140166664473031) {
 pushCont(co, 11, clofun1, 1, import);
 __nargs = 2;
 __arg0 = globalRef(symsymbol_45_62string);
@@ -2366,13 +2366,13 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246339872999 = __arg1;
+Obj x140166664474471 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 12, clofun1, 1, import);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = makeCString("#");
-__arg2 = x140246339872999;
+__arg2 = x140166664474471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2382,13 +2382,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140246339873031 = __arg1;
+Obj x140166664474503 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 13, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = import;
-__arg2 = x140246339873031;
+__arg2 = x140166664474503;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2398,10 +2398,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140246339873063 = __arg1;
+Obj x140166664474535 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140246339873063;
+__arg1 = x140166664474535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2425,8 +2425,8 @@ label15:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj x140246339860359 = PRIM_EQ(ns, makeCString(""));
-if (True == x140246339860359) {
+Obj x140166664691815 = PRIM_EQ(ns, makeCString(""));
+if (True == x140166664691815) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2447,10 +2447,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140246339860615 = __arg1;
+Obj x140166664692359 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246339860615) {
+if (True == x140166664692359) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2471,13 +2471,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140246339861351 = __arg1;
+Obj x140166664693383 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun1, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = makeCString("#");
-__arg2 = x140246339861351;
+__arg2 = x140166664693383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2487,13 +2487,13 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140246339861383 = __arg1;
+Obj x140166664693511 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 19, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = ns;
-__arg2 = x140246339861383;
+__arg2 = x140166664693511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2503,10 +2503,10 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140246339861415 = __arg1;
+Obj x140166664693543 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140246339861415;
+__arg1 = x140166664693543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2530,9 +2530,9 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140246339851367 = __arg1;
+Obj x140166665044071 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = x140246339851367;
+Obj path = x140166665044071;
 pushCont(co, 22, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -2546,12 +2546,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140246339851847 = __arg1;
+Obj x140166665044743 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 23, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library);
-__arg1 = x140246339851847;
+__arg1 = x140166665044743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2561,10 +2561,10 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140246339851879 = __arg1;
+Obj x140166665044775 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = x140246339851879;
+__arg0 = x140166665044775;
 __arg1 = makeNative(24, clofun1, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2578,8 +2578,8 @@ label24:
 Obj import = __arg1;
 Obj export = __arg2;
 Obj body = __arg3;
-Obj x140246339852743 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 25, clofun1, 3, export, body, x140246339852743);
+Obj x140166665046311 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 25, clofun1, 3, export, body, x140166665046311);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = makeNative(27, clofun1, 1, 0);
@@ -2593,21 +2593,21 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140246339854023 = __arg1;
+Obj x140166664831495 = __arg1;
 Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339852743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246339859271 = makeCons(export, Nil);
-Obj x140246339859303 = makeCons(symbackquote, x140246339859271);
-Obj x140246339859367 = makeCons(x140246339859303, Nil);
-Obj x140246339859399 = makeCons(sym_42ns_45export_42, x140246339859367);
-Obj x140246339859431 = makeCons(symdef, x140246339859399);
-Obj x140246339859495 = makeCons(x140246339859431, body);
-pushCont(co, 26, clofun1, 1, x140246339852743);
+Obj x140166665046311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140166664833287 = makeCons(export, Nil);
+Obj x140166664833479 = makeCons(symbackquote, x140166664833287);
+Obj x140166664833735 = makeCons(x140166664833479, Nil);
+Obj x140166664833767 = makeCons(sym_42ns_45export_42, x140166664833735);
+Obj x140166664833799 = makeCons(symdef, x140166664833767);
+Obj x140166664833863 = makeCons(x140166664833799, body);
+pushCont(co, 26, clofun1, 1, x140166665046311);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = x140246339854023;
-__arg2 = x140246339859495;
+__arg1 = x140166664831495;
+__arg2 = x140166664833863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2617,15 +2617,15 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140246339859527 = __arg1;
-Obj x140246339852743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339859559 = makeCons(symbegin, x140246339859527);
-Obj x140246339859623 = makeCons(x140246339859559, Nil);
-Obj x140246339859655 = makeCons(x140246339852743, x140246339859623);
-Obj x140246339859687 = makeCons(closureRef(co, 0), x140246339859655);
-Obj x140246339859719 = makeCons(symns, x140246339859687);
+Obj x140166664833927 = __arg1;
+Obj x140166665046311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664833959 = makeCons(symbegin, x140166664833927);
+Obj x140166664834023 = makeCons(x140166664833959, Nil);
+Obj x140166664834087 = makeCons(x140166665046311, x140166664834023);
+Obj x140166664834183 = makeCons(closureRef(co, 0), x140166664834087);
+Obj x140166664834215 = makeCons(symns, x140166664834183);
 __nargs = 2;
-__arg1 = x140246339859719;
+__arg1 = x140166664834215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2634,10 +2634,10 @@ goto *jumpTable[co->ctx.pc.label];
 label27:
 {
 Obj imp = __arg1;
-Obj x140246339853927 = makeCons(imp, Nil);
-Obj x140246339853959 = makeCons(symimport, x140246339853927);
+Obj x140166664831271 = makeCons(imp, Nil);
+Obj x140166664831431 = makeCons(symimport, x140166664831271);
 __nargs = 2;
-__arg1 = x140246339853959;
+__arg1 = x140166664831431;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2662,43 +2662,43 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140246338973671 = __arg1;
-Obj x140246338949127 = __arg2;
-Obj x140246338949159 = __arg3;
-Obj x140246338949223 = co->args[4];
-Obj x140246338949575 = makeNative(30, clofun1, 0, 4, x140246338973671, x140246338949127, x140246338949159, x140246338949223);
-Obj x140246337971911 = PRIM_ISCONS(x140246338973671);
-if (True == x140246337971911) {
-Obj x140246337972391 = PRIM_CAR(x140246338973671);
-Obj x140246337972423 = PRIM_ISCONS(x140246337972391);
-if (True == x140246337972423) {
-Obj x140246337973127 = PRIM_CAR(x140246338973671);
-Obj x140246337973159 = PRIM_CAR(x140246337973127);
-Obj x140246337973191 = PRIM_EQ(symimport, x140246337973159);
-if (True == x140246337973191) {
-Obj x140246337973863 = PRIM_CAR(x140246338973671);
-Obj x140246337973895 = PRIM_CDR(x140246337973863);
-Obj x140246337973927 = PRIM_ISCONS(x140246337973895);
-if (True == x140246337973927) {
-Obj x140246337885383 = PRIM_CAR(x140246338973671);
-Obj x140246337885415 = PRIM_CDR(x140246337885383);
-Obj x140246337885447 = PRIM_CAR(x140246337885415);
-Obj lib = x140246337885447;
-Obj x140246337886343 = PRIM_CAR(x140246338973671);
-Obj x140246337886375 = PRIM_CDR(x140246337886343);
-Obj x140246337886407 = PRIM_CDR(x140246337886375);
-Obj x140246337886439 = PRIM_EQ(Nil, x140246337886407);
-if (True == x140246337886439) {
-Obj x140246337886695 = PRIM_CDR(x140246338973671);
-Obj rest = x140246337886695;
-Obj imports = x140246338949127;
-Obj exports = x140246338949159;
-Obj k = x140246338949223;
-Obj x140246337887399 = makeCons(lib, imports);
+Obj x140166664294023 = __arg1;
+Obj x140166664294055 = __arg2;
+Obj x140166664294087 = __arg3;
+Obj x140166664294151 = co->args[4];
+Obj x140166664130631 = makeNative(30, clofun1, 0, 4, x140166664294023, x140166664294055, x140166664294087, x140166664294151);
+Obj x140166665232039 = PRIM_ISCONS(x140166664294023);
+if (True == x140166665232039) {
+Obj x140166665163047 = PRIM_CAR(x140166664294023);
+Obj x140166665163079 = PRIM_ISCONS(x140166665163047);
+if (True == x140166665163079) {
+Obj x140166665163783 = PRIM_CAR(x140166664294023);
+Obj x140166665163943 = PRIM_CAR(x140166665163783);
+Obj x140166665164007 = PRIM_EQ(symimport, x140166665163943);
+if (True == x140166665164007) {
+Obj x140166665165351 = PRIM_CAR(x140166664294023);
+Obj x140166665165383 = PRIM_CDR(x140166665165351);
+Obj x140166665165415 = PRIM_ISCONS(x140166665165383);
+if (True == x140166665165415) {
+Obj x140166665166183 = PRIM_CAR(x140166664294023);
+Obj x140166665166279 = PRIM_CDR(x140166665166183);
+Obj x140166665166311 = PRIM_CAR(x140166665166279);
+Obj lib = x140166665166311;
+Obj x140166665094375 = PRIM_CAR(x140166664294023);
+Obj x140166665094407 = PRIM_CDR(x140166665094375);
+Obj x140166665094439 = PRIM_CDR(x140166665094407);
+Obj x140166665094471 = PRIM_EQ(Nil, x140166665094439);
+if (True == x140166665094471) {
+Obj x140166665094727 = PRIM_CDR(x140166664294023);
+Obj rest = x140166665094727;
+Obj imports = x140166664294055;
+Obj exports = x140166664294087;
+Obj k = x140166664294151;
+Obj x140166665095335 = makeCons(lib, imports);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
 __arg1 = rest;
-__arg2 = x140246337887399;
+__arg2 = x140166665095335;
 __arg3 = exports;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -2708,7 +2708,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949575;
+__arg0 = x140166664130631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2717,7 +2717,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949575;
+__arg0 = x140166664130631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2726,7 +2726,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949575;
+__arg0 = x140166664130631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2735,7 +2735,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949575;
+__arg0 = x140166664130631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2744,7 +2744,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949575;
+__arg0 = x140166664130631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2755,21 +2755,21 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140246338950663 = makeNative(31, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x140246338169415 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338169415) {
-Obj x140246338169831 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338169863 = PRIM_ISCONS(x140246338169831);
-if (True == x140246338169863) {
-Obj x140246338170535 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338170567 = PRIM_CAR(x140246338170535);
-Obj x140246338170599 = PRIM_EQ(symexport, x140246338170567);
-if (True == x140246338170599) {
-Obj x140246337970343 = PRIM_CAR(closureRef(co, 0));
-Obj x140246337970375 = PRIM_CDR(x140246337970343);
-Obj more = x140246337970375;
-Obj x140246337970663 = PRIM_CDR(closureRef(co, 0));
-Obj rest = x140246337970663;
+Obj x140166664131751 = makeNative(31, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140166665275847 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665275847) {
+Obj x140166665276263 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665276295 = PRIM_ISCONS(x140166665276263);
+if (True == x140166665276295) {
+Obj x140166665229159 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665229191 = PRIM_CAR(x140166665229159);
+Obj x140166665229319 = PRIM_EQ(symexport, x140166665229191);
+if (True == x140166665229319) {
+Obj x140166665229895 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665229927 = PRIM_CDR(x140166665229895);
+Obj more = x140166665229927;
+Obj x140166665230279 = PRIM_CDR(closureRef(co, 0));
+Obj rest = x140166665230279;
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
 Obj k = closureRef(co, 3);
@@ -2786,7 +2786,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338950663;
+__arg0 = x140166664131751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2795,7 +2795,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950663;
+__arg0 = x140166664131751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2804,7 +2804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950663;
+__arg0 = x140166664131751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2815,7 +2815,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140246338951559 = makeNative(33, clofun1, 0, 0);
+Obj x140166664132839 = makeNative(33, clofun1, 0, 0);
 Obj body = closureRef(co, 0);
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
@@ -2833,13 +2833,13 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140246338169095 = __arg1;
+Obj x140166665275463 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 __nargs = 4;
 __arg0 = k;
-__arg1 = x140246338169095;
+__arg1 = x140166665275463;
 __arg2 = exports;
 __arg3 = body;
 co->ctx.frees = __arg0;
@@ -2877,10 +2877,10 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140246338167559 = __arg1;
+Obj x140166665273703 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = x140246338167559;
+__arg1 = x140166665273703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2890,21 +2890,21 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140246338971655 = __arg1;
-Obj x140246338971815 = makeNative(37, clofun1, 0, 1, x140246338971655);
-Obj x = x140246338971655;
-Obj x140246338207047 = primIsSymbol(x);
-if (True == x140246338207047) {
-Obj x140246338207559 = makeCons(x, Nil);
-Obj x140246338207591 = makeCons(symquote, x140246338207559);
+Obj x140166664291975 = __arg1;
+Obj x140166664292199 = makeNative(37, clofun1, 0, 1, x140166664291975);
+Obj x = x140166664291975;
+Obj x140166665277287 = primIsSymbol(x);
+if (True == x140166665277287) {
+Obj x140166665093383 = makeCons(x, Nil);
+Obj x140166665093415 = makeCons(symquote, x140166665093383);
 __nargs = 2;
-__arg1 = x140246338207591;
+__arg1 = x140166665093415;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971815;
+__arg0 = x140166664292199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2915,22 +2915,22 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140246338972071 = makeNative(38, clofun1, 0, 1, closureRef(co, 0));
-Obj x140246338203751 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338203751) {
-Obj x140246338204359 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338204391 = PRIM_EQ(symunquote, x140246338204359);
-if (True == x140246338204391) {
-Obj x140246338204807 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338204839 = PRIM_ISCONS(x140246338204807);
-if (True == x140246338204839) {
-Obj x140246338205287 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338205319 = PRIM_CAR(x140246338205287);
-Obj x = x140246338205319;
-Obj x140246338206055 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338206087 = PRIM_CDR(x140246338206055);
-Obj x140246338206119 = PRIM_EQ(Nil, x140246338206087);
-if (True == x140246338206119) {
+Obj x140166664292423 = makeNative(38, clofun1, 0, 1, closureRef(co, 0));
+Obj x140166665274407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665274407) {
+Obj x140166665274855 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665274887 = PRIM_EQ(symunquote, x140166665274855);
+if (True == x140166665274887) {
+Obj x140166665275303 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665275335 = PRIM_ISCONS(x140166665275303);
+if (True == x140166665275335) {
+Obj x140166665275751 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665275783 = PRIM_CAR(x140166665275751);
+Obj x = x140166665275783;
+Obj x140166665276391 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665276423 = PRIM_CDR(x140166665276391);
+Obj x140166665276455 = PRIM_EQ(Nil, x140166665276423);
+if (True == x140166665276455) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2938,7 +2938,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338972071;
+__arg0 = x140166664292423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2947,7 +2947,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972071;
+__arg0 = x140166664292423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2956,7 +2956,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972071;
+__arg0 = x140166664292423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2965,7 +2965,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972071;
+__arg0 = x140166664292423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2976,19 +2976,19 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140246338972551 = makeNative(40, clofun1, 0, 1, closureRef(co, 0));
-Obj x140246338230407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338230407) {
-Obj x140246338230791 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140246338230791;
-Obj x140246338231239 = PRIM_CDR(closureRef(co, 0));
-Obj more = x140246338231239;
-Obj x140246338231975 = makeCons(x, more);
+Obj x140166664292903 = makeNative(40, clofun1, 0, 1, closureRef(co, 0));
+Obj x140166663368359 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663368359) {
+Obj x140166663368615 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140166663368615;
+Obj x140166665273351 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140166665273351;
+Obj x140166665273959 = makeCons(x, more);
 PUSH_CONT_0(co, 39, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = x140246338231975;
+__arg2 = x140166665273959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2996,7 +2996,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338972551;
+__arg0 = x140166664292903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3007,10 +3007,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140246338232007 = __arg1;
-Obj x140246338232039 = makeCons(symlist, x140246338232007);
+Obj x140166665273991 = __arg1;
+Obj x140166665274023 = makeCons(symlist, x140166665273991);
 __nargs = 2;
-__arg1 = x140246338232039;
+__arg1 = x140166665274023;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3018,7 +3018,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x140246338972967 = makeNative(41, clofun1, 0, 0);
+Obj x140166664293319 = makeNative(41, clofun1, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -3042,10 +3042,10 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj exp = __arg1;
-Obj x140246338228711 = PRIM_CDR(exp);
+Obj x140166663367015 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = x140246338228711;
+__arg1 = x140166663367015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3055,15 +3055,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140246338969895 = __arg1;
-Obj x140246338970023 = makeNative(44, clofun1, 0, 1, x140246338969895);
-Obj x140246338251047 = PRIM_ISCONS(x140246338969895);
-if (True == x140246338251047) {
-Obj x140246338251303 = PRIM_CAR(x140246338969895);
-Obj x = x140246338251303;
-Obj x140246338251911 = PRIM_CDR(x140246338969895);
-Obj x140246338251943 = PRIM_EQ(Nil, x140246338251911);
-if (True == x140246338251943) {
+Obj x140166664132359 = __arg1;
+Obj x140166664132487 = makeNative(44, clofun1, 0, 1, x140166664132359);
+Obj x140166663473287 = PRIM_ISCONS(x140166664132359);
+if (True == x140166663473287) {
+Obj x140166663473703 = PRIM_CAR(x140166664132359);
+Obj x = x140166663473703;
+Obj x140166663366023 = PRIM_CDR(x140166664132359);
+Obj x140166663366055 = PRIM_EQ(Nil, x140166663366023);
+if (True == x140166663366055) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3071,7 +3071,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970023;
+__arg0 = x140166664132487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3080,7 +3080,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970023;
+__arg0 = x140166664132487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3091,32 +3091,32 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140246338970535 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
-Obj x140246338352935 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338352935) {
-Obj x140246338353287 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140246338353287;
-Obj x140246338353991 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338354023 = PRIM_ISCONS(x140246338353991);
-if (True == x140246338354023) {
-Obj x140246338354631 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338354663 = PRIM_CAR(x140246338354631);
-Obj y = x140246338354663;
-Obj x140246338249095 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338249127 = PRIM_CDR(x140246338249095);
-Obj x140246338249159 = PRIM_EQ(Nil, x140246338249127);
-if (True == x140246338249159) {
-Obj x140246338250151 = makeCons(y, Nil);
-Obj x140246338250183 = makeCons(x, x140246338250151);
-Obj x140246338250215 = makeCons(symdo, x140246338250183);
+Obj x140166664290823 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
+Obj x140166663535143 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663535143) {
+Obj x140166663535527 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140166663535527;
+Obj x140166663535943 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663535975 = PRIM_ISCONS(x140166663535943);
+if (True == x140166663535975) {
+Obj x140166663536519 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663536551 = PRIM_CAR(x140166663536519);
+Obj y = x140166663536551;
+Obj x140166663471751 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663471783 = PRIM_CDR(x140166663471751);
+Obj x140166663471815 = PRIM_EQ(Nil, x140166663471783);
+if (True == x140166663471815) {
+Obj x140166663472583 = makeCons(y, Nil);
+Obj x140166663472615 = makeCons(x, x140166663472583);
+Obj x140166663472647 = makeCons(symdo, x140166663472615);
 __nargs = 2;
-__arg1 = x140246338250215;
+__arg1 = x140166663472647;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970535;
+__arg0 = x140166664290823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3125,7 +3125,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970535;
+__arg0 = x140166664290823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3134,7 +3134,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970535;
+__arg0 = x140166664290823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3145,13 +3145,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140246338971079 = makeNative(47, clofun1, 0, 0);
-Obj x140246338452615 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338452615) {
-Obj x140246338453127 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140246338453127;
-Obj x140246338453383 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140246338453383;
+Obj x140166664291431 = makeNative(47, clofun1, 0, 0);
+Obj x140166663533159 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663533159) {
+Obj x140166663533479 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140166663533479;
+Obj x140166663533735 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140166663533735;
 pushCont(co, 46, clofun1, 1, x);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
@@ -3163,7 +3163,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971079;
+__arg0 = x140166664291431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3174,13 +3174,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140246338352263 = __arg1;
+Obj x140166663534631 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338352359 = makeCons(x140246338352263, Nil);
-Obj x140246338352391 = makeCons(x, x140246338352359);
-Obj x140246338352423 = makeCons(symdo, x140246338352391);
+Obj x140166663534695 = makeCons(x140166663534631, Nil);
+Obj x140166663534727 = makeCons(x, x140166663534695);
+Obj x140166663534759 = makeCons(symdo, x140166663534727);
 __nargs = 2;
-__arg1 = x140246338352423;
+__arg1 = x140166663534759;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3214,11 +3214,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140246338450951 = __arg1;
+Obj x140166663560615 = __arg1;
 PUSH_CONT_0(co, 0, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45namespace);
-__arg1 = x140246338450951;
+__arg1 = x140166663560615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3248,10 +3248,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140246338450983 = __arg1;
+Obj x140166663560647 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x140246338450983;
+__arg1 = x140166663560647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3262,12 +3262,6 @@ goto *jumpTable[ps.label];
 label1:
 {
 Obj exp = __arg1;
-Obj x140246338496999 = PRIM_ISCONS(exp);
-if (True == x140246338496999) {
-Obj x140246338497479 = PRIM_CAR(exp);
-Obj x140246338497511 = PRIM_EQ(symns, x140246338497479);
-if (True == x140246338497511) {
-if (True == True) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = Nil;
@@ -3279,86 +3273,37 @@ struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-if (True == False) {
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = Nil;
-__arg2 = makeCString("");
-__arg3 = Nil;
-co->args[4] = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-} else {
-if (True == False) {
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = Nil;
-__arg2 = makeCString("");
-__arg3 = Nil;
-co->args[4] = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
 }
 
 label2:
 {
-Obj x140246338970183 = __arg1;
-Obj x140246338970343 = makeNative(3, clofun2, 0, 1, x140246338970183);
-Obj x140246338552967 = PRIM_ISCONS(x140246338970183);
-if (True == x140246338552967) {
-Obj x140246338553511 = PRIM_CAR(x140246338970183);
-Obj x140246338553543 = PRIM_EQ(symquote, x140246338553511);
-if (True == x140246338553543) {
-Obj x140246338554087 = PRIM_CDR(x140246338970183);
-Obj x140246338554119 = PRIM_ISCONS(x140246338554087);
-if (True == x140246338554119) {
-Obj x140246338554855 = PRIM_CDR(x140246338970183);
-Obj x140246338554887 = PRIM_CAR(x140246338554855);
-Obj x = x140246338554887;
-Obj x140246338555655 = PRIM_CDR(x140246338970183);
-Obj x140246338555687 = PRIM_CDR(x140246338555655);
-Obj x140246338555751 = PRIM_EQ(Nil, x140246338555687);
-if (True == x140246338555751) {
-Obj x140246338495111 = makeCons(x, Nil);
-Obj x140246338495143 = makeCons(symquote, x140246338495111);
+Obj x140166664290855 = __arg1;
+Obj x140166664290567 = makeNative(3, clofun2, 0, 1, x140166664290855);
+Obj x140166663563495 = PRIM_ISCONS(x140166664290855);
+if (True == x140166663563495) {
+Obj x140166663564071 = PRIM_CAR(x140166664290855);
+Obj x140166663564103 = PRIM_EQ(symquote, x140166663564071);
+if (True == x140166663564103) {
+Obj x140166663564519 = PRIM_CDR(x140166664290855);
+Obj x140166663564551 = PRIM_ISCONS(x140166663564519);
+if (True == x140166663564551) {
+Obj x140166663565063 = PRIM_CDR(x140166664290855);
+Obj x140166663565095 = PRIM_CAR(x140166663565063);
+Obj x = x140166663565095;
+Obj x140166663557607 = PRIM_CDR(x140166664290855);
+Obj x140166663557639 = PRIM_CDR(x140166663557607);
+Obj x140166663557671 = PRIM_EQ(Nil, x140166663557639);
+if (True == x140166663557671) {
+Obj x140166663558183 = makeCons(x, Nil);
+Obj x140166663558215 = makeCons(symquote, x140166663558183);
 __nargs = 2;
-__arg1 = x140246338495143;
+__arg1 = x140166663558215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970343;
+__arg0 = x140166664290567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3367,7 +3312,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970343;
+__arg0 = x140166664290567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3376,7 +3321,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970343;
+__arg0 = x140166664290567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3385,7 +3330,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970343;
+__arg0 = x140166664290567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3396,22 +3341,22 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140246338970855 = makeNative(5, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338627815 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338627815) {
-Obj x140246338628423 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338628455 = PRIM_EQ(symcons_63, x140246338628423);
-if (True == x140246338628455) {
-Obj x140246338629319 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338629351 = PRIM_ISCONS(x140246338629319);
-if (True == x140246338629351) {
-Obj x140246338601223 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338601255 = PRIM_CAR(x140246338601223);
-Obj x = x140246338601255;
-Obj x140246338602471 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338602503 = PRIM_CDR(x140246338602471);
-Obj x140246338602535 = PRIM_EQ(Nil, x140246338602503);
-if (True == x140246338602535) {
+Obj x140166664291143 = makeNative(5, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166663575111 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663575111) {
+Obj x140166663575719 = PRIM_CAR(closureRef(co, 0));
+Obj x140166663575751 = PRIM_EQ(symcons_63, x140166663575719);
+if (True == x140166663575751) {
+Obj x140166663576199 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663576231 = PRIM_ISCONS(x140166663576199);
+if (True == x140166663576231) {
+Obj x140166663576807 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663576839 = PRIM_CAR(x140166663576807);
+Obj x = x140166663576839;
+Obj x140166663561479 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663561511 = PRIM_CDR(x140166663561479);
+Obj x140166663561543 = PRIM_EQ(Nil, x140166663561511);
+if (True == x140166663561543) {
 PUSH_CONT_0(co, 4, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3423,7 +3368,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970855;
+__arg0 = x140166664291143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3432,7 +3377,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970855;
+__arg0 = x140166664291143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3441,7 +3386,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970855;
+__arg0 = x140166664291143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3450,7 +3395,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970855;
+__arg0 = x140166664291143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3461,13 +3406,13 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140246338602823 = __arg1;
-Obj x1 = x140246338602823;
-Obj x140246338604103 = makeCons(x1, Nil);
-Obj x140246338604839 = makeCons(symcons_63, x140246338604103);
+Obj x140166663561799 = __arg1;
+Obj x1 = x140166663561799;
+Obj x140166663562375 = makeCons(x1, Nil);
+Obj x140166663562407 = makeCons(symcons_63, x140166663562375);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246338604839;
+__arg1 = x140166663562407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3477,22 +3422,22 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140246338971335 = makeNative(7, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338826215 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338826215) {
-Obj x140246338699975 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338700007 = PRIM_EQ(symcar, x140246338699975);
-if (True == x140246338700007) {
-Obj x140246338700711 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338700775 = PRIM_ISCONS(x140246338700711);
-if (True == x140246338700775) {
-Obj x140246338701767 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338701799 = PRIM_CAR(x140246338701767);
-Obj x = x140246338701799;
-Obj x140246338702791 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338702887 = PRIM_CDR(x140246338702791);
-Obj x140246338702919 = PRIM_EQ(Nil, x140246338702887);
-if (True == x140246338702919) {
+Obj x140166664291623 = makeNative(7, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166663758087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663758087) {
+Obj x140166663758631 = PRIM_CAR(closureRef(co, 0));
+Obj x140166663758663 = PRIM_EQ(symcar, x140166663758631);
+if (True == x140166663758663) {
+Obj x140166663759335 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663759367 = PRIM_ISCONS(x140166663759335);
+if (True == x140166663759367) {
+Obj x140166663759975 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663760007 = PRIM_CAR(x140166663759975);
+Obj x = x140166663760007;
+Obj x140166663760839 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663760871 = PRIM_CDR(x140166663760839);
+Obj x140166663760903 = PRIM_EQ(Nil, x140166663760871);
+if (True == x140166663760903) {
 PUSH_CONT_0(co, 6, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3504,7 +3449,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971335;
+__arg0 = x140166664291623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3513,7 +3458,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971335;
+__arg0 = x140166664291623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3522,7 +3467,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971335;
+__arg0 = x140166664291623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3531,7 +3476,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971335;
+__arg0 = x140166664291623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3542,13 +3487,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140246338703239 = __arg1;
-Obj x1 = x140246338703239;
-Obj x140246338626183 = makeCons(x1, Nil);
-Obj x140246338626215 = makeCons(symcar, x140246338626183);
+Obj x140166663761319 = __arg1;
+Obj x1 = x140166663761319;
+Obj x140166663573863 = makeCons(x1, Nil);
+Obj x140166663573927 = makeCons(symcar, x140166663573863);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246338626215;
+__arg1 = x140166663573927;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3558,22 +3503,22 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140246338971783 = makeNative(9, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338951111 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338951111) {
-Obj x140246338951975 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338952007 = PRIM_EQ(symcdr, x140246338951975);
-if (True == x140246338952007) {
-Obj x140246338952679 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338952743 = PRIM_ISCONS(x140246338952679);
-if (True == x140246338952743) {
-Obj x140246338822439 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338822471 = PRIM_CAR(x140246338822439);
-Obj x = x140246338822471;
-Obj x140246338823783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338823847 = PRIM_CDR(x140246338823783);
-Obj x140246338823879 = PRIM_EQ(Nil, x140246338823847);
-if (True == x140246338823879) {
+Obj x140166664292103 = makeNative(9, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166663953223 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663953223) {
+Obj x140166663953991 = PRIM_CAR(closureRef(co, 0));
+Obj x140166663954023 = PRIM_EQ(symcdr, x140166663953991);
+if (True == x140166663954023) {
+Obj x140166663925959 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663925991 = PRIM_ISCONS(x140166663925959);
+if (True == x140166663925991) {
+Obj x140166663926631 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663926663 = PRIM_CAR(x140166663926631);
+Obj x = x140166663926663;
+Obj x140166663927495 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663927527 = PRIM_CDR(x140166663927495);
+Obj x140166663927559 = PRIM_EQ(Nil, x140166663927527);
+if (True == x140166663927559) {
 PUSH_CONT_0(co, 8, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3585,7 +3530,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971783;
+__arg0 = x140166664292103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3594,7 +3539,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971783;
+__arg0 = x140166664292103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3603,7 +3548,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971783;
+__arg0 = x140166664292103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3612,7 +3557,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971783;
+__arg0 = x140166664292103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3623,13 +3568,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140246338824231 = __arg1;
-Obj x1 = x140246338824231;
-Obj x140246338825127 = makeCons(x1, Nil);
-Obj x140246338825159 = makeCons(symcdr, x140246338825127);
+Obj x140166663928199 = __arg1;
+Obj x1 = x140166663928199;
+Obj x140166663928999 = makeCons(x1, Nil);
+Obj x140166663929031 = makeCons(symcdr, x140166663928999);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246338825159;
+__arg1 = x140166663929031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3639,31 +3584,31 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140246338972263 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339373639 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339373639) {
-Obj x140246339374599 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339374695 = PRIM_EQ(symand, x140246339374599);
-if (True == x140246339374695) {
-Obj x140246339318215 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339318247 = PRIM_ISCONS(x140246339318215);
-if (True == x140246339318247) {
-Obj x140246339318823 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339318855 = PRIM_CAR(x140246339318823);
-Obj x = x140246339318855;
-Obj x140246339319783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339319847 = PRIM_CDR(x140246339319783);
-Obj x140246339319879 = PRIM_ISCONS(x140246339319847);
-if (True == x140246339319879) {
-Obj x140246339320839 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339320871 = PRIM_CDR(x140246339320839);
-Obj x140246339320903 = PRIM_CAR(x140246339320871);
-Obj y = x140246339320903;
-Obj x140246338970247 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338970311 = PRIM_CDR(x140246338970247);
-Obj x140246338970407 = PRIM_CDR(x140246338970311);
-Obj x140246338970471 = PRIM_EQ(Nil, x140246338970407);
-if (True == x140246338970471) {
+Obj x140166664292583 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664082823 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664082823) {
+Obj x140166664083399 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664083431 = PRIM_EQ(symand, x140166664083399);
+if (True == x140166664083431) {
+Obj x140166664084327 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664084359 = PRIM_ISCONS(x140166664084327);
+if (True == x140166664084359) {
+Obj x140166664084967 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664084999 = PRIM_CAR(x140166664084967);
+Obj x = x140166664084999;
+Obj x140166664073479 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664073511 = PRIM_CDR(x140166664073479);
+Obj x140166664073543 = PRIM_ISCONS(x140166664073511);
+if (True == x140166664073543) {
+Obj x140166664074439 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664074471 = PRIM_CDR(x140166664074439);
+Obj x140166664074503 = PRIM_CAR(x140166664074471);
+Obj y = x140166664074503;
+Obj x140166664075719 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664075847 = PRIM_CDR(x140166664075719);
+Obj x140166664075911 = PRIM_CDR(x140166664075847);
+Obj x140166664075943 = PRIM_EQ(Nil, x140166664075911);
+if (True == x140166664075943) {
 pushCont(co, 10, clofun2, 1, y);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3675,7 +3620,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338972263;
+__arg0 = x140166664292583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3684,7 +3629,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972263;
+__arg0 = x140166664292583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3693,7 +3638,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972263;
+__arg0 = x140166664292583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3702,7 +3647,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972263;
+__arg0 = x140166664292583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3711,7 +3656,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972263;
+__arg0 = x140166664292583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3722,9 +3667,9 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140246338971047 = __arg1;
+Obj x140166664076423 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1 = x140246338971047;
+Obj x1 = x140166664076423;
 pushCont(co, 11, clofun2, 1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3738,15 +3683,15 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246338971495 = __arg1;
+Obj x140166664076807 = __arg1;
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y1 = x140246338971495;
-Obj x140246338973159 = makeCons(y1, Nil);
-Obj x140246338973191 = makeCons(x1, x140246338973159);
-Obj x140246338973223 = makeCons(symand, x140246338973191);
+Obj y1 = x140166664076807;
+Obj x140166663951847 = makeCons(y1, Nil);
+Obj x140166663951879 = makeCons(x1, x140166663951847);
+Obj x140166663951911 = makeCons(symand, x140166663951879);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246338973223;
+__arg1 = x140166663951911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3756,22 +3701,22 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140246338972871 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339621671 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339621671) {
-Obj x140246339622503 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339622535 = PRIM_EQ(symnull_63, x140246339622503);
-if (True == x140246339622535) {
-Obj x140246339623143 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339623335 = PRIM_ISCONS(x140246339623143);
-if (True == x140246339623335) {
-Obj x140246339623879 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339623911 = PRIM_CAR(x140246339623879);
-Obj x = x140246339623911;
-Obj x140246339371015 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339371047 = PRIM_CDR(x140246339371015);
-Obj x140246339371079 = PRIM_EQ(Nil, x140246339371047);
-if (True == x140246339371079) {
+Obj x140166664293191 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664117447 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664117447) {
+Obj x140166664118023 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664118183 = PRIM_EQ(symnull_63, x140166664118023);
+if (True == x140166664118183) {
+Obj x140166664086087 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664086119 = PRIM_ISCONS(x140166664086087);
+if (True == x140166664086119) {
+Obj x140166664086855 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664086887 = PRIM_CAR(x140166664086855);
+Obj x = x140166664086887;
+Obj x140166664088199 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664088231 = PRIM_CDR(x140166664088199);
+Obj x140166664088263 = PRIM_EQ(Nil, x140166664088231);
+if (True == x140166664088263) {
 PUSH_CONT_0(co, 13, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3783,7 +3728,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338972871;
+__arg0 = x140166664293191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3792,7 +3737,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972871;
+__arg0 = x140166664293191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3801,7 +3746,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972871;
+__arg0 = x140166664293191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3810,7 +3755,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972871;
+__arg0 = x140166664293191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3821,13 +3766,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140246339371527 = __arg1;
-Obj x1 = x140246339371527;
-Obj x140246339372519 = makeCons(x1, Nil);
-Obj x140246339372551 = makeCons(symnull_63, x140246339372519);
+Obj x140166664088679 = __arg1;
+Obj x1 = x140166664088679;
+Obj x140166664081543 = makeCons(x1, Nil);
+Obj x140166664081575 = makeCons(symnull_63, x140166664081543);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246339372551;
+__arg1 = x140166664081575;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3837,22 +3782,22 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140246338973351 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339751399 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339751399) {
-Obj x140246339711079 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339711111 = PRIM_EQ(symnot, x140246339711079);
-if (True == x140246339711111) {
-Obj x140246339711879 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339711911 = PRIM_ISCONS(x140246339711879);
-if (True == x140246339711911) {
-Obj x140246339712359 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339712423 = PRIM_CAR(x140246339712359);
-Obj x = x140246339712423;
-Obj x140246339713447 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339713479 = PRIM_CDR(x140246339713447);
-Obj x140246339713511 = PRIM_EQ(Nil, x140246339713479);
-if (True == x140246339713511) {
+Obj x140166664293639 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664130951 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664130951) {
+Obj x140166664131975 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664132039 = PRIM_EQ(symnot, x140166664131975);
+if (True == x140166664132039) {
+Obj x140166664132743 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664132871 = PRIM_ISCONS(x140166664132743);
+if (True == x140166664132871) {
+Obj x140166664133703 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664133735 = PRIM_CAR(x140166664133703);
+Obj x = x140166664133735;
+Obj x140166664114407 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664114439 = PRIM_CDR(x140166664114407);
+Obj x140166664114471 = PRIM_EQ(Nil, x140166664114439);
+if (True == x140166664114471) {
 PUSH_CONT_0(co, 15, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3864,7 +3809,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338973351;
+__arg0 = x140166664293639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3873,7 +3818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973351;
+__arg0 = x140166664293639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3882,7 +3827,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973351;
+__arg0 = x140166664293639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3891,7 +3836,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973351;
+__arg0 = x140166664293639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3902,13 +3847,13 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140246339713831 = __arg1;
-Obj x1 = x140246339713831;
-Obj x140246339714535 = makeCons(x1, Nil);
-Obj x140246339714759 = makeCons(symnot, x140246339714535);
+Obj x140166664114887 = __arg1;
+Obj x1 = x140166664114887;
+Obj x140166664115943 = makeCons(x1, Nil);
+Obj x140166664115975 = makeCons(symnot, x140166664115943);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246339714759;
+__arg1 = x140166664115975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3918,42 +3863,42 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140246338949255 = makeNative(20, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246337886887 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246337886887) {
-Obj x140246337887335 = PRIM_CAR(closureRef(co, 0));
-Obj x140246337887367 = PRIM_EQ(symif, x140246337887335);
-if (True == x140246337887367) {
-Obj x140246337887783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337887815 = PRIM_ISCONS(x140246337887783);
-if (True == x140246337887815) {
-Obj x140246337888231 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337862215 = PRIM_CAR(x140246337888231);
-Obj x = x140246337862215;
-Obj x140246339789319 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339789351 = PRIM_CDR(x140246339789319);
-Obj x140246339789383 = PRIM_ISCONS(x140246339789351);
-if (True == x140246339789383) {
-Obj x140246339789959 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339789991 = PRIM_CDR(x140246339789959);
-Obj x140246339790023 = PRIM_CAR(x140246339789991);
-Obj y = x140246339790023;
-Obj x140246339790439 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339790471 = PRIM_CDR(x140246339790439);
-Obj x140246339790503 = PRIM_CDR(x140246339790471);
-Obj x140246339790535 = PRIM_ISCONS(x140246339790503);
-if (True == x140246339790535) {
-Obj x140246339791271 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339791303 = PRIM_CDR(x140246339791271);
-Obj x140246339791335 = PRIM_CDR(x140246339791303);
-Obj x140246339791367 = PRIM_CAR(x140246339791335);
-Obj z = x140246339791367;
-Obj x140246339792295 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339792327 = PRIM_CDR(x140246339792295);
-Obj x140246339792359 = PRIM_CDR(x140246339792327);
-Obj x140246339792391 = PRIM_CDR(x140246339792359);
-Obj x140246339792423 = PRIM_EQ(Nil, x140246339792391);
-if (True == x140246339792423) {
+Obj x140166664294119 = makeNative(20, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664834055 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664834055) {
+Obj x140166664834663 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664834759 = PRIM_EQ(symif, x140166664834663);
+if (True == x140166664834759) {
+Obj x140166664692103 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664692135 = PRIM_ISCONS(x140166664692103);
+if (True == x140166664692135) {
+Obj x140166664692583 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664692615 = PRIM_CAR(x140166664692583);
+Obj x = x140166664692615;
+Obj x140166664693415 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664693447 = PRIM_CDR(x140166664693415);
+Obj x140166664693479 = PRIM_ISCONS(x140166664693447);
+if (True == x140166664693479) {
+Obj x140166664694567 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664694599 = PRIM_CDR(x140166664694567);
+Obj x140166664694663 = PRIM_CAR(x140166664694599);
+Obj y = x140166664694663;
+Obj x140166664695655 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664695687 = PRIM_CDR(x140166664695655);
+Obj x140166664695719 = PRIM_CDR(x140166664695687);
+Obj x140166664695751 = PRIM_ISCONS(x140166664695719);
+if (True == x140166664695751) {
+Obj x140166664471751 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664471783 = PRIM_CDR(x140166664471751);
+Obj x140166664471815 = PRIM_CDR(x140166664471783);
+Obj x140166664471847 = PRIM_CAR(x140166664471815);
+Obj z = x140166664471847;
+Obj x140166664473319 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664473351 = PRIM_CDR(x140166664473319);
+Obj x140166664473383 = PRIM_CDR(x140166664473351);
+Obj x140166664473511 = PRIM_CDR(x140166664473383);
+Obj x140166664473543 = PRIM_EQ(Nil, x140166664473511);
+if (True == x140166664473543) {
 pushCont(co, 17, clofun2, 2, y, z);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3965,7 +3910,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3974,7 +3919,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3983,7 +3928,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3992,7 +3937,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4001,7 +3946,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4010,7 +3955,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949255;
+__arg0 = x140166664294119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4021,10 +3966,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140246339792679 = __arg1;
+Obj x140166664473799 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x1 = x140246339792679;
+Obj x1 = x140166664473799;
 pushCont(co, 18, clofun2, 2, z, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -4038,10 +3983,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140246339747879 = __arg1;
+Obj x140166664474119 = __arg1;
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y1 = x140246339747879;
+Obj y1 = x140166664474119;
 pushCont(co, 19, clofun2, 2, y1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -4055,17 +4000,17 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140246339748263 = __arg1;
+Obj x140166664474567 = __arg1;
 Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj z1 = x140246339748263;
-Obj x140246339749703 = makeCons(z1, Nil);
-Obj x140246339749735 = makeCons(y1, x140246339749703);
-Obj x140246339749767 = makeCons(x1, x140246339749735);
-Obj x140246339749799 = makeCons(symif, x140246339749767);
+Obj z1 = x140166664474567;
+Obj x140166664292487 = makeCons(z1, Nil);
+Obj x140166664292519 = makeCons(y1, x140166664292487);
+Obj x140166664292551 = makeCons(x1, x140166664292519);
+Obj x140166664292615 = makeCons(symif, x140166664292551);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140246339749799;
+__arg1 = x140166664292615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4075,31 +4020,31 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140246338949959 = makeNative(22, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246337970855 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246337970855) {
-Obj x140246337971303 = PRIM_CAR(closureRef(co, 0));
-Obj x140246337971335 = PRIM_EQ(symlambda, x140246337971303);
-if (True == x140246337971335) {
-Obj x140246337971751 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337971783 = PRIM_ISCONS(x140246337971751);
-if (True == x140246337971783) {
-Obj x140246337972199 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337972231 = PRIM_CAR(x140246337972199);
-Obj args = x140246337972231;
-Obj x140246337972807 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337972839 = PRIM_CDR(x140246337972807);
-Obj x140246337972871 = PRIM_ISCONS(x140246337972839);
-if (True == x140246337972871) {
-Obj x140246337973447 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337973479 = PRIM_CDR(x140246337973447);
-Obj x140246337973511 = PRIM_CAR(x140246337973479);
-Obj body = x140246337973511;
-Obj x140246337885031 = PRIM_CDR(closureRef(co, 0));
-Obj x140246337885063 = PRIM_CDR(x140246337885031);
-Obj x140246337885095 = PRIM_CDR(x140246337885063);
-Obj x140246337885127 = PRIM_EQ(Nil, x140246337885095);
-if (True == x140246337885127) {
+Obj x140166664131015 = makeNative(22, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166665166151 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665166151) {
+Obj x140166665044007 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665044039 = PRIM_EQ(symlambda, x140166665044007);
+if (True == x140166665044039) {
+Obj x140166665044583 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665044615 = PRIM_ISCONS(x140166665044583);
+if (True == x140166665044615) {
+Obj x140166665045095 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665045127 = PRIM_CAR(x140166665045095);
+Obj args = x140166665045127;
+Obj x140166665046119 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665046151 = PRIM_CDR(x140166665046119);
+Obj x140166665046183 = PRIM_ISCONS(x140166665046151);
+if (True == x140166665046183) {
+Obj x140166665047143 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665047175 = PRIM_CDR(x140166665047143);
+Obj x140166665047239 = PRIM_CAR(x140166665047175);
+Obj body = x140166665047239;
+Obj x140166664831303 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664831335 = PRIM_CDR(x140166664831303);
+Obj x140166664831367 = PRIM_CDR(x140166664831335);
+Obj x140166664831399 = PRIM_EQ(Nil, x140166664831367);
+if (True == x140166664831399) {
 pushCont(co, 21, clofun2, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -4111,7 +4056,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949959;
+__arg0 = x140166664131015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4120,7 +4065,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949959;
+__arg0 = x140166664131015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4129,7 +4074,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949959;
+__arg0 = x140166664131015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4138,7 +4083,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949959;
+__arg0 = x140166664131015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4147,7 +4092,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949959;
+__arg0 = x140166664131015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4158,13 +4103,13 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140246337885863 = __arg1;
+Obj x140166664832391 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246337885927 = makeCons(x140246337885863, Nil);
-Obj x140246337885959 = makeCons(args, x140246337885927);
-Obj x140246337885991 = makeCons(symlambda, x140246337885959);
+Obj x140166664832455 = makeCons(x140166664832391, Nil);
+Obj x140166664832487 = makeCons(args, x140166664832455);
+Obj x140166664832519 = makeCons(symlambda, x140166664832487);
 __nargs = 2;
-__arg1 = x140246337885991;
+__arg1 = x140166664832519;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4172,18 +4117,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label22:
 {
-Obj x140246338950599 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338170247 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338170247) {
-Obj x140246338170503 = PRIM_CAR(closureRef(co, 0));
-Obj f = x140246338170503;
-Obj x140246338170759 = PRIM_CDR(closureRef(co, 0));
-Obj args = x140246338170759;
-Obj x140246337970471 = makeCons(f, args);
+Obj x140166664131623 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166665164103 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665164103) {
+Obj x140166665164359 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140166665164359;
+Obj x140166665164711 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140166665164711;
+Obj x140166665165703 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35propagate_45boolean);
-__arg2 = x140246337970471;
+__arg2 = x140166665165703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4191,7 +4136,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338950599;
+__arg0 = x140166664131623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4202,7 +4147,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140246338950983 = makeNative(24, clofun2, 0, 0);
+Obj x140166664132007 = makeNative(24, clofun2, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -4225,58 +4170,58 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140246338970151 = __arg1;
-Obj x140246338970279 = makeNative(26, clofun2, 0, 1, x140246338970151);
-Obj x140246338353223 = PRIM_ISCONS(x140246338970151);
-if (True == x140246338353223) {
-Obj x140246338353895 = PRIM_CAR(x140246338970151);
-Obj x140246338353927 = PRIM_EQ(symcar, x140246338353895);
-if (True == x140246338353927) {
-Obj x140246338354343 = PRIM_CDR(x140246338970151);
-Obj x140246338354375 = PRIM_ISCONS(x140246338354343);
-if (True == x140246338354375) {
-Obj x140246338355175 = PRIM_CDR(x140246338970151);
-Obj x140246338248711 = PRIM_CAR(x140246338355175);
-Obj x140246338248743 = PRIM_ISCONS(x140246338248711);
-if (True == x140246338248743) {
-Obj x140246338249895 = PRIM_CDR(x140246338970151);
-Obj x140246338249927 = PRIM_CAR(x140246338249895);
-Obj x140246338249959 = PRIM_CAR(x140246338249927);
-Obj x140246338249991 = PRIM_EQ(symcons, x140246338249959);
-if (True == x140246338249991) {
-Obj x140246338250791 = PRIM_CDR(x140246338970151);
-Obj x140246338250823 = PRIM_CAR(x140246338250791);
-Obj x140246338250855 = PRIM_CDR(x140246338250823);
-Obj x140246338250887 = PRIM_ISCONS(x140246338250855);
-if (True == x140246338250887) {
-Obj x140246338251655 = PRIM_CDR(x140246338970151);
-Obj x140246338251687 = PRIM_CAR(x140246338251655);
-Obj x140246338251719 = PRIM_CDR(x140246338251687);
-Obj x140246338251751 = PRIM_CAR(x140246338251719);
-Obj x = x140246338251751;
-Obj x140246338252775 = PRIM_CDR(x140246338970151);
-Obj x140246338228231 = PRIM_CAR(x140246338252775);
-Obj x140246338228263 = PRIM_CDR(x140246338228231);
-Obj x140246338228295 = PRIM_CDR(x140246338228263);
-Obj x140246338228327 = PRIM_ISCONS(x140246338228295);
-if (True == x140246338228327) {
-Obj x140246338229415 = PRIM_CDR(x140246338970151);
-Obj x140246338229447 = PRIM_CAR(x140246338229415);
-Obj x140246338229479 = PRIM_CDR(x140246338229447);
-Obj x140246338229511 = PRIM_CDR(x140246338229479);
-Obj x140246338229543 = PRIM_CAR(x140246338229511);
-Obj __ = x140246338229543;
-Obj x140246338230855 = PRIM_CDR(x140246338970151);
-Obj x140246338230887 = PRIM_CAR(x140246338230855);
-Obj x140246338230919 = PRIM_CDR(x140246338230887);
-Obj x140246338230951 = PRIM_CDR(x140246338230919);
-Obj x140246338230983 = PRIM_CDR(x140246338230951);
-Obj x140246338231015 = PRIM_EQ(Nil, x140246338230983);
-if (True == x140246338231015) {
-Obj x140246338166791 = PRIM_CDR(x140246338970151);
-Obj x140246338166823 = PRIM_CDR(x140246338166791);
-Obj x140246338166855 = PRIM_EQ(Nil, x140246338166823);
-if (True == x140246338166855) {
+Obj x140166664292007 = __arg1;
+Obj x140166664292135 = makeNative(26, clofun2, 0, 1, x140166664292007);
+Obj x140166663532935 = PRIM_ISCONS(x140166664292007);
+if (True == x140166663532935) {
+Obj x140166663533383 = PRIM_CAR(x140166664292007);
+Obj x140166663533415 = PRIM_EQ(symcar, x140166663533383);
+if (True == x140166663533415) {
+Obj x140166663533831 = PRIM_CDR(x140166664292007);
+Obj x140166663533863 = PRIM_ISCONS(x140166663533831);
+if (True == x140166663533863) {
+Obj x140166663534439 = PRIM_CDR(x140166664292007);
+Obj x140166663534471 = PRIM_CAR(x140166663534439);
+Obj x140166663534503 = PRIM_ISCONS(x140166663534471);
+if (True == x140166663534503) {
+Obj x140166663535271 = PRIM_CDR(x140166664292007);
+Obj x140166663535303 = PRIM_CAR(x140166663535271);
+Obj x140166663535335 = PRIM_CAR(x140166663535303);
+Obj x140166663535367 = PRIM_EQ(symcons, x140166663535335);
+if (True == x140166663535367) {
+Obj x140166663536103 = PRIM_CDR(x140166664292007);
+Obj x140166663536135 = PRIM_CAR(x140166663536103);
+Obj x140166663536167 = PRIM_CDR(x140166663536135);
+Obj x140166663536199 = PRIM_ISCONS(x140166663536167);
+if (True == x140166663536199) {
+Obj x140166663471399 = PRIM_CDR(x140166664292007);
+Obj x140166663471431 = PRIM_CAR(x140166663471399);
+Obj x140166663471463 = PRIM_CDR(x140166663471431);
+Obj x140166663471495 = PRIM_CAR(x140166663471463);
+Obj x = x140166663471495;
+Obj x140166663472391 = PRIM_CDR(x140166664292007);
+Obj x140166663472423 = PRIM_CAR(x140166663472391);
+Obj x140166663472455 = PRIM_CDR(x140166663472423);
+Obj x140166663472487 = PRIM_CDR(x140166663472455);
+Obj x140166663472519 = PRIM_ISCONS(x140166663472487);
+if (True == x140166663472519) {
+Obj x140166663473415 = PRIM_CDR(x140166664292007);
+Obj x140166663473447 = PRIM_CAR(x140166663473415);
+Obj x140166663473479 = PRIM_CDR(x140166663473447);
+Obj x140166663473511 = PRIM_CDR(x140166663473479);
+Obj x140166663473543 = PRIM_CAR(x140166663473511);
+Obj __ = x140166663473543;
+Obj x140166663474631 = PRIM_CDR(x140166664292007);
+Obj x140166663474663 = PRIM_CAR(x140166663474631);
+Obj x140166663474695 = PRIM_CDR(x140166663474663);
+Obj x140166663474727 = PRIM_CDR(x140166663474695);
+Obj x140166663474759 = PRIM_CDR(x140166663474727);
+Obj x140166663474791 = PRIM_EQ(Nil, x140166663474759);
+if (True == x140166663474791) {
+Obj x140166665228679 = PRIM_CDR(x140166664292007);
+Obj x140166665228711 = PRIM_CDR(x140166665228679);
+Obj x140166665228743 = PRIM_EQ(Nil, x140166665228711);
+if (True == x140166665228743) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4284,7 +4229,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4293,7 +4238,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4302,7 +4247,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4311,7 +4256,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4320,7 +4265,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4329,7 +4274,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4338,7 +4283,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4347,7 +4292,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4356,7 +4301,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970279;
+__arg0 = x140166664292135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4367,57 +4312,57 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140246338971143 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338553831 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338553831) {
-Obj x140246338554503 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338554535 = PRIM_EQ(symcdr, x140246338554503);
-if (True == x140246338554535) {
-Obj x140246338555047 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338555079 = PRIM_ISCONS(x140246338555047);
-if (True == x140246338555079) {
-Obj x140246338555783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338555815 = PRIM_CAR(x140246338555783);
-Obj x140246338555847 = PRIM_ISCONS(x140246338555815);
-if (True == x140246338555847) {
-Obj x140246338495495 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338495527 = PRIM_CAR(x140246338495495);
-Obj x140246338495559 = PRIM_CAR(x140246338495527);
-Obj x140246338495591 = PRIM_EQ(symcons, x140246338495559);
-if (True == x140246338495591) {
-Obj x140246338496647 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338496679 = PRIM_CAR(x140246338496647);
-Obj x140246338496711 = PRIM_CDR(x140246338496679);
-Obj x140246338496743 = PRIM_ISCONS(x140246338496711);
-if (True == x140246338496743) {
-Obj x140246338497575 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338497607 = PRIM_CAR(x140246338497575);
-Obj x140246338497639 = PRIM_CDR(x140246338497607);
-Obj x140246338497671 = PRIM_CAR(x140246338497639);
-Obj __ = x140246338497671;
-Obj x140246338449959 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338449991 = PRIM_CAR(x140246338449959);
-Obj x140246338450023 = PRIM_CDR(x140246338449991);
-Obj x140246338450055 = PRIM_CDR(x140246338450023);
-Obj x140246338450119 = PRIM_ISCONS(x140246338450055);
-if (True == x140246338450119) {
-Obj x140246338451143 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338451175 = PRIM_CAR(x140246338451143);
-Obj x140246338451207 = PRIM_CDR(x140246338451175);
-Obj x140246338451239 = PRIM_CDR(x140246338451207);
-Obj x140246338451271 = PRIM_CAR(x140246338451239);
-Obj x = x140246338451271;
-Obj x140246338452647 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338452679 = PRIM_CAR(x140246338452647);
-Obj x140246338452711 = PRIM_CDR(x140246338452679);
-Obj x140246338452743 = PRIM_CDR(x140246338452711);
-Obj x140246338452775 = PRIM_CDR(x140246338452743);
-Obj x140246338452871 = PRIM_EQ(Nil, x140246338452775);
-if (True == x140246338452871) {
-Obj x140246338351175 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338351207 = PRIM_CDR(x140246338351175);
-Obj x140246338351239 = PRIM_EQ(Nil, x140246338351207);
-if (True == x140246338351239) {
+Obj x140166664292935 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166663758599 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663758599) {
+Obj x140166663759111 = PRIM_CAR(closureRef(co, 0));
+Obj x140166663759143 = PRIM_EQ(symcdr, x140166663759111);
+if (True == x140166663759143) {
+Obj x140166663759783 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663759815 = PRIM_ISCONS(x140166663759783);
+if (True == x140166663759815) {
+Obj x140166663760519 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663760583 = PRIM_CAR(x140166663760519);
+Obj x140166663760615 = PRIM_ISCONS(x140166663760583);
+if (True == x140166663760615) {
+Obj x140166663761575 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663761607 = PRIM_CAR(x140166663761575);
+Obj x140166663761639 = PRIM_CAR(x140166663761607);
+Obj x140166663761671 = PRIM_EQ(symcons, x140166663761639);
+if (True == x140166663761671) {
+Obj x140166663574311 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663574343 = PRIM_CAR(x140166663574311);
+Obj x140166663574375 = PRIM_CDR(x140166663574343);
+Obj x140166663574407 = PRIM_ISCONS(x140166663574375);
+if (True == x140166663574407) {
+Obj x140166663575367 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663575399 = PRIM_CAR(x140166663575367);
+Obj x140166663575431 = PRIM_CDR(x140166663575399);
+Obj x140166663575463 = PRIM_CAR(x140166663575431);
+Obj __ = x140166663575463;
+Obj x140166663576423 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663576455 = PRIM_CAR(x140166663576423);
+Obj x140166663576487 = PRIM_CDR(x140166663576455);
+Obj x140166663576519 = PRIM_CDR(x140166663576487);
+Obj x140166663576551 = PRIM_ISCONS(x140166663576519);
+if (True == x140166663576551) {
+Obj x140166663561319 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663561351 = PRIM_CAR(x140166663561319);
+Obj x140166663561383 = PRIM_CDR(x140166663561351);
+Obj x140166663561415 = PRIM_CDR(x140166663561383);
+Obj x140166663561447 = PRIM_CAR(x140166663561415);
+Obj x = x140166663561447;
+Obj x140166663562535 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663562567 = PRIM_CAR(x140166663562535);
+Obj x140166663562599 = PRIM_CDR(x140166663562567);
+Obj x140166663562631 = PRIM_CDR(x140166663562599);
+Obj x140166663562663 = PRIM_CDR(x140166663562631);
+Obj x140166663562695 = PRIM_EQ(Nil, x140166663562663);
+if (True == x140166663562695) {
+Obj x140166663563335 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663563367 = PRIM_CDR(x140166663563335);
+Obj x140166663563399 = PRIM_EQ(Nil, x140166663563367);
+if (True == x140166663563399) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4425,7 +4370,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4434,7 +4379,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4443,7 +4388,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4452,7 +4397,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4461,7 +4406,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4470,7 +4415,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4479,7 +4424,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4488,7 +4433,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4497,7 +4442,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971143;
+__arg0 = x140166664292935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4508,57 +4453,57 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x140246338971943 = makeNative(28, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338825991 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338825991) {
-Obj x140246338699591 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338699623 = PRIM_EQ(symcons_63, x140246338699591);
-if (True == x140246338699623) {
-Obj x140246338700199 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338700231 = PRIM_ISCONS(x140246338700199);
-if (True == x140246338700231) {
-Obj x140246338701479 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338701511 = PRIM_CAR(x140246338701479);
-Obj x140246338701543 = PRIM_ISCONS(x140246338701511);
-if (True == x140246338701543) {
-Obj x140246338702503 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338702535 = PRIM_CAR(x140246338702503);
-Obj x140246338702567 = PRIM_CAR(x140246338702535);
-Obj x140246338702599 = PRIM_EQ(symcons, x140246338702567);
-if (True == x140246338702599) {
-Obj x140246338625831 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338625863 = PRIM_CAR(x140246338625831);
-Obj x140246338625895 = PRIM_CDR(x140246338625863);
-Obj x140246338625927 = PRIM_ISCONS(x140246338625895);
-if (True == x140246338625927) {
-Obj x140246338626951 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338626983 = PRIM_CAR(x140246338626951);
-Obj x140246338627015 = PRIM_CDR(x140246338626983);
-Obj x140246338627047 = PRIM_CAR(x140246338627015);
-Obj __ = x140246338627047;
-Obj x140246338628519 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338628551 = PRIM_CAR(x140246338628519);
-Obj x140246338628583 = PRIM_CDR(x140246338628551);
-Obj x140246338628615 = PRIM_CDR(x140246338628583);
-Obj x140246338628743 = PRIM_ISCONS(x140246338628615);
-if (True == x140246338628743) {
-Obj x140246338601287 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338601319 = PRIM_CAR(x140246338601287);
-Obj x140246338601351 = PRIM_CDR(x140246338601319);
-Obj x140246338601383 = PRIM_CDR(x140246338601351);
-Obj x140246338601415 = PRIM_CAR(x140246338601383);
-__ = x140246338601415;
-Obj x140246338603271 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338603335 = PRIM_CAR(x140246338603271);
-Obj x140246338603399 = PRIM_CDR(x140246338603335);
-Obj x140246338603431 = PRIM_CDR(x140246338603399);
-Obj x140246338603463 = PRIM_CDR(x140246338603431);
-Obj x140246338603495 = PRIM_EQ(Nil, x140246338603463);
-if (True == x140246338603495) {
-Obj x140246338604967 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338604999 = PRIM_CDR(x140246338604967);
-Obj x140246338605031 = PRIM_EQ(Nil, x140246338604999);
-if (True == x140246338605031) {
+Obj x140166664293735 = makeNative(28, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664085287 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664085287) {
+Obj x140166664073607 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664073671 = PRIM_EQ(symcons_63, x140166664073607);
+if (True == x140166664073671) {
+Obj x140166664074215 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664074247 = PRIM_ISCONS(x140166664074215);
+if (True == x140166664074247) {
+Obj x140166664075015 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664075047 = PRIM_CAR(x140166664075015);
+Obj x140166664075079 = PRIM_ISCONS(x140166664075047);
+if (True == x140166664075079) {
+Obj x140166664076199 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664076231 = PRIM_CAR(x140166664076199);
+Obj x140166664076263 = PRIM_CAR(x140166664076231);
+Obj x140166664076295 = PRIM_EQ(symcons, x140166664076263);
+if (True == x140166664076295) {
+Obj x140166663951111 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663951143 = PRIM_CAR(x140166663951111);
+Obj x140166663951399 = PRIM_CDR(x140166663951143);
+Obj x140166663951431 = PRIM_ISCONS(x140166663951399);
+if (True == x140166663951431) {
+Obj x140166663952295 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663952327 = PRIM_CAR(x140166663952295);
+Obj x140166663952359 = PRIM_CDR(x140166663952327);
+Obj x140166663952391 = PRIM_CAR(x140166663952359);
+Obj __ = x140166663952391;
+Obj x140166663953511 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663953543 = PRIM_CAR(x140166663953511);
+Obj x140166663953575 = PRIM_CDR(x140166663953543);
+Obj x140166663953607 = PRIM_CDR(x140166663953575);
+Obj x140166663953639 = PRIM_ISCONS(x140166663953607);
+if (True == x140166663953639) {
+Obj x140166663926247 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663926279 = PRIM_CAR(x140166663926247);
+Obj x140166663926311 = PRIM_CDR(x140166663926279);
+Obj x140166663926343 = PRIM_CDR(x140166663926311);
+Obj x140166663926375 = PRIM_CAR(x140166663926343);
+__ = x140166663926375;
+Obj x140166663927751 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663927911 = PRIM_CAR(x140166663927751);
+Obj x140166663927943 = PRIM_CDR(x140166663927911);
+Obj x140166663927975 = PRIM_CDR(x140166663927943);
+Obj x140166663928007 = PRIM_CDR(x140166663927975);
+Obj x140166663928039 = PRIM_EQ(Nil, x140166663928007);
+if (True == x140166663928039) {
+Obj x140166663928679 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663928711 = PRIM_CDR(x140166663928679);
+Obj x140166663928839 = PRIM_EQ(Nil, x140166663928711);
+if (True == x140166663928839) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4566,7 +4511,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4575,7 +4520,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4584,7 +4529,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4593,7 +4538,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4602,7 +4547,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4611,7 +4556,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4620,7 +4565,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4629,7 +4574,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4638,7 +4583,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338971943;
+__arg0 = x140166664293735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4649,33 +4594,33 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x140246338972743 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338973127 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338973127) {
-Obj x140246338949863 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338949895 = PRIM_EQ(symand, x140246338949863);
-if (True == x140246338949895) {
-Obj x140246338950407 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338950471 = PRIM_ISCONS(x140246338950407);
-if (True == x140246338950471) {
-Obj x140246338951655 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338951687 = PRIM_CAR(x140246338951655);
-Obj x140246338951719 = PRIM_EQ(True, x140246338951687);
-if (True == x140246338951719) {
-Obj x140246338952775 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338952839 = PRIM_CDR(x140246338952775);
-Obj x140246338952871 = PRIM_ISCONS(x140246338952839);
-if (True == x140246338952871) {
-Obj x140246338822919 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338823111 = PRIM_CDR(x140246338822919);
-Obj x140246338823143 = PRIM_CAR(x140246338823111);
-Obj x140246338823175 = PRIM_EQ(True, x140246338823143);
-if (True == x140246338823175) {
-Obj x140246338824391 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338824423 = PRIM_CDR(x140246338824391);
-Obj x140246338824455 = PRIM_CDR(x140246338824423);
-Obj x140246338824551 = PRIM_EQ(Nil, x140246338824455);
-if (True == x140246338824551) {
+Obj x140166664130695 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664085991 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664085991) {
+Obj x140166664086695 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664086727 = PRIM_EQ(symand, x140166664086695);
+if (True == x140166664086727) {
+Obj x140166664087335 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664087431 = PRIM_ISCONS(x140166664087335);
+if (True == x140166664087431) {
+Obj x140166664088487 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664088519 = PRIM_CAR(x140166664088487);
+Obj x140166664088551 = PRIM_EQ(True, x140166664088519);
+if (True == x140166664088551) {
+Obj x140166664089383 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664089415 = PRIM_CDR(x140166664089383);
+Obj x140166664089447 = PRIM_ISCONS(x140166664089415);
+if (True == x140166664089447) {
+Obj x140166664082247 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664082279 = PRIM_CDR(x140166664082247);
+Obj x140166664082311 = PRIM_CAR(x140166664082279);
+Obj x140166664082375 = PRIM_EQ(True, x140166664082311);
+if (True == x140166664082375) {
+Obj x140166664083559 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664083591 = PRIM_CDR(x140166664083559);
+Obj x140166664083623 = PRIM_CDR(x140166664083591);
+Obj x140166664083655 = PRIM_EQ(Nil, x140166664083623);
+if (True == x140166664083655) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4683,7 +4628,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4692,7 +4637,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4701,7 +4646,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4710,7 +4655,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4719,7 +4664,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4728,7 +4673,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4737,7 +4682,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338972743;
+__arg0 = x140166664130695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4748,23 +4693,23 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140246338973319 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339319815 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339319815) {
-Obj x140246339320423 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339320455 = PRIM_EQ(symnull_63, x140246339320423);
-if (True == x140246339320455) {
-Obj x140246339321031 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339321063 = PRIM_ISCONS(x140246339321031);
-if (True == x140246339321063) {
-Obj x140246338969927 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338969959 = PRIM_CAR(x140246338969927);
-Obj x140246338969991 = PRIM_EQ(Nil, x140246338969959);
-if (True == x140246338969991) {
-Obj x140246338971271 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338971303 = PRIM_CDR(x140246338971271);
-Obj x140246338971367 = PRIM_EQ(Nil, x140246338971303);
-if (True == x140246338971367) {
+Obj x140166664131271 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664134343 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664134343) {
+Obj x140166664114599 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664114631 = PRIM_EQ(symnull_63, x140166664114599);
+if (True == x140166664114631) {
+Obj x140166664115335 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664115367 = PRIM_ISCONS(x140166664115335);
+if (True == x140166664115367) {
+Obj x140166664116327 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664116359 = PRIM_CAR(x140166664116327);
+Obj x140166664116391 = PRIM_EQ(Nil, x140166664116359);
+if (True == x140166664116391) {
+Obj x140166664117255 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664117287 = PRIM_CDR(x140166664117255);
+Obj x140166664117319 = PRIM_EQ(Nil, x140166664117287);
+if (True == x140166664117319) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4772,7 +4717,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338973319;
+__arg0 = x140166664131271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4781,7 +4726,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973319;
+__arg0 = x140166664131271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4790,7 +4735,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973319;
+__arg0 = x140166664131271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4799,7 +4744,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973319;
+__arg0 = x140166664131271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4808,7 +4753,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338973319;
+__arg0 = x140166664131271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4819,57 +4764,57 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140246338949191 = makeNative(31, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339712103 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339712103) {
-Obj x140246339712583 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339712615 = PRIM_EQ(symnull_63, x140246339712583);
-if (True == x140246339712615) {
-Obj x140246339713255 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339713351 = PRIM_ISCONS(x140246339713255);
-if (True == x140246339713351) {
-Obj x140246339713991 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339714023 = PRIM_CAR(x140246339713991);
-Obj x140246339714055 = PRIM_ISCONS(x140246339714023);
-if (True == x140246339714055) {
-Obj x140246339620967 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339620999 = PRIM_CAR(x140246339620967);
-Obj x140246339621031 = PRIM_CAR(x140246339620999);
-Obj x140246339621063 = PRIM_EQ(symcons, x140246339621031);
-if (True == x140246339621063) {
-Obj x140246339621927 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339621959 = PRIM_CAR(x140246339621927);
-Obj x140246339621991 = PRIM_CDR(x140246339621959);
-Obj x140246339622023 = PRIM_ISCONS(x140246339621991);
-if (True == x140246339622023) {
-Obj x140246339623175 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339623207 = PRIM_CAR(x140246339623175);
-Obj x140246339623239 = PRIM_CDR(x140246339623207);
-Obj x140246339623303 = PRIM_CAR(x140246339623239);
-Obj __ = x140246339623303;
-Obj x140246339624583 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339624615 = PRIM_CAR(x140246339624583);
-Obj x140246339624647 = PRIM_CDR(x140246339624615);
-Obj x140246339624679 = PRIM_CDR(x140246339624647);
-Obj x140246339624711 = PRIM_ISCONS(x140246339624679);
-if (True == x140246339624711) {
-Obj x140246339372039 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339372071 = PRIM_CAR(x140246339372039);
-Obj x140246339372103 = PRIM_CDR(x140246339372071);
-Obj x140246339372135 = PRIM_CDR(x140246339372103);
-Obj x140246339372199 = PRIM_CAR(x140246339372135);
-__ = x140246339372199;
-Obj x140246339373671 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339373703 = PRIM_CAR(x140246339373671);
-Obj x140246339373735 = PRIM_CDR(x140246339373703);
-Obj x140246339373831 = PRIM_CDR(x140246339373735);
-Obj x140246339373863 = PRIM_CDR(x140246339373831);
-Obj x140246339374055 = PRIM_EQ(Nil, x140246339373863);
-if (True == x140246339374055) {
-Obj x140246339375079 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339317767 = PRIM_CDR(x140246339375079);
-Obj x140246339317799 = PRIM_EQ(Nil, x140246339317767);
-if (True == x140246339317799) {
+Obj x140166664131719 = makeNative(31, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664693095 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664693095) {
+Obj x140166664693575 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664693607 = PRIM_EQ(symnull_63, x140166664693575);
+if (True == x140166664693607) {
+Obj x140166664694279 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664694439 = PRIM_ISCONS(x140166664694279);
+if (True == x140166664694439) {
+Obj x140166664695143 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664695175 = PRIM_CAR(x140166664695143);
+Obj x140166664695207 = PRIM_ISCONS(x140166664695175);
+if (True == x140166664695207) {
+Obj x140166664470951 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664470983 = PRIM_CAR(x140166664470951);
+Obj x140166664471015 = PRIM_CAR(x140166664470983);
+Obj x140166664471047 = PRIM_EQ(symcons, x140166664471015);
+if (True == x140166664471047) {
+Obj x140166664472007 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664472039 = PRIM_CAR(x140166664472007);
+Obj x140166664472071 = PRIM_CDR(x140166664472039);
+Obj x140166664472103 = PRIM_ISCONS(x140166664472071);
+if (True == x140166664472103) {
+Obj x140166664473127 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664473159 = PRIM_CAR(x140166664473127);
+Obj x140166664473191 = PRIM_CDR(x140166664473159);
+Obj x140166664473223 = PRIM_CAR(x140166664473191);
+Obj __ = x140166664473223;
+Obj x140166664474311 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664474343 = PRIM_CAR(x140166664474311);
+Obj x140166664474375 = PRIM_CDR(x140166664474343);
+Obj x140166664474407 = PRIM_CDR(x140166664474375);
+Obj x140166664474439 = PRIM_ISCONS(x140166664474407);
+if (True == x140166664474439) {
+Obj x140166664291815 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664291847 = PRIM_CAR(x140166664291815);
+Obj x140166664291879 = PRIM_CDR(x140166664291847);
+Obj x140166664291911 = PRIM_CDR(x140166664291879);
+Obj x140166664291943 = PRIM_CAR(x140166664291911);
+__ = x140166664291943;
+Obj x140166664293831 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664293863 = PRIM_CAR(x140166664293831);
+Obj x140166664293895 = PRIM_CDR(x140166664293863);
+Obj x140166664293927 = PRIM_CDR(x140166664293895);
+Obj x140166664293959 = PRIM_CDR(x140166664293927);
+Obj x140166664293991 = PRIM_EQ(Nil, x140166664293959);
+if (True == x140166664293991) {
+Obj x140166664131655 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664131687 = PRIM_CDR(x140166664131655);
+Obj x140166664131783 = PRIM_EQ(Nil, x140166664131687);
+if (True == x140166664131783) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4877,7 +4822,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4886,7 +4831,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4895,7 +4840,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4904,7 +4849,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4913,7 +4858,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4922,7 +4867,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4931,7 +4876,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4940,7 +4885,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4949,7 +4894,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949191;
+__arg0 = x140166664131719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4960,23 +4905,23 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140246338949991 = makeNative(32, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246339748871 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339748871) {
-Obj x140246339749319 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339749351 = PRIM_EQ(symnot, x140246339749319);
-if (True == x140246339749351) {
-Obj x140246339750055 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339750087 = PRIM_ISCONS(x140246339750055);
-if (True == x140246339750087) {
-Obj x140246339750855 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339750887 = PRIM_CAR(x140246339750855);
-Obj x140246339750919 = PRIM_EQ(True, x140246339750887);
-if (True == x140246339750919) {
-Obj x140246339751719 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339751751 = PRIM_CDR(x140246339751719);
-Obj x140246339751783 = PRIM_EQ(Nil, x140246339751751);
-if (True == x140246339751783) {
+Obj x140166664132519 = makeNative(32, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166664832231 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664832231) {
+Obj x140166664832743 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664832775 = PRIM_EQ(symnot, x140166664832743);
+if (True == x140166664832775) {
+Obj x140166664833511 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664833543 = PRIM_ISCONS(x140166664833511);
+if (True == x140166664833543) {
+Obj x140166664834375 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664834407 = PRIM_CAR(x140166664834375);
+Obj x140166664834439 = PRIM_EQ(True, x140166664834407);
+if (True == x140166664834439) {
+Obj x140166664691847 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664691879 = PRIM_CDR(x140166664691847);
+Obj x140166664691911 = PRIM_EQ(Nil, x140166664691879);
+if (True == x140166664691911) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4984,7 +4929,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338949991;
+__arg0 = x140166664132519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4993,7 +4938,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949991;
+__arg0 = x140166664132519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5002,7 +4947,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949991;
+__arg0 = x140166664132519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5011,7 +4956,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949991;
+__arg0 = x140166664132519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5020,7 +4965,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338949991;
+__arg0 = x140166664132519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5031,23 +4976,23 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140246338950439 = makeNative(33, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338205063 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338205063) {
-Obj x140246338205511 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338205543 = PRIM_EQ(symnot, x140246338205511);
-if (True == x140246338205543) {
-Obj x140246338205959 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338205991 = PRIM_ISCONS(x140246338205959);
-if (True == x140246338205991) {
-Obj x140246338206599 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338206631 = PRIM_CAR(x140246338206599);
-Obj x140246338206663 = PRIM_EQ(False, x140246338206631);
-if (True == x140246338206663) {
-Obj x140246338207271 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338207303 = PRIM_CDR(x140246338207271);
-Obj x140246338207335 = PRIM_EQ(Nil, x140246338207303);
-if (True == x140246338207335) {
+Obj x140166664132967 = makeNative(33, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166665045063 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665045063) {
+Obj x140166665045767 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665045799 = PRIM_EQ(symnot, x140166665045767);
+if (True == x140166665045799) {
+Obj x140166665046471 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665046503 = PRIM_ISCONS(x140166665046471);
+if (True == x140166665046503) {
+Obj x140166665047303 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665047335 = PRIM_CAR(x140166665047303);
+Obj x140166665047367 = PRIM_EQ(False, x140166665047335);
+if (True == x140166665047367) {
+Obj x140166664831047 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664831111 = PRIM_CDR(x140166664831047);
+Obj x140166664831143 = PRIM_EQ(Nil, x140166664831111);
+if (True == x140166664831143) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5055,7 +5000,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338950439;
+__arg0 = x140166664132967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5064,7 +5009,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950439;
+__arg0 = x140166664132967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5073,7 +5018,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950439;
+__arg0 = x140166664132967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5082,7 +5027,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950439;
+__arg0 = x140166664132967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5091,7 +5036,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950439;
+__arg0 = x140166664132967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5102,43 +5047,43 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140246338950887 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338251559 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338251559) {
-Obj x140246338252007 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338252039 = PRIM_EQ(symif, x140246338252007);
-if (True == x140246338252039) {
-Obj x140246338252455 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338252487 = PRIM_ISCONS(x140246338252455);
-if (True == x140246338252487) {
-Obj x140246338228519 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338228551 = PRIM_CAR(x140246338228519);
-Obj x140246338228583 = PRIM_EQ(True, x140246338228551);
-if (True == x140246338228583) {
-Obj x140246338229159 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338229191 = PRIM_CDR(x140246338229159);
-Obj x140246338229223 = PRIM_ISCONS(x140246338229191);
-if (True == x140246338229223) {
-Obj x140246338229799 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338229831 = PRIM_CDR(x140246338229799);
-Obj x140246338229863 = PRIM_CAR(x140246338229831);
-Obj y = x140246338229863;
-Obj x140246338230599 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338230631 = PRIM_CDR(x140246338230599);
-Obj x140246338230663 = PRIM_CDR(x140246338230631);
-Obj x140246338230695 = PRIM_ISCONS(x140246338230663);
-if (True == x140246338230695) {
-Obj x140246338231431 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338231463 = PRIM_CDR(x140246338231431);
-Obj x140246338231495 = PRIM_CDR(x140246338231463);
-Obj x140246338231527 = PRIM_CAR(x140246338231495);
-Obj z = x140246338231527;
-Obj x140246338203783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338203815 = PRIM_CDR(x140246338203783);
-Obj x140246338203847 = PRIM_CDR(x140246338203815);
-Obj x140246338203879 = PRIM_CDR(x140246338203847);
-Obj x140246338203911 = PRIM_EQ(Nil, x140246338203879);
-if (True == x140246338203911) {
+Obj x140166664133415 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166665228935 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166665228935) {
+Obj x140166665229479 = PRIM_CAR(closureRef(co, 0));
+Obj x140166665229511 = PRIM_EQ(symif, x140166665229479);
+if (True == x140166665229511) {
+Obj x140166665230023 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665230055 = PRIM_ISCONS(x140166665230023);
+if (True == x140166665230055) {
+Obj x140166665230919 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665231047 = PRIM_CAR(x140166665230919);
+Obj x140166665231079 = PRIM_EQ(True, x140166665231047);
+if (True == x140166665231079) {
+Obj x140166665231751 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665231783 = PRIM_CDR(x140166665231751);
+Obj x140166665231815 = PRIM_ISCONS(x140166665231783);
+if (True == x140166665231815) {
+Obj x140166665162919 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665162951 = PRIM_CDR(x140166665162919);
+Obj x140166665162983 = PRIM_CAR(x140166665162951);
+Obj y = x140166665162983;
+Obj x140166665163815 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665163847 = PRIM_CDR(x140166665163815);
+Obj x140166665163879 = PRIM_CDR(x140166665163847);
+Obj x140166665163911 = PRIM_ISCONS(x140166665163879);
+if (True == x140166665163911) {
+Obj x140166665164999 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665165127 = PRIM_CDR(x140166665164999);
+Obj x140166665165287 = PRIM_CDR(x140166665165127);
+Obj x140166665165319 = PRIM_CAR(x140166665165287);
+Obj z = x140166665165319;
+Obj x140166665166439 = PRIM_CDR(closureRef(co, 0));
+Obj x140166665166471 = PRIM_CDR(x140166665166439);
+Obj x140166665166503 = PRIM_CDR(x140166665166471);
+Obj x140166665166535 = PRIM_CDR(x140166665166503);
+Obj x140166665166567 = PRIM_EQ(Nil, x140166665166535);
+if (True == x140166665166567) {
 __nargs = 2;
 __arg1 = y;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5146,7 +5091,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5155,7 +5100,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5164,7 +5109,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5173,7 +5118,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5182,7 +5127,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5191,7 +5136,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5200,7 +5145,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338950887;
+__arg0 = x140166664133415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5211,43 +5156,43 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x140246338951591 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
-Obj x140246338451783 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338451783) {
-Obj x140246338452263 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338452295 = PRIM_EQ(symif, x140246338452263);
-if (True == x140246338452295) {
-Obj x140246338452807 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338452839 = PRIM_ISCONS(x140246338452807);
-if (True == x140246338452839) {
-Obj x140246338453447 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338453479 = PRIM_CAR(x140246338453447);
-Obj x140246338351111 = PRIM_EQ(False, x140246338453479);
-if (True == x140246338351111) {
-Obj x140246338351911 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338351943 = PRIM_CDR(x140246338351911);
-Obj x140246338351975 = PRIM_ISCONS(x140246338351943);
-if (True == x140246338351975) {
-Obj x140246338352647 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338352679 = PRIM_CDR(x140246338352647);
-Obj x140246338352711 = PRIM_CAR(x140246338352679);
-Obj y = x140246338352711;
-Obj x140246338353511 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338353543 = PRIM_CDR(x140246338353511);
-Obj x140246338353575 = PRIM_CDR(x140246338353543);
-Obj x140246338353607 = PRIM_ISCONS(x140246338353575);
-if (True == x140246338353607) {
-Obj x140246338354439 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338354471 = PRIM_CDR(x140246338354439);
-Obj x140246338354503 = PRIM_CDR(x140246338354471);
-Obj x140246338354535 = PRIM_CAR(x140246338354503);
-Obj z = x140246338354535;
-Obj x140246338249191 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338249223 = PRIM_CDR(x140246338249191);
-Obj x140246338249255 = PRIM_CDR(x140246338249223);
-Obj x140246338249287 = PRIM_CDR(x140246338249255);
-Obj x140246338249351 = PRIM_EQ(Nil, x140246338249287);
-if (True == x140246338249351) {
+Obj x140166664134119 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
+Obj x140166663563111 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166663563111) {
+Obj x140166663563559 = PRIM_CAR(closureRef(co, 0));
+Obj x140166663563591 = PRIM_EQ(symif, x140166663563559);
+if (True == x140166663563591) {
+Obj x140166663564007 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663564039 = PRIM_ISCONS(x140166663564007);
+if (True == x140166663564039) {
+Obj x140166663564647 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663564679 = PRIM_CAR(x140166663564647);
+Obj x140166663564711 = PRIM_EQ(False, x140166663564679);
+if (True == x140166663564711) {
+Obj x140166663565287 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663557127 = PRIM_CDR(x140166663565287);
+Obj x140166663557159 = PRIM_ISCONS(x140166663557127);
+if (True == x140166663557159) {
+Obj x140166663557735 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663557767 = PRIM_CDR(x140166663557735);
+Obj x140166663557799 = PRIM_CAR(x140166663557767);
+Obj y = x140166663557799;
+Obj x140166663558535 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663558567 = PRIM_CDR(x140166663558535);
+Obj x140166663558599 = PRIM_CDR(x140166663558567);
+Obj x140166663558631 = PRIM_ISCONS(x140166663558599);
+if (True == x140166663558631) {
+Obj x140166663559367 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663559399 = PRIM_CDR(x140166663559367);
+Obj x140166663559431 = PRIM_CDR(x140166663559399);
+Obj x140166663559463 = PRIM_CAR(x140166663559431);
+Obj z = x140166663559463;
+Obj x140166663560391 = PRIM_CDR(closureRef(co, 0));
+Obj x140166663560423 = PRIM_CDR(x140166663560391);
+Obj x140166663560455 = PRIM_CDR(x140166663560423);
+Obj x140166663560487 = PRIM_CDR(x140166663560455);
+Obj x140166663560519 = PRIM_EQ(Nil, x140166663560487);
+if (True == x140166663560519) {
 __nargs = 2;
 __arg1 = z;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5255,7 +5200,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5264,7 +5209,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5273,7 +5218,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5282,7 +5227,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5291,7 +5236,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5300,7 +5245,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5309,7 +5254,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338951591;
+__arg0 = x140166664134119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5320,7 +5265,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140246338952295 = makeNative(36, clofun2, 0, 0);
+Obj x140166664114343 = makeNative(36, clofun2, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -5357,12 +5302,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140246338495623 = __arg1;
+Obj x140166663573607 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 39, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = x140246338495623;
+__arg1 = x140166663573607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5372,9 +5317,9 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140246338495655 = __arg1;
+Obj x140166663573639 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = x140246338495655;
+Obj body = x140166663573639;
 pushCont(co, 40, clofun2, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rules_45arg_45count);
@@ -5388,10 +5333,10 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140246338495943 = __arg1;
+Obj x140166663573895 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = x140246338495943;
+Obj nargs = x140166663573895;
 pushCont(co, 41, clofun2, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
@@ -5405,10 +5350,10 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140246338496231 = __arg1;
+Obj x140166663574183 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = x140246338496231;
+Obj args = x140166663574183;
 pushCont(co, 42, clofun2, 2, body, args);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -5422,18 +5367,18 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140246338496935 = __arg1;
+Obj x140166663574759 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338498119 = makeCons(symlist, args);
-Obj x140246338498183 = makeCons(x140246338498119, body);
-Obj x140246338498215 = makeCons(symmatch, x140246338498183);
-Obj x140246338498279 = makeCons(x140246338498215, Nil);
-Obj x140246338498311 = makeCons(args, x140246338498279);
-Obj x140246338498343 = makeCons(x140246338496935, x140246338498311);
-Obj x140246338498375 = makeCons(symdefun, x140246338498343);
+Obj x140166663576999 = makeCons(symlist, args);
+Obj x140166663577063 = makeCons(x140166663576999, body);
+Obj x140166663577095 = makeCons(symmatch, x140166663577063);
+Obj x140166663577159 = makeCons(x140166663577095, Nil);
+Obj x140166663577191 = makeCons(args, x140166663577159);
+Obj x140166663577223 = makeCons(x140166663574759, x140166663577191);
+Obj x140166663577255 = makeCons(symdefun, x140166663577223);
 __nargs = 2;
-__arg1 = x140246338498375;
+__arg1 = x140166663577255;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5442,20 +5387,20 @@ goto *jumpTable[co->ctx.pc.label];
 label43:
 {
 Obj n = __arg1;
-Obj x140246338555239 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == x140246338555239) {
+Obj x140166663760167 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == x140166663760167) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338555591 = primGenSym();
-Obj x140246338494599 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 44, clofun2, 1, x140246338555591);
+Obj x140166663760551 = primGenSym();
+Obj x140166663760999 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 44, clofun2, 1, x140166663760551);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = x140246338494599;
+__arg1 = x140166663760999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5466,11 +5411,11 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140246338494631 = __arg1;
-Obj x140246338555591= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338494663 = makeCons(x140246338555591, x140246338494631);
+Obj x140166663761031 = __arg1;
+Obj x140166663760551= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166663761063 = makeCons(x140166663760551, x140166663761031);
 __nargs = 2;
-__arg1 = x140246338494663;
+__arg1 = x140166663761063;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5493,8 +5438,8 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140246338603911 = __arg1;
-Obj pats = x140246338603911;
+Obj x140166663928487 = __arg1;
+Obj pats = x140166663928487;
 Obj len = makeNative(1, clofun3, 1, 0);
 PUSH_CONT_0(co, 47, clofun2);
 __nargs = 3;
@@ -5510,17 +5455,17 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x140246338552487 = __arg1;
-Obj counts = x140246338552487;
-Obj x140246338552743 = PRIM_CAR(counts);
-Obj n = x140246338552743;
+Obj x140166663929351 = __arg1;
+Obj counts = x140166663929351;
+Obj x140166663929767 = PRIM_CAR(counts);
+Obj n = x140166663929767;
 Obj dif = makeNative(0, clofun3, 1, 1, n);
-Obj x140246338554247 = PRIM_CDR(counts);
+Obj x140166663759175 = PRIM_CDR(counts);
 pushCont(co, 48, clofun2, 1, n);
 __nargs = 3;
 __arg0 = globalRef(symfilter);
 __arg1 = dif;
-__arg2 = x140246338554247;
+__arg2 = x140166663759175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5530,12 +5475,12 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x140246338554279 = __arg1;
+Obj x140166663759207 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun2, 1, n);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140246338554279;
+__arg1 = x140166663759207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5545,10 +5490,10 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140246338554343 = __arg1;
+Obj x140166663759239 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338554375 = primNot(x140246338554343);
-if (True == x140246338554375) {
+Obj x140166663759271 = primNot(x140166663759239);
+if (True == x140166663759271) {
 __nargs = 2;
 __arg0 = globalRef(symerror);
 __arg1 = makeCString("inconsistent func rule args count");
@@ -5589,10 +5534,10 @@ goto *jumpTable[co->ctx.pc.label];
 label0:
 {
 Obj x = __arg1;
-Obj x140246338553351 = PRIM_EQ(closureRef(co, 0), x);
-Obj x140246338553383 = primNot(x140246338553351);
+Obj x140166663758311 = PRIM_EQ(closureRef(co, 0), x);
+Obj x140166663758343 = primNot(x140166663758311);
 __nargs = 2;
-__arg1 = x140246338553383;
+__arg1 = x140166663758343;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5601,10 +5546,10 @@ goto *jumpTable[co->ctx.pc.label];
 label1:
 {
 Obj x = __arg1;
-Obj x140246338551847 = PRIM_CDR(x);
+Obj x140166663929063 = PRIM_CDR(x);
 __nargs = 2;
 __arg0 = globalRef(symlength);
-__arg1 = x140246338551847;
+__arg1 = x140166663929063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5616,20 +5561,20 @@ label2:
 {
 Obj l1 = __arg1;
 Obj l2 = __arg2;
-Obj x140246338601703 = PRIM_EQ(l1, Nil);
-if (True == x140246338601703) {
+Obj x140166663926791 = PRIM_EQ(l1, Nil);
+if (True == x140166663926791) {
 __nargs = 2;
 __arg1 = l2;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338602407 = PRIM_CAR(l1);
-Obj x140246338602791 = PRIM_CDR(l1);
-pushCont(co, 3, clofun3, 1, x140246338602407);
+Obj x140166663927271 = PRIM_CAR(l1);
+Obj x140166663927687 = PRIM_CDR(l1);
+pushCont(co, 3, clofun3, 1, x140166663927271);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = x140246338602791;
+__arg1 = x140166663927687;
 __arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5641,11 +5586,11 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140246338602855 = __arg1;
-Obj x140246338602407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338602919 = makeCons(x140246338602407, x140246338602855);
+Obj x140166663927815 = __arg1;
+Obj x140166663927271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166663927847 = makeCons(x140166663927271, x140166663927815);
 __nargs = 2;
-__arg1 = x140246338602919;
+__arg1 = x140166663927847;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5672,13 +5617,13 @@ label5:
 Obj res = __arg1;
 Obj fn = __arg2;
 Obj l = __arg3;
-Obj x140246338626247 = PRIM_ISCONS(l);
-if (True == x140246338626247) {
-Obj x140246338626855 = PRIM_CAR(l);
+Obj x140166663951975 = PRIM_ISCONS(l);
+if (True == x140166663951975) {
+Obj x140166663952455 = PRIM_CAR(l);
 pushCont(co, 6, clofun3, 3, l, res, fn);
 __nargs = 2;
 __arg0 = fn;
-__arg1 = x140246338626855;
+__arg1 = x140166663952455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5698,31 +5643,31 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140246338626887 = __arg1;
+Obj x140166663952519 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140246338626887) {
-Obj x140246338627847 = PRIM_CAR(l);
-Obj x140246338627911 = makeCons(x140246338627847, res);
-Obj x140246338628231 = PRIM_CDR(l);
+if (True == x140166663952519) {
+Obj x140166663953063 = PRIM_CAR(l);
+Obj x140166663953127 = makeCons(x140166663953063, res);
+Obj x140166663953383 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = x140246338627911;
+__arg1 = x140166663953127;
 __arg2 = fn;
-__arg3 = x140246338628231;
+__arg3 = x140166663953383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338628647 = PRIM_CDR(l);
+Obj x140166663953895 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
 __arg1 = res;
 __arg2 = fn;
-__arg3 = x140246338628647;
+__arg3 = x140166663953895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5749,20 +5694,20 @@ label8:
 {
 Obj i = __arg1;
 Obj l = __arg2;
-Obj x140246338702023 = PRIM_EQ(l, Nil);
-if (True == x140246338702023) {
+Obj x140166664076007 = PRIM_EQ(l, Nil);
+if (True == x140166664076007) {
 __nargs = 2;
 __arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338702471 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj x140246338702823 = PRIM_CDR(l);
+Obj x140166664076487 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x140166664076711 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = x140246338702471;
-__arg2 = x140246338702823;
+__arg1 = x140166664076487;
+__arg2 = x140166664076711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5788,10 +5733,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140246338699751 = __arg1;
+Obj x140166664073927 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246338699751) {
+if (True == x140166664073927) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = res;
@@ -5801,9 +5746,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338700647 = PRIM_CAR(rules);
-Obj x140246338700743 = makeCons(x140246338700647, res);
-pushCont(co, 11, clofun3, 1, x140246338700743);
+Obj x140166664074727 = PRIM_CAR(rules);
+Obj x140166664074823 = makeCons(x140166664074727, res);
+pushCont(co, 11, clofun3, 1, x140166664074823);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = rules;
@@ -5817,12 +5762,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246338700967 = __arg1;
-Obj x140246338700743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664075143 = __arg1;
+Obj x140166664074823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = x140246338700743;
-__arg2 = x140246338700967;
+__arg1 = x140166664074823;
+__arg2 = x140166664075143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5850,9 +5795,9 @@ label13:
 Obj input = __arg1;
 Obj current = __arg2;
 Obj result = __arg3;
-Obj x140246338969735 = makeNative(14, clofun3, 0, 3, input, current, result);
-Obj x140246338824903 = PRIM_EQ(Nil, input);
-if (True == x140246338824903) {
+Obj x140166664290439 = makeNative(14, clofun3, 0, 3, input, current, result);
+Obj x140166664084487 = PRIM_EQ(Nil, input);
+if (True == x140166664084487) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = result;
@@ -5863,7 +5808,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338969735;
+__arg0 = x140166664290439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5874,42 +5819,42 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140246338969831 = makeNative(16, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140246339320135 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339320135) {
-Obj x140246339320711 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339320743 = PRIM_EQ(sym_61_62, x140246339320711);
-if (True == x140246339320743) {
-Obj x140246339321255 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339321287 = PRIM_ISCONS(x140246339321255);
-if (True == x140246339321287) {
-Obj x140246339321799 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339321831 = PRIM_CAR(x140246339321799);
-Obj act = x140246339321831;
-Obj x140246338970823 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338970919 = PRIM_CDR(x140246338970823);
-Obj x140246338970951 = PRIM_ISCONS(x140246338970919);
-if (True == x140246338970951) {
-Obj x140246338972199 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338972231 = PRIM_CDR(x140246338972199);
-Obj x140246338972295 = PRIM_CAR(x140246338972231);
-Obj x140246338972359 = PRIM_EQ(symwhere, x140246338972295);
-if (True == x140246338972359) {
-Obj x140246338973479 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338973543 = PRIM_CDR(x140246338973479);
-Obj x140246338949319 = PRIM_CDR(x140246338973543);
-Obj x140246338949351 = PRIM_ISCONS(x140246338949319);
-if (True == x140246338949351) {
-Obj x140246338950503 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338950567 = PRIM_CDR(x140246338950503);
-Obj x140246338950631 = PRIM_CDR(x140246338950567);
-Obj x140246338950695 = PRIM_CAR(x140246338950631);
-Obj pred = x140246338950695;
-Obj x140246338951783 = PRIM_CDR(closureRef(co, 0));
-Obj x140246338951815 = PRIM_CDR(x140246338951783);
-Obj x140246338951847 = PRIM_CDR(x140246338951815);
-Obj x140246338951943 = PRIM_CDR(x140246338951847);
-Obj remain = x140246338951943;
+Obj x140166664290535 = makeNative(16, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140166664114567 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664114567) {
+Obj x140166664115047 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664115111 = PRIM_EQ(sym_61_62, x140166664115047);
+if (True == x140166664115111) {
+Obj x140166664115783 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664115815 = PRIM_ISCONS(x140166664115783);
+if (True == x140166664115815) {
+Obj x140166664116455 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664116487 = PRIM_CAR(x140166664116455);
+Obj act = x140166664116487;
+Obj x140166664117127 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664117159 = PRIM_CDR(x140166664117127);
+Obj x140166664117191 = PRIM_ISCONS(x140166664117159);
+if (True == x140166664117191) {
+Obj x140166664085511 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664085543 = PRIM_CDR(x140166664085511);
+Obj x140166664085575 = PRIM_CAR(x140166664085543);
+Obj x140166664085607 = PRIM_EQ(symwhere, x140166664085575);
+if (True == x140166664085607) {
+Obj x140166664086503 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664086567 = PRIM_CDR(x140166664086503);
+Obj x140166664086599 = PRIM_CDR(x140166664086567);
+Obj x140166664086663 = PRIM_ISCONS(x140166664086599);
+if (True == x140166664086663) {
+Obj x140166664087687 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664087911 = PRIM_CDR(x140166664087687);
+Obj x140166664087943 = PRIM_CDR(x140166664087911);
+Obj x140166664087975 = PRIM_CAR(x140166664087943);
+Obj pred = x140166664087975;
+Obj x140166664088807 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664088839 = PRIM_CDR(x140166664088807);
+Obj x140166664088871 = PRIM_CDR(x140166664088839);
+Obj x140166664088903 = PRIM_CDR(x140166664088871);
+Obj remain = x140166664088903;
 pushCont(co, 15, clofun3, 3, act, pred, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -5921,7 +5866,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5930,7 +5875,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5939,7 +5884,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5948,7 +5893,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5957,7 +5902,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5966,7 +5911,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338969831;
+__arg0 = x140166664290535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5977,22 +5922,22 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140246338952583 = __arg1;
+Obj x140166664089511 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246338952615 = makeCons(symlist, x140246338952583);
-Obj pat = x140246338952615;
-Obj x140246338822983 = makeCons(act, Nil);
-Obj x140246338823015 = makeCons(pred, x140246338822983);
-Obj x140246338823079 = makeCons(symwhere, x140246338823015);
-Obj x140246338823335 = makeCons(pat, closureRef(co, 2));
-Obj x140246338823367 = makeCons(x140246338823079, x140246338823335);
+Obj x140166664089543 = makeCons(symlist, x140166664089511);
+Obj pat = x140166664089543;
+Obj x140166664082503 = makeCons(act, Nil);
+Obj x140166664082535 = makeCons(pred, x140166664082503);
+Obj x140166664082567 = makeCons(symwhere, x140166664082535);
+Obj x140166664082951 = makeCons(pat, closureRef(co, 2));
+Obj x140166664082983 = makeCons(x140166664082567, x140166664082951);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x140246338823367;
+__arg3 = x140166664082983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6002,21 +5947,21 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140246338970375 = makeNative(18, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140246339372647 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339372647) {
-Obj x140246339373287 = PRIM_CAR(closureRef(co, 0));
-Obj x140246339373319 = PRIM_EQ(sym_61_62, x140246339373287);
-if (True == x140246339373319) {
-Obj x140246339373767 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339373799 = PRIM_ISCONS(x140246339373767);
-if (True == x140246339373799) {
-Obj x140246339374407 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339374439 = PRIM_CAR(x140246339374407);
-Obj act = x140246339374439;
-Obj x140246339317831 = PRIM_CDR(closureRef(co, 0));
-Obj x140246339317863 = PRIM_CDR(x140246339317831);
-Obj remain = x140246339317863;
+Obj x140166664291079 = makeNative(18, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140166664292871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664292871) {
+Obj x140166664293543 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664293671 = PRIM_EQ(sym_61_62, x140166664293543);
+if (True == x140166664293671) {
+Obj x140166664294279 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664130567 = PRIM_ISCONS(x140166664294279);
+if (True == x140166664130567) {
+Obj x140166664131367 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664131399 = PRIM_CAR(x140166664131367);
+Obj act = x140166664131399;
+Obj x140166664132071 = PRIM_CDR(closureRef(co, 0));
+Obj x140166664132103 = PRIM_CDR(x140166664132071);
+Obj remain = x140166664132103;
 pushCont(co, 17, clofun3, 2, act, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -6028,7 +5973,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970375;
+__arg0 = x140166664291079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6037,7 +5982,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970375;
+__arg0 = x140166664291079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6046,7 +5991,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140246338970375;
+__arg0 = x140166664291079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6057,18 +6002,18 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140246339318407 = __arg1;
+Obj x140166664132775 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339318439 = makeCons(symlist, x140246339318407);
-Obj pat = x140246339318439;
-Obj x140246339319143 = makeCons(pat, closureRef(co, 2));
-Obj x140246339319175 = makeCons(act, x140246339319143);
+Obj x140166664132807 = makeCons(symlist, x140166664132775);
+Obj pat = x140166664132807;
+Obj x140166664133991 = makeCons(pat, closureRef(co, 2));
+Obj x140166664134023 = makeCons(act, x140166664133991);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x140246339319175;
+__arg3 = x140166664134023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6078,18 +6023,18 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140246338970695 = makeNative(19, clofun3, 0, 0);
-Obj x140246339624903 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246339624903) {
-Obj x140246339371367 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140246339371367;
-Obj x140246339371623 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140246339371623;
-Obj x140246339372167 = makeCons(x, closureRef(co, 1));
+Obj x140166664291399 = makeNative(19, clofun3, 0, 0);
+Obj x140166664290695 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664290695) {
+Obj x140166664291175 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140166664291175;
+Obj x140166664291719 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140166664291719;
+Obj x140166664292327 = makeCons(x, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = y;
-__arg2 = x140246339372167;
+__arg2 = x140166664292327;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6098,7 +6043,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140246338970695;
+__arg0 = x140166664291399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6148,12 +6093,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140246339750983 = __arg1;
+Obj x140166664834695 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 23, clofun3, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
-__arg1 = x140246339750983;
+__arg1 = x140166664834695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6163,9 +6108,9 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140246339751047 = __arg1;
+Obj x140166664834727 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = x140246339751047;
+Obj value = x140166664834727;
 pushCont(co, 24, clofun3, 1, value);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -6179,18 +6124,18 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140246339751303 = __arg1;
+Obj x140166664835047 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = x140246339751303;
-Obj x140246339751655 = PRIM_ISCONS(value);
-if (True == x140246339751655) {
-Obj x140246339711335 = PRIM_CAR(value);
-Obj x140246339711367 = PRIM_EQ(symcons, x140246339711335);
-Obj x140246339711399 = primNot(x140246339711367);
-if (True == x140246339711399) {
+Obj rules = x140166664835047;
+Obj x140166664692071 = PRIM_ISCONS(value);
+if (True == x140166664692071) {
+Obj x140166664692711 = PRIM_CAR(value);
+Obj x140166664692743 = PRIM_EQ(symcons, x140166664692711);
+Obj x140166664692775 = primNot(x140166664692743);
+if (True == x140166664692775) {
 if (True == True) {
-Obj x140246339711847 = primGenSym();
-Obj val = x140246339711847;
+Obj x140166664693031 = primGenSym();
+Obj val = x140166664693031;
 pushCont(co, 27, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6214,8 +6159,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140246339713543 = primGenSym();
-Obj val = x140246339713543;
+Obj x140166664694855 = primGenSym();
+Obj val = x140166664694855;
 pushCont(co, 26, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6240,8 +6185,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140246339621095 = primGenSym();
-Obj val = x140246339621095;
+Obj x140166664471303 = primGenSym();
+Obj val = x140166664471303;
 pushCont(co, 25, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6268,15 +6213,15 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140246339622151 = __arg1;
+Obj x140166664472487 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339622215 = makeCons(x140246339622151, Nil);
-Obj x140246339622279 = makeCons(value, x140246339622215);
-Obj x140246339622343 = makeCons(val, x140246339622279);
-Obj x140246339622375 = makeCons(symlet, x140246339622343);
+Obj x140166664472551 = makeCons(x140166664472487, Nil);
+Obj x140166664472583 = makeCons(value, x140166664472551);
+Obj x140166664472615 = makeCons(val, x140166664472583);
+Obj x140166664472647 = makeCons(symlet, x140166664472615);
 __nargs = 2;
-__arg1 = x140246339622375;
+__arg1 = x140166664472647;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6284,15 +6229,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label26:
 {
-Obj x140246339714567 = __arg1;
+Obj x140166664470695 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339714791 = makeCons(x140246339714567, Nil);
-Obj x140246339714823 = makeCons(value, x140246339714791);
-Obj x140246339714855 = makeCons(val, x140246339714823);
-Obj x140246339714887 = makeCons(symlet, x140246339714855);
+Obj x140166664470759 = makeCons(x140166664470695, Nil);
+Obj x140166664470791 = makeCons(value, x140166664470759);
+Obj x140166664470823 = makeCons(val, x140166664470791);
+Obj x140166664470855 = makeCons(symlet, x140166664470823);
 __nargs = 2;
-__arg1 = x140246339714887;
+__arg1 = x140166664470855;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6300,15 +6245,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x140246339712903 = __arg1;
+Obj x140166664694247 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339712967 = makeCons(x140246339712903, Nil);
-Obj x140246339712999 = makeCons(value, x140246339712967);
-Obj x140246339713031 = makeCons(val, x140246339712999);
-Obj x140246339713063 = makeCons(symlet, x140246339713031);
+Obj x140166664694311 = makeCons(x140166664694247, Nil);
+Obj x140166664694343 = makeCons(value, x140166664694311);
+Obj x140166664694375 = makeCons(val, x140166664694343);
+Obj x140166664694407 = makeCons(symlet, x140166664694375);
 __nargs = 2;
-__arg1 = x140246339713063;
+__arg1 = x140166664694407;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6331,14 +6276,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140246338498471 = __arg1;
+Obj x140166665229255 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246338498471) {
-Obj x140246338449735 = makeCons(makeCString("no match-help found!"), Nil);
-Obj x140246338449767 = makeCons(symerror, x140246338449735);
+if (True == x140166665229255) {
+Obj x140166665229703 = makeCons(makeCString("no match-help found!"), Nil);
+Obj x140166665229735 = makeCons(symerror, x140166665229703);
 __nargs = 2;
-__arg1 = x140246338449767;
+__arg1 = x140166665229735;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6357,15 +6302,15 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140246338450087 = __arg1;
+Obj x140166665230087 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246338450087) {
-Obj x140246338450503 = PRIM_CDR(rules);
+if (True == x140166665230087) {
+Obj x140166665230663 = PRIM_CDR(rules);
 pushCont(co, 35, clofun3, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
-__arg1 = x140246338450503;
+__arg1 = x140166665230663;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6373,10 +6318,10 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
-Obj x140246338249319 = PRIM_CAR(rules);
-Obj pat = x140246338249319;
-Obj x140246338249543 = primGenSym();
-Obj cc = x140246338249543;
+Obj x140166665046919 = PRIM_CAR(rules);
+Obj pat = x140166665046919;
+Obj x140166665047207 = primGenSym();
+Obj cc = x140166665047207;
 pushCont(co, 31, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6402,12 +6347,12 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140246338249831 = __arg1;
+Obj x140166665047527 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140246338249831;
+Obj action = x140166665047527;
 pushCont(co, 32, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6421,7 +6366,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140246338250247 = __arg1;
+Obj x140166665048039 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6429,7 +6374,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 33, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140246338250247;
+__arg1 = x140166665048039;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6442,18 +6387,18 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140246338250375 = __arg1;
+Obj x140166664831079 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140246338250375;
-Obj x140246339747975 = PRIM_CDR(rules);
-Obj x140246339748007 = PRIM_CDR(x140246339747975);
+Obj curr = x140166664831079;
+Obj x140166664831783 = PRIM_CDR(rules);
+Obj x140166664831815 = PRIM_CDR(x140166664831783);
 pushCont(co, 34, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140246339748007;
+__arg2 = x140166664831815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6463,19 +6408,19 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x140246339748071 = __arg1;
+Obj x140166664831847 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140246339748071;
-Obj x140246339749447 = makeCons(rest, Nil);
-Obj x140246339749543 = makeCons(Nil, x140246339749447);
-Obj x140246339749575 = makeCons(symlambda, x140246339749543);
-Obj x140246339749831 = makeCons(curr, Nil);
-Obj x140246339749863 = makeCons(x140246339749575, x140246339749831);
-Obj x140246339749895 = makeCons(cc, x140246339749863);
-Obj x140246339749927 = makeCons(symlet, x140246339749895);
+Obj rest = x140166664831847;
+Obj x140166664833063 = makeCons(rest, Nil);
+Obj x140166664833095 = makeCons(Nil, x140166664833063);
+Obj x140166664833127 = makeCons(symlambda, x140166664833095);
+Obj x140166664833607 = makeCons(curr, Nil);
+Obj x140166664833639 = makeCons(x140166664833127, x140166664833607);
+Obj x140166664833671 = makeCons(cc, x140166664833639);
+Obj x140166664833703 = makeCons(symlet, x140166664833671);
 __nargs = 2;
-__arg1 = x140246339749927;
+__arg1 = x140166664833703;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6483,15 +6428,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label35:
 {
-Obj x140246338450535 = __arg1;
+Obj x140166665230695 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246338450535) {
+if (True == x140166665230695) {
 if (True == True) {
-Obj x140246338450791 = PRIM_CAR(rules);
-Obj pat = x140246338450791;
-Obj x140246338451015 = primGenSym();
-Obj cc = x140246338451015;
+Obj x140166665230983 = PRIM_CAR(rules);
+Obj pat = x140166665230983;
+Obj x140166665231239 = primGenSym();
+Obj cc = x140166665231239;
 pushCont(co, 40, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6514,10 +6459,10 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140246338352103 = PRIM_CAR(rules);
-Obj pat = x140246338352103;
-Obj x140246338352327 = primGenSym();
-Obj cc = x140246338352327;
+Obj x140166665165607 = PRIM_CAR(rules);
+Obj pat = x140166665165607;
+Obj x140166665165831 = primGenSym();
+Obj cc = x140166665165831;
 pushCont(co, 36, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6543,12 +6488,12 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140246338352615 = __arg1;
+Obj x140166665166119 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140246338352615;
+Obj action = x140166665166119;
 pushCont(co, 37, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6562,7 +6507,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140246338353031 = __arg1;
+Obj x140166665166599 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6570,7 +6515,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 38, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140246338353031;
+__arg1 = x140166665166599;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6583,18 +6528,18 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140246338353159 = __arg1;
+Obj x140166665166727 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140246338353159;
-Obj x140246338353767 = PRIM_CDR(rules);
-Obj x140246338353799 = PRIM_CDR(x140246338353767);
+Obj curr = x140166665166727;
+Obj x140166665044487 = PRIM_CDR(rules);
+Obj x140166665044519 = PRIM_CDR(x140166665044487);
 pushCont(co, 39, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140246338353799;
+__arg2 = x140166665044519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6604,19 +6549,19 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140246338353831 = __arg1;
+Obj x140166665044551 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140246338353831;
-Obj x140246338354983 = makeCons(rest, Nil);
-Obj x140246338355015 = makeCons(Nil, x140246338354983);
-Obj x140246338355047 = makeCons(symlambda, x140246338355015);
-Obj x140246338248807 = makeCons(curr, Nil);
-Obj x140246338248839 = makeCons(x140246338355047, x140246338248807);
-Obj x140246338248871 = makeCons(cc, x140246338248839);
-Obj x140246338248903 = makeCons(symlet, x140246338248871);
+Obj rest = x140166665044551;
+Obj x140166665045991 = makeCons(rest, Nil);
+Obj x140166665046023 = makeCons(Nil, x140166665045991);
+Obj x140166665046055 = makeCons(symlambda, x140166665046023);
+Obj x140166665046343 = makeCons(curr, Nil);
+Obj x140166665046375 = makeCons(x140166665046055, x140166665046343);
+Obj x140166665046407 = makeCons(cc, x140166665046375);
+Obj x140166665046439 = makeCons(symlet, x140166665046407);
 __nargs = 2;
-__arg1 = x140246338248903;
+__arg1 = x140166665046439;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6624,12 +6569,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x140246338451303 = __arg1;
+Obj x140166665231559 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140246338451303;
+Obj action = x140166665231559;
 pushCont(co, 41, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6643,7 +6588,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140246338451719 = __arg1;
+Obj x140166665231975 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6651,7 +6596,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 42, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140246338451719;
+__arg1 = x140166665231975;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6664,18 +6609,18 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140246338451847 = __arg1;
+Obj x140166665232167 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140246338451847;
-Obj x140246338452455 = PRIM_CDR(rules);
-Obj x140246338452487 = PRIM_CDR(x140246338452455);
+Obj curr = x140166665232167;
+Obj x140166665163175 = PRIM_CDR(rules);
+Obj x140166665163207 = PRIM_CDR(x140166665163175);
 pushCont(co, 43, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140246338452487;
+__arg2 = x140166665163207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6685,19 +6630,19 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140246338452519 = __arg1;
+Obj x140166665163239 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140246338452519;
-Obj x140246338351271 = makeCons(rest, Nil);
-Obj x140246338351303 = makeCons(Nil, x140246338351271);
-Obj x140246338351335 = makeCons(symlambda, x140246338351303);
-Obj x140246338351591 = makeCons(curr, Nil);
-Obj x140246338351623 = makeCons(x140246338351335, x140246338351591);
-Obj x140246338351655 = makeCons(cc, x140246338351623);
-Obj x140246338351687 = makeCons(symlet, x140246338351655);
+Obj rest = x140166665163239;
+Obj x140166665164487 = makeCons(rest, Nil);
+Obj x140166665164519 = makeCons(Nil, x140166665164487);
+Obj x140166665164551 = makeCons(symlambda, x140166665164519);
+Obj x140166665164839 = makeCons(curr, Nil);
+Obj x140166665164871 = makeCons(x140166665164551, x140166665164839);
+Obj x140166665164903 = makeCons(cc, x140166665164871);
+Obj x140166665164935 = makeCons(symlet, x140166665164903);
 __nargs = 2;
-__arg1 = x140246338351687;
+__arg1 = x140166665164935;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6707,9 +6652,9 @@ label44:
 {
 Obj rules = __arg1;
 Obj cc = __arg2;
-Obj x140246338553959 = PRIM_CDR(rules);
-Obj x140246338553991 = PRIM_CAR(x140246338553959);
-Obj action = x140246338553991;
+Obj x140166663759591 = PRIM_CDR(rules);
+Obj x140166663759623 = PRIM_CAR(x140166663759591);
+Obj action = x140166663759623;
 pushCont(co, 45, clofun3, 2, cc, action);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
@@ -6723,13 +6668,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140246338554311 = __arg1;
+Obj x140166663759943 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140246338554311) {
-Obj x140246338554727 = PRIM_CAR(action);
-Obj x140246338554791 = PRIM_EQ(x140246338554727, symwhere);
-if (True == x140246338554791) {
+if (True == x140166663759943) {
+Obj x140166663760359 = PRIM_CAR(action);
+Obj x140166663760423 = PRIM_EQ(x140166663760359, symwhere);
+if (True == x140166663760423) {
 if (True == True) {
 pushCont(co, 0, clofun4, 2, action, cc);
 __nargs = 2;
@@ -6789,10 +6734,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj x140246338496903 = __arg1;
+Obj x140166663575559 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 47, clofun3, 2, cc, x140246338496903);
+pushCont(co, 47, clofun3, 2, cc, x140166663575559);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6805,16 +6750,16 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x140246338497287 = __arg1;
+Obj x140166663575943 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338496903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338497703 = makeCons(cc, Nil);
-Obj x140246338497767 = makeCons(x140246338497703, Nil);
-Obj x140246338497799 = makeCons(x140246338497287, x140246338497767);
-Obj x140246338497831 = makeCons(x140246338496903, x140246338497799);
-Obj x140246338497863 = makeCons(symif, x140246338497831);
+Obj x140166663575559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166665228359 = makeCons(cc, Nil);
+Obj x140166665228423 = makeCons(x140166665228359, Nil);
+Obj x140166665228455 = makeCons(x140166663575943, x140166665228423);
+Obj x140166665228487 = makeCons(x140166663575559, x140166665228455);
+Obj x140166665228519 = makeCons(symif, x140166665228487);
 __nargs = 2;
-__arg1 = x140246338497863;
+__arg1 = x140166665228519;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6822,10 +6767,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label48:
 {
-Obj x140246338495399 = __arg1;
+Obj x140166663574055 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 49, clofun3, 2, cc, x140246338495399);
+pushCont(co, 49, clofun3, 2, cc, x140166663574055);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6838,16 +6783,16 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140246338495783 = __arg1;
+Obj x140166663574439 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338495399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338496199 = makeCons(cc, Nil);
-Obj x140246338496263 = makeCons(x140246338496199, Nil);
-Obj x140246338496295 = makeCons(x140246338495783, x140246338496263);
-Obj x140246338496327 = makeCons(x140246338495399, x140246338496295);
-Obj x140246338496359 = makeCons(symif, x140246338496327);
+Obj x140166663574055= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166663574855 = makeCons(cc, Nil);
+Obj x140166663574919 = makeCons(x140166663574855, Nil);
+Obj x140166663574951 = makeCons(x140166663574439, x140166663574919);
+Obj x140166663574983 = makeCons(x140166663574055, x140166663574951);
+Obj x140166663575015 = makeCons(symif, x140166663574983);
 __nargs = 2;
-__arg1 = x140246338496359;
+__arg1 = x140166663575015;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6875,10 +6820,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140246338555335 = __arg1;
+Obj x140166663760967 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 1, clofun4, 2, cc, x140246338555335);
+pushCont(co, 1, clofun4, 2, cc, x140166663760967);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6891,16 +6836,16 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140246338555719 = __arg1;
+Obj x140166663761351 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338555335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338494695 = makeCons(cc, Nil);
-Obj x140246338494759 = makeCons(x140246338494695, Nil);
-Obj x140246338494791 = makeCons(x140246338555719, x140246338494759);
-Obj x140246338494823 = makeCons(x140246338555335, x140246338494791);
-Obj x140246338494855 = makeCons(symif, x140246338494823);
+Obj x140166663760967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166663761767 = makeCons(cc, Nil);
+Obj x140166663761831 = makeCons(x140166663761767, Nil);
+Obj x140166663761863 = makeCons(x140166663761351, x140166663761831);
+Obj x140166663761895 = makeCons(x140166663760967, x140166663761863);
+Obj x140166663573511 = makeCons(symif, x140166663761895);
 __nargs = 2;
-__arg1 = x140246338494855;
+__arg1 = x140166663573511;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6926,43 +6871,43 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140246338703047 = __arg1;
+Obj x140166663952487 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140246338703047) {
-Obj x140246338703335 = PRIM_EQ(pat, expr);
-if (True == x140246338703335) {
+if (True == x140166663952487) {
+Obj x140166663952775 = PRIM_EQ(pat, expr);
+if (True == x140166663952775) {
 __nargs = 2;
 __arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338626567 = makeCons(expr, Nil);
-Obj x140246338626599 = makeCons(pat, x140246338626567);
-Obj x140246338626631 = makeCons(sym_61, x140246338626599);
-Obj x140246338627303 = makeCons(cc, Nil);
-Obj x140246338627367 = makeCons(x140246338627303, Nil);
-Obj x140246338627399 = makeCons(body, x140246338627367);
-Obj x140246338627431 = makeCons(x140246338626631, x140246338627399);
-Obj x140246338627463 = makeCons(symif, x140246338627431);
+Obj x140166663953735 = makeCons(expr, Nil);
+Obj x140166663953767 = makeCons(pat, x140166663953735);
+Obj x140166663953799 = makeCons(sym_61, x140166663953767);
+Obj x140166663954407 = makeCons(cc, Nil);
+Obj x140166663925799 = makeCons(x140166663954407, Nil);
+Obj x140166663925831 = makeCons(body, x140166663925799);
+Obj x140166663925863 = makeCons(x140166663953799, x140166663925831);
+Obj x140166663925895 = makeCons(symif, x140166663925863);
 __nargs = 2;
-__arg1 = x140246338627463;
+__arg1 = x140166663925895;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
-Obj x140246338627943 = primIsSymbol(pat);
-if (True == x140246338627943) {
-Obj x140246338628839 = makeCons(body, Nil);
-Obj x140246338628871 = makeCons(expr, x140246338628839);
-Obj x140246338628903 = makeCons(pat, x140246338628871);
-Obj x140246338628935 = makeCons(symlet, x140246338628903);
+Obj x140166663926151 = primIsSymbol(pat);
+if (True == x140166663926151) {
+Obj x140166663926951 = makeCons(body, Nil);
+Obj x140166663926983 = makeCons(expr, x140166663926951);
+Obj x140166663927015 = makeCons(pat, x140166663926983);
+Obj x140166663927047 = makeCons(symlet, x140166663927015);
 __nargs = 2;
-__arg1 = x140246338628935;
+__arg1 = x140166663927047;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6982,32 +6927,32 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140246338629191 = __arg1;
+Obj x140166663927303 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140246338629191) {
-Obj x140246338600967 = PRIM_CAR(pat);
-Obj x140246338601031 = PRIM_EQ(x140246338600967, symquote);
-if (True == x140246338601031) {
-Obj x140246338602055 = makeCons(expr, Nil);
-Obj x140246338602183 = makeCons(pat, x140246338602055);
-Obj x140246338602343 = makeCons(sym_61, x140246338602183);
-Obj x140246338602983 = makeCons(cc, Nil);
-Obj x140246338603047 = makeCons(x140246338602983, Nil);
-Obj x140246338603079 = makeCons(body, x140246338603047);
-Obj x140246338603111 = makeCons(x140246338602343, x140246338603079);
-Obj x140246338603143 = makeCons(symif, x140246338603111);
+if (True == x140166663927303) {
+Obj x140166663927719 = PRIM_CAR(pat);
+Obj x140166663927783 = PRIM_EQ(x140166663927719, symquote);
+if (True == x140166663927783) {
+Obj x140166663928743 = makeCons(expr, Nil);
+Obj x140166663928775 = makeCons(pat, x140166663928743);
+Obj x140166663928807 = makeCons(sym_61, x140166663928775);
+Obj x140166663929415 = makeCons(cc, Nil);
+Obj x140166663929479 = makeCons(x140166663929415, Nil);
+Obj x140166663929511 = makeCons(body, x140166663929479);
+Obj x140166663929543 = makeCons(x140166663928807, x140166663929511);
+Obj x140166663929575 = makeCons(symif, x140166663929543);
 __nargs = 2;
-__arg1 = x140246338603143;
+__arg1 = x140166663929575;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338603623 = PRIM_CAR(pat);
-Obj x140246338603687 = PRIM_EQ(x140246338603623, symcons);
-if (True == x140246338603687) {
+Obj x140166663757959 = PRIM_CAR(pat);
+Obj x140166663758023 = PRIM_EQ(x140166663757959, symcons);
+if (True == x140166663758023) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match_45cons_45expander);
 __arg1 = pat;
@@ -7046,10 +6991,10 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140246338552103 = __arg1;
+Obj x140166663758823 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symerror);
-__arg1 = x140246338552103;
+__arg1 = x140166663758823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7073,12 +7018,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140246338702247 = __arg1;
+Obj x140166663951783 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140246338702247) {
-Obj x140246338702663 = primIsSymbol(x);
-Obj x140246338702759 = primNot(x140246338702663);
-if (True == x140246338702759) {
+if (True == x140166663951783) {
+Obj x140166663952199 = primIsSymbol(x);
+Obj x140166663952231 = primNot(x140166663952199);
+if (True == x140166663952231) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7119,12 +7064,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140246339318951 = __arg1;
+Obj x140166664114503 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = x140246339318951;
+Obj x = x140166664114503;
 pushCont(co, 10, clofun4, 4, expr, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7138,17 +7083,17 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140246339319207 = __arg1;
+Obj x140166664114759 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = x140246339319207;
-Obj x140246339319719 = PRIM_ISCONS(expr);
-if (True == x140246339319719) {
-Obj x140246339320199 = PRIM_CAR(expr);
-Obj x140246339320263 = PRIM_EQ(x140246339320199, symcons);
-if (True == x140246339320263) {
+Obj y = x140166664114759;
+Obj x140166664115079 = PRIM_ISCONS(expr);
+if (True == x140166664115079) {
+Obj x140166664115687 = PRIM_CAR(expr);
+Obj x140166664115751 = PRIM_EQ(x140166664115687, symcons);
+if (True == x140166664115751) {
 if (True == True) {
 pushCont(co, 23, clofun4, 5, expr, y, body, x, cc);
 __nargs = 2;
@@ -7160,17 +7105,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338970503 = makeCons(expr, Nil);
-Obj x140246338970567 = makeCons(symcons_63, x140246338970503);
-Obj x140246338971751 = makeCons(expr, Nil);
-Obj x140246338971847 = makeCons(symcar, x140246338971751);
-Obj x140246338972679 = makeCons(expr, Nil);
-Obj x140246338972711 = makeCons(symcdr, x140246338972679);
-pushCont(co, 21, clofun4, 4, x, x140246338971847, cc, x140246338970567);
+Obj x140166664117831 = makeCons(expr, Nil);
+Obj x140166664117863 = makeCons(symcons_63, x140166664117831);
+Obj x140166664086183 = makeCons(expr, Nil);
+Obj x140166664086215 = makeCons(symcar, x140166664086183);
+Obj x140166664086919 = makeCons(expr, Nil);
+Obj x140166664086951 = makeCons(symcdr, x140166664086919);
+pushCont(co, 21, clofun4, 4, x, x140166664086215, cc, x140166664117863);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140246338972711;
+__arg2 = x140166664086951;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7191,17 +7136,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338951879 = makeCons(expr, Nil);
-Obj x140246338951911 = makeCons(symcons_63, x140246338951879);
-Obj x140246338953031 = makeCons(expr, Nil);
-Obj x140246338953063 = makeCons(symcar, x140246338953031);
-Obj x140246338822759 = makeCons(expr, Nil);
-Obj x140246338822791 = makeCons(symcdr, x140246338822759);
-pushCont(co, 16, clofun4, 4, x, x140246338953063, cc, x140246338951911);
+Obj x140166664081703 = makeCons(expr, Nil);
+Obj x140166664081735 = makeCons(symcons_63, x140166664081703);
+Obj x140166664082599 = makeCons(expr, Nil);
+Obj x140166664082631 = makeCons(symcar, x140166664082599);
+Obj x140166664083335 = makeCons(expr, Nil);
+Obj x140166664083367 = makeCons(symcdr, x140166664083335);
+pushCont(co, 16, clofun4, 4, x, x140166664082631, cc, x140166664081735);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140246338822791;
+__arg2 = x140166664083367;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7223,17 +7168,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338825703 = makeCons(expr, Nil);
-Obj x140246338825735 = makeCons(symcons_63, x140246338825703);
-Obj x140246338699687 = makeCons(expr, Nil);
-Obj x140246338699719 = makeCons(symcar, x140246338699687);
-Obj x140246338700487 = makeCons(expr, Nil);
-Obj x140246338700519 = makeCons(symcdr, x140246338700487);
-pushCont(co, 11, clofun4, 4, x, x140246338699719, cc, x140246338825735);
+Obj x140166664073959 = makeCons(expr, Nil);
+Obj x140166664073991 = makeCons(symcons_63, x140166664073959);
+Obj x140166664074887 = makeCons(expr, Nil);
+Obj x140166664074919 = makeCons(symcar, x140166664074887);
+Obj x140166664075623 = makeCons(expr, Nil);
+Obj x140166664075655 = makeCons(symcdr, x140166664075623);
+pushCont(co, 11, clofun4, 4, x, x140166664074919, cc, x140166664073991);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140246338700519;
+__arg2 = x140166664075655;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7247,17 +7192,17 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246338700615 = __arg1;
+Obj x140166664075815 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338699719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664074919= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246338825735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 12, clofun4, 2, cc, x140246338825735);
+Obj x140166664073991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 12, clofun4, 2, cc, x140166664073991);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140246338699719;
-__arg3 = x140246338700615;
+__arg2 = x140166664074919;
+__arg3 = x140166664075815;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7268,16 +7213,16 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140246338700679 = __arg1;
+Obj x140166664075879 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338825735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338701255 = makeCons(cc, Nil);
-Obj x140246338701319 = makeCons(x140246338701255, Nil);
-Obj x140246338701351 = makeCons(x140246338700679, x140246338701319);
-Obj x140246338701383 = makeCons(x140246338825735, x140246338701351);
-Obj x140246338701415 = makeCons(symif, x140246338701383);
+Obj x140166664073991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664076391 = makeCons(cc, Nil);
+Obj x140166664076455 = makeCons(x140166664076391, Nil);
+Obj x140166663950791 = makeCons(x140166664075879, x140166664076455);
+Obj x140166663950823 = makeCons(x140166664073991, x140166663950791);
+Obj x140166663950855 = makeCons(symif, x140166663950823);
 __nargs = 2;
-__arg1 = x140246338701415;
+__arg1 = x140166663950855;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7285,13 +7230,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label13:
 {
-Obj x140246338823911 = __arg1;
+Obj x140166664084519 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140246338823911;
+Obj e1 = x140166664084519;
 pushCont(co, 14, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7305,13 +7250,13 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140246338824167 = __arg1;
+Obj x140166664084775 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140246338824167;
+Obj e2 = x140166664084775;
 pushCont(co, 15, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7328,7 +7273,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140246338824807 = __arg1;
+Obj x140166664085319 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7336,7 +7281,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140246338824807;
+__arg3 = x140166664085319;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7347,17 +7292,17 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140246338822887 = __arg1;
+Obj x140166664083463 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338953063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664082631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246338951911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 17, clofun4, 2, cc, x140246338951911);
+Obj x140166664081735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 17, clofun4, 2, cc, x140166664081735);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140246338953063;
-__arg3 = x140246338822887;
+__arg2 = x140166664082631;
+__arg3 = x140166664083463;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7368,16 +7313,16 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140246338822951 = __arg1;
+Obj x140166664083527 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338951911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338823399 = makeCons(cc, Nil);
-Obj x140246338823527 = makeCons(x140246338823399, Nil);
-Obj x140246338823559 = makeCons(x140246338822951, x140246338823527);
-Obj x140246338823591 = makeCons(x140246338951911, x140246338823559);
-Obj x140246338823623 = makeCons(symif, x140246338823591);
+Obj x140166664081735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664084071 = makeCons(cc, Nil);
+Obj x140166664084135 = makeCons(x140166664084071, Nil);
+Obj x140166664084167 = makeCons(x140166664083527, x140166664084135);
+Obj x140166664084199 = makeCons(x140166664081735, x140166664084167);
+Obj x140166664084231 = makeCons(symif, x140166664084199);
 __nargs = 2;
-__arg1 = x140246338823623;
+__arg1 = x140166664084231;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7385,13 +7330,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label18:
 {
-Obj x140246338949767 = __arg1;
+Obj x140166664088135 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140246338949767;
+Obj e1 = x140166664088135;
 pushCont(co, 19, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7405,13 +7350,13 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140246338950119 = __arg1;
+Obj x140166664088391 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140246338950119;
+Obj e2 = x140166664088391;
 pushCont(co, 20, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7428,7 +7373,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140246338950919 = __arg1;
+Obj x140166664088935 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7436,7 +7381,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140246338950919;
+__arg3 = x140166664088935;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7447,17 +7392,17 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140246338972839 = __arg1;
+Obj x140166664087047 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338971847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664086215= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246338970567= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 22, clofun4, 2, cc, x140246338970567);
+Obj x140166664117863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 22, clofun4, 2, cc, x140166664117863);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140246338971847;
-__arg3 = x140246338972839;
+__arg2 = x140166664086215;
+__arg3 = x140166664087047;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7468,16 +7413,16 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140246338972935 = __arg1;
+Obj x140166664087175 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338970567= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338973511 = makeCons(cc, Nil);
-Obj x140246338973575 = makeCons(x140246338973511, Nil);
-Obj x140246338973607 = makeCons(x140246338972935, x140246338973575);
-Obj x140246338973639 = makeCons(x140246338970567, x140246338973607);
-Obj x140246338949287 = makeCons(symif, x140246338973639);
+Obj x140166664117863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664087655 = makeCons(cc, Nil);
+Obj x140166664087719 = makeCons(x140166664087655, Nil);
+Obj x140166664087751 = makeCons(x140166664087175, x140166664087719);
+Obj x140166664087783 = makeCons(x140166664117863, x140166664087751);
+Obj x140166664087815 = makeCons(symif, x140166664087783);
 __nargs = 2;
-__arg1 = x140246338949287;
+__arg1 = x140166664087815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7485,13 +7430,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label23:
 {
-Obj x140246339320519 = __arg1;
+Obj x140166664116007 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140246339320519;
+Obj e1 = x140166664116007;
 pushCont(co, 24, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7505,13 +7450,13 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140246339320807 = __arg1;
+Obj x140166664116423 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140246339320807;
+Obj e2 = x140166664116423;
 pushCont(co, 25, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7528,7 +7473,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140246339321447 = __arg1;
+Obj x140166664116967 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7536,7 +7481,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140246339321447;
+__arg3 = x140166664116967;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7548,10 +7493,10 @@ goto *jumpTable[ps.label];
 label26:
 {
 Obj exp = __arg1;
-Obj x140246339318311 = PRIM_CDR(exp);
+Obj x140166664134151 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140246339318311;
+__arg1 = x140166664134151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7562,11 +7507,11 @@ goto *jumpTable[ps.label];
 label27:
 {
 Obj pat = __arg1;
-Obj x140246339373159 = PRIM_CDR(pat);
+Obj x140166664131047 = PRIM_CDR(pat);
 pushCont(co, 28, clofun4, 1, pat);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140246339373159;
+__arg1 = x140166664131047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7576,22 +7521,22 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x140246339373191 = __arg1;
+Obj x140166664131079 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140246339373191) {
-Obj x140246339373383 = PRIM_CAR(pat);
+if (True == x140166664131079) {
+Obj x140166664131335 = PRIM_CAR(pat);
 __nargs = 2;
-__arg1 = x140246339373383;
+__arg1 = x140166664131335;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339374087 = PRIM_CAR(pat);
-Obj x140246339374631 = PRIM_CDR(pat);
-pushCont(co, 29, clofun4, 1, x140246339374087);
+Obj x140166664132135 = PRIM_CAR(pat);
+Obj x140166664132935 = PRIM_CDR(pat);
+pushCont(co, 29, clofun4, 1, x140166664132135);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140246339374631;
+__arg1 = x140166664132935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7602,13 +7547,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140246339374663 = __arg1;
-Obj x140246339374087= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339374727 = makeCons(x140246339374663, Nil);
-Obj x140246339374759 = makeCons(x140246339374087, x140246339374727);
-Obj x140246339374791 = makeCons(symcons, x140246339374759);
+Obj x140166664132999 = __arg1;
+Obj x140166664132135= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664133063 = makeCons(x140166664132999, Nil);
+Obj x140166664133095 = makeCons(x140166664132135, x140166664133063);
+Obj x140166664133127 = makeCons(symcons, x140166664133095);
 __nargs = 2;
-__arg1 = x140246339374791;
+__arg1 = x140166664133127;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7617,16 +7562,16 @@ goto *jumpTable[co->ctx.pc.label];
 label30:
 {
 Obj x = __arg1;
-Obj x140246339371879 = PRIM_EQ(x, True);
-if (True == x140246339371879) {
+Obj x140166664293159 = PRIM_EQ(x, True);
+if (True == x140166664293159) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339372263 = PRIM_EQ(x, False);
-if (True == x140246339372263) {
+Obj x140166664293575 = PRIM_EQ(x, False);
+if (True == x140166664293575) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7645,10 +7590,10 @@ goto *jumpTable[co->ctx.pc.label];
 label31:
 {
 Obj exp = __arg1;
-Obj x140246339371143 = PRIM_CDR(exp);
+Obj x140166664292391 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140246339371143;
+__arg1 = x140166664292391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7659,28 +7604,28 @@ goto *jumpTable[ps.label];
 label32:
 {
 Obj l = __arg1;
-Obj x140246339621831 = PRIM_EQ(Nil, l);
-if (True == x140246339621831) {
+Obj x140166664472999 = PRIM_EQ(Nil, l);
+if (True == x140166664472999) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339622247 = PRIM_CAR(l);
-Obj x140246339622311 = PRIM_EQ(x140246339622247, False);
-if (True == x140246339622311) {
+Obj x140166664473415 = PRIM_CAR(l);
+Obj x140166664473479 = PRIM_EQ(x140166664473415, False);
+if (True == x140166664473479) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339622727 = PRIM_CDR(l);
+Obj x140166664473895 = PRIM_CDR(l);
 pushCont(co, 33, clofun4, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140246339622727;
+__arg1 = x140166664473895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7692,24 +7637,24 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140246339622759 = __arg1;
+Obj x140166664473927 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140246339622759;
-Obj x140246339623111 = PRIM_EQ(more, False);
-if (True == x140246339623111) {
+Obj more = x140166664473927;
+Obj x140166664474215 = PRIM_EQ(more, False);
+if (True == x140166664474215) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339623751 = PRIM_CAR(l);
-Obj x140246339624199 = makeCons(False, Nil);
-Obj x140246339624231 = makeCons(more, x140246339624199);
-Obj x140246339624263 = makeCons(x140246339623751, x140246339624231);
-Obj x140246339624295 = makeCons(symif, x140246339624263);
+Obj x140166664290599 = PRIM_CAR(l);
+Obj x140166664291271 = makeCons(False, Nil);
+Obj x140166664291303 = makeCons(more, x140166664291271);
+Obj x140166664291335 = makeCons(x140166664290599, x140166664291303);
+Obj x140166664291367 = makeCons(symif, x140166664291335);
 __nargs = 2;
-__arg1 = x140246339624295;
+__arg1 = x140166664291367;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7719,10 +7664,10 @@ goto *jumpTable[co->ctx.pc.label];
 label34:
 {
 Obj exp = __arg1;
-Obj x140246339621191 = PRIM_CDR(exp);
+Obj x140166664472359 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140246339621191;
+__arg1 = x140166664472359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7733,28 +7678,28 @@ goto *jumpTable[ps.label];
 label35:
 {
 Obj l = __arg1;
-Obj x140246339712391 = PRIM_EQ(l, Nil);
-if (True == x140246339712391) {
+Obj x140166664694631 = PRIM_EQ(l, Nil);
+if (True == x140166664694631) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339712807 = PRIM_CAR(l);
-Obj x140246339712871 = PRIM_EQ(x140246339712807, True);
-if (True == x140246339712871) {
+Obj x140166664695047 = PRIM_CAR(l);
+Obj x140166664695111 = PRIM_EQ(x140166664695047, True);
+if (True == x140166664695111) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339713287 = PRIM_CDR(l);
+Obj x140166664695527 = PRIM_CDR(l);
 pushCont(co, 36, clofun4, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140246339713287;
+__arg1 = x140166664695527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7766,24 +7711,24 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140246339713319 = __arg1;
+Obj x140166664695559 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140246339713319;
-Obj x140246339713607 = PRIM_EQ(more, True);
-if (True == x140246339713607) {
+Obj more = x140166664695559;
+Obj x140166664470567 = PRIM_EQ(more, True);
+if (True == x140166664470567) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246339714151 = PRIM_CAR(l);
-Obj x140246339714599 = makeCons(more, Nil);
-Obj x140246339714631 = makeCons(True, x140246339714599);
-Obj x140246339714663 = makeCons(x140246339714151, x140246339714631);
-Obj x140246339714695 = makeCons(symif, x140246339714663);
+Obj x140166664471111 = PRIM_CAR(l);
+Obj x140166664471559 = makeCons(more, Nil);
+Obj x140166664471591 = makeCons(True, x140166664471559);
+Obj x140166664471623 = makeCons(x140166664471111, x140166664471591);
+Obj x140166664471655 = makeCons(symif, x140166664471623);
 __nargs = 2;
-__arg1 = x140246339714695;
+__arg1 = x140166664471655;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7793,13 +7738,13 @@ goto *jumpTable[co->ctx.pc.label];
 label37:
 {
 Obj exp = __arg1;
-Obj x140246339750279 = PRIM_CDR(exp);
-Obj x140246339750311 = PRIM_EQ(Nil, x140246339750279);
-if (True == x140246339750311) {
-Obj x140246339750727 = makeCons(makeCString("no cond match"), Nil);
-Obj x140246339750759 = makeCons(symerror, x140246339750727);
+Obj x140166664834919 = PRIM_CDR(exp);
+Obj x140166664834951 = PRIM_EQ(Nil, x140166664834919);
+if (True == x140166664834951) {
+Obj x140166664692007 = makeCons(makeCString("no cond match"), Nil);
+Obj x140166664692039 = makeCons(symerror, x140166664692007);
 __nargs = 2;
-__arg1 = x140246339750759;
+__arg1 = x140166664692039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7818,11 +7763,11 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140246339751015 = __arg1;
+Obj x140166664692295 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = x140246339751015;
-Obj x140246339751559 = PRIM_CAR(curr);
-pushCont(co, 39, clofun4, 2, exp, x140246339751559);
+Obj curr = x140166664692295;
+Obj x140166664692839 = PRIM_CAR(curr);
+pushCont(co, 39, clofun4, 2, exp, x140166664692839);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = curr;
@@ -7835,10 +7780,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140246339710983 = __arg1;
+Obj x140166664693223 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339751559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 40, clofun4, 2, x140246339710983, x140246339751559);
+Obj x140166664692839= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 40, clofun4, 2, x140166664693223, x140166664692839);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -7851,16 +7796,16 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140246339711559 = __arg1;
-Obj x140246339710983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339751559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339711591 = makeCons(symcond, x140246339711559);
-Obj x140246339711655 = makeCons(x140246339711591, Nil);
-Obj x140246339711687 = makeCons(x140246339710983, x140246339711655);
-Obj x140246339711719 = makeCons(x140246339751559, x140246339711687);
-Obj x140246339711751 = makeCons(symif, x140246339711719);
+Obj x140166664693799 = __arg1;
+Obj x140166664693223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664692839= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664693831 = makeCons(symcond, x140166664693799);
+Obj x140166664693895 = makeCons(x140166664693831, Nil);
+Obj x140166664693927 = makeCons(x140166664693223, x140166664693895);
+Obj x140166664693959 = makeCons(x140166664692839, x140166664693927);
+Obj x140166664693991 = makeCons(symif, x140166664693959);
 __nargs = 2;
-__arg1 = x140246339711751;
+__arg1 = x140166664693991;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7869,10 +7814,10 @@ goto *jumpTable[co->ctx.pc.label];
 label41:
 {
 Obj exp = __arg1;
-Obj x140246339749479 = PRIM_CDR(exp);
+Obj x140166664834119 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140246339749479;
+__arg1 = x140166664834119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7883,11 +7828,11 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj exp = __arg1;
-Obj x140246338552903 = PRIM_CDR(exp);
+Obj x140166664831527 = PRIM_CDR(exp);
 pushCont(co, 43, clofun4, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140246338552903;
+__arg1 = x140166664831527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7897,18 +7842,18 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140246338552935 = __arg1;
+Obj x140166664831559 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140246338552935) {
-Obj x140246338553127 = PRIM_CAR(exp);
+if (True == x140166664831559) {
+Obj x140166664831751 = PRIM_CAR(exp);
 __nargs = 2;
-__arg1 = x140246338553127;
+__arg1 = x140166664831751;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338553671 = PRIM_CAR(exp);
-pushCont(co, 44, clofun4, 2, exp, x140246338553671);
+Obj x140166664832295 = PRIM_CAR(exp);
+pushCont(co, 44, clofun4, 2, exp, x140166664832295);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -7922,10 +7867,10 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140246339748039 = __arg1;
+Obj x140166664832679 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 45, clofun4, 2, x140246339748039, x140246338553671);
+Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun4, 2, x140166664832679, x140166664832295);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -7938,13 +7883,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140246339748583 = __arg1;
-Obj x140246339748039= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun4, 2, x140246339748039, x140246338553671);
+Obj x140166664833223 = __arg1;
+Obj x140166664832679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun4, 2, x140166664832679, x140166664832295);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140246339748583;
+__arg1 = x140166664833223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7954,15 +7899,15 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140246339748615 = __arg1;
-Obj x140246339748039= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246339748679 = makeCons(x140246339748615, Nil);
-Obj x140246339748711 = makeCons(x140246339748039, x140246339748679);
-Obj x140246339748743 = makeCons(x140246338553671, x140246339748711);
-Obj x140246339748775 = makeCons(symlet, x140246339748743);
+Obj x140166664833255 = __arg1;
+Obj x140166664832679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166664833319 = makeCons(x140166664833255, Nil);
+Obj x140166664833351 = makeCons(x140166664832679, x140166664833319);
+Obj x140166664833383 = makeCons(x140166664832295, x140166664833351);
+Obj x140166664833415 = makeCons(symlet, x140166664833383);
 __nargs = 2;
-__arg1 = x140246339748775;
+__arg1 = x140166664833415;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7971,10 +7916,10 @@ goto *jumpTable[co->ctx.pc.label];
 label47:
 {
 Obj x = __arg1;
-Obj x140246338551911 = PRIM_ISCONS(x);
-Obj x140246338551943 = primNot(x140246338551911);
+Obj x140166665047815 = PRIM_ISCONS(x);
+Obj x140166665047847 = primNot(x140166665047815);
 __nargs = 2;
-__arg1 = x140246338551943;
+__arg1 = x140166665047847;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7984,22 +7929,22 @@ label48:
 {
 Obj x = __arg1;
 Obj l = __arg2;
-Obj x140246338602887 = PRIM_ISCONS(l);
-if (True == x140246338602887) {
-Obj x140246338603303 = PRIM_CAR(l);
-Obj x140246338603367 = PRIM_EQ(x140246338603303, x);
-if (True == x140246338603367) {
+Obj x140166665046215 = PRIM_ISCONS(l);
+if (True == x140166665046215) {
+Obj x140166665046631 = PRIM_CAR(l);
+Obj x140166665046695 = PRIM_EQ(x140166665046631, x);
+if (True == x140166665046695) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338603751 = PRIM_CDR(l);
+Obj x140166665047079 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
 __arg1 = x;
-__arg2 = x140246338603751;
+__arg2 = x140166665047079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8051,9 +7996,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140246338629575 = __arg1;
+Obj x140166665044231 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 1, clofun5, 2, exp, x140246338629575);
+pushCont(co, 1, clofun5, 2, exp, x140166665044231);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8066,10 +8011,10 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140246338601639 = __arg1;
+Obj x140166665044967 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338629575= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 2, clofun5, 2, x140246338601639, x140246338629575);
+Obj x140166665044231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun5, 2, x140166665044967, x140166665044231);
 __nargs = 2;
 __arg0 = globalRef(symcadddr);
 __arg1 = exp;
@@ -8082,17 +8027,17 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140246338602023 = __arg1;
-Obj x140246338601639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338629575= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338602087 = makeCons(x140246338602023, Nil);
-Obj x140246338602119 = makeCons(x140246338601639, x140246338602087);
-Obj x140246338602151 = makeCons(symlambda, x140246338602119);
-Obj x140246338602215 = makeCons(x140246338602151, Nil);
-Obj x140246338602247 = makeCons(x140246338629575, x140246338602215);
-Obj x140246338602279 = makeCons(symdef, x140246338602247);
+Obj x140166665045351 = __arg1;
+Obj x140166665044967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166665044231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166665045415 = makeCons(x140166665045351, Nil);
+Obj x140166665045447 = makeCons(x140166665044967, x140166665045415);
+Obj x140166665045479 = makeCons(symlambda, x140166665045447);
+Obj x140166665045543 = makeCons(x140166665045479, Nil);
+Obj x140166665045575 = makeCons(x140166665044231, x140166665045543);
+Obj x140166665045607 = makeCons(symdef, x140166665045575);
 __nargs = 2;
-__arg1 = x140246338602279;
+__arg1 = x140166665045607;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8101,10 +8046,10 @@ goto *jumpTable[co->ctx.pc.label];
 label3:
 {
 Obj exp = __arg1;
-Obj x140246338628679 = PRIM_CDR(exp);
+Obj x140166665166215 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = x140246338628679;
+__arg1 = x140166665166215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8128,11 +8073,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140246338626407 = __arg1;
+Obj x140166665163975 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338626471 = makeCons(x140246338626407, Nil);
-Obj x140246338626503 = makeCons(symquote, x140246338626471);
-pushCont(co, 6, clofun5, 2, exp, x140246338626503);
+Obj x140166665164039 = makeCons(x140166665163975, Nil);
+Obj x140166665164071 = makeCons(symquote, x140166665164039);
+pushCont(co, 6, clofun5, 2, exp, x140166665164071);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8145,10 +8090,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140246338627271 = __arg1;
+Obj x140166665164807 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338626503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 7, clofun5, 2, x140246338627271, x140246338626503);
+Obj x140166665164071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 7, clofun5, 2, x140166665164807, x140166665164071);
 __nargs = 2;
 __arg0 = globalRef(symcdddr);
 __arg1 = exp;
@@ -8161,16 +8106,16 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140246338627495 = __arg1;
-Obj x140246338627271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338626503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140246338627527 = makeCons(x140246338627271, x140246338627495);
-Obj x140246338627559 = makeCons(symlambda, x140246338627527);
-Obj x140246338627623 = makeCons(x140246338627559, Nil);
-Obj x140246338627655 = makeCons(x140246338626503, x140246338627623);
-Obj x140246338627687 = makeCons(symcora_47init_35add_45to_45_42macros_42, x140246338627655);
+Obj x140166665165031 = __arg1;
+Obj x140166665164807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166665164071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140166665165063 = makeCons(x140166665164807, x140166665165031);
+Obj x140166665165095 = makeCons(symlambda, x140166665165063);
+Obj x140166665165159 = makeCons(x140166665165095, Nil);
+Obj x140166665165191 = makeCons(x140166665164071, x140166665165159);
+Obj x140166665165223 = makeCons(symcora_47init_35add_45to_45_42macros_42, x140166665165191);
 __nargs = 2;
-__arg1 = x140246338627687;
+__arg1 = x140166665165223;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8179,21 +8124,21 @@ goto *jumpTable[co->ctx.pc.label];
 label8:
 {
 Obj exp = __arg1;
-Obj x140246338825671 = PRIM_ISCONS(exp);
-if (True == x140246338825671) {
-Obj x140246338826087 = PRIM_CAR(exp);
-Obj x140246338826151 = PRIM_EQ(x140246338826087, globalRef(sym_42protect_45symbol_42));
-if (True == x140246338826151) {
-Obj x140246338699367 = PRIM_CDR(exp);
+Obj x140166663950631 = PRIM_ISCONS(exp);
+if (True == x140166663950631) {
+Obj x140166665228551 = PRIM_CAR(exp);
+Obj x140166665228615 = PRIM_EQ(x140166665228551, globalRef(sym_42protect_45symbol_42));
+if (True == x140166665228615) {
+Obj x140166665228807 = PRIM_CDR(exp);
 __nargs = 2;
-__arg1 = x140246338699367;
+__arg1 = x140166665228807;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338699815 = PRIM_CAR(exp);
-Obj x140246338699879 = PRIM_EQ(x140246338699815, symlambda);
-if (True == x140246338699879) {
+Obj x140166665229223 = PRIM_CAR(exp);
+Obj x140166665229287 = PRIM_EQ(x140166665229223, symlambda);
+if (True == x140166665229287) {
 pushCont(co, 11, clofun5, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -8204,9 +8149,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338701575 = PRIM_CAR(exp);
-Obj x140246338701639 = PRIM_EQ(x140246338701575, symquote);
-if (True == x140246338701639) {
+Obj x140166665230951 = PRIM_CAR(exp);
+Obj x140166665231015 = PRIM_EQ(x140166665230951, symquote);
+if (True == x140166665231015) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -8236,11 +8181,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label9:
 {
-Obj x140246338702695 = __arg1;
+Obj x140166665232071 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = makeNative(10, clofun5, 1, 1, exp);
-__arg1 = x140246338702695;
+__arg1 = x140166665232071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8251,8 +8196,8 @@ goto *jumpTable[ps.label];
 label10:
 {
 Obj exp1 = __arg1;
-Obj x140246338702119 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == x140246338702119) {
+Obj x140166665231495 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == x140166665231495) {
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35macroexpand_45boot);
@@ -8276,9 +8221,9 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140246338700455 = __arg1;
+Obj x140166665229831 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 12, clofun5, 1, x140246338700455);
+pushCont(co, 12, clofun5, 1, x140166665229831);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8291,12 +8236,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140246338700999 = __arg1;
-Obj x140246338700455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 13, clofun5, 1, x140246338700455);
+Obj x140166665230375 = __arg1;
+Obj x140166665229831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 13, clofun5, 1, x140166665229831);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = x140246338700999;
+__arg1 = x140166665230375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8306,13 +8251,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140246338701031 = __arg1;
-Obj x140246338700455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246338701095 = makeCons(x140246338701031, Nil);
-Obj x140246338701127 = makeCons(x140246338700455, x140246338701095);
-Obj x140246338701159 = makeCons(symlambda, x140246338701127);
+Obj x140166665230407 = __arg1;
+Obj x140166665229831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166665230471 = makeCons(x140166665230407, Nil);
+Obj x140166665230503 = makeCons(x140166665229831, x140166665230471);
+Obj x140166665230535 = makeCons(symlambda, x140166665230503);
 __nargs = 2;
-__arg1 = x140246338701159;
+__arg1 = x140166665230535;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8336,18 +8281,18 @@ label15:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj x140246338951623 = PRIM_EQ(Nil, macros);
-if (True == x140246338951623) {
+Obj x140166664084423 = PRIM_EQ(Nil, macros);
+if (True == x140166664084423) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140246338824487 = PRIM_CAR(macros);
+Obj x140166664075751 = PRIM_CAR(macros);
 __nargs = 2;
 __arg0 = makeNative(16, clofun5, 1, 2, exp, macros);
-__arg1 = x140246338824487;
+__arg1 = x140166664075751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8359,16 +8304,16 @@ goto *jumpTable[ps.label];
 label16:
 {
 Obj item = __arg1;
-Obj x140246338952135 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140246338952135) {
-Obj x140246338952711 = PRIM_CAR(closureRef(co, 0));
-Obj x140246338952967 = PRIM_CAR(item);
-Obj x140246338952999 = PRIM_EQ(x140246338952711, x140246338952967);
-if (True == x140246338952999) {
+Obj x140166664084935 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140166664084935) {
+Obj x140166664085351 = PRIM_CAR(closureRef(co, 0));
+Obj x140166664073287 = PRIM_CAR(item);
+Obj x140166664073319 = PRIM_EQ(x140166664085351, x140166664073287);
+if (True == x140166664073319) {
 if (True == True) {
-Obj x140246338822311 = PRIM_CDR(item);
+Obj x140166664073639 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140246338822311;
+__arg0 = x140166664073639;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8376,11 +8321,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338822727 = PRIM_CDR(closureRef(co, 1));
+Obj x140166664074055 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140246338822727;
+__arg2 = x140166664074055;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8389,9 +8334,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140246338823047 = PRIM_CDR(item);
+Obj x140166664074375 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140246338823047;
+__arg0 = x140166664074375;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8399,11 +8344,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338823495 = PRIM_CDR(closureRef(co, 1));
+Obj x140166664074791 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140246338823495;
+__arg2 = x140166664074791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8413,9 +8358,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140246338823815 = PRIM_CDR(item);
+Obj x140166664075111 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140246338823815;
+__arg0 = x140166664075111;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8423,11 +8368,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140246338824263 = PRIM_CDR(closureRef(co, 1));
+Obj x140166664075527 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140246338824263;
+__arg2 = x140166664075527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8441,11 +8386,11 @@ label17:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj x140246338950727 = makeCons(n, v);
-Obj x140246338950791 = makeCons(x140246338950727, globalRef(sym_42macros_42));
-Obj x140246338950823 = primSet(co, sym_42macros_42, x140246338950791);
+Obj x140166664083687 = makeCons(n, v);
+Obj x140166664083751 = makeCons(x140166664083687, globalRef(sym_42macros_42));
+Obj x140166664083783 = primSet(co, sym_42macros_42, x140166664083751);
 __nargs = 2;
-__arg1 = x140246338950823;
+__arg1 = x140166664083783;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8472,13 +8417,13 @@ label19:
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj x140246338970727 = PRIM_ISCONS(l);
-if (True == x140246338970727) {
-Obj x140246338971559 = PRIM_CAR(l);
+Obj x140166664088455 = PRIM_ISCONS(l);
+if (True == x140166664088455) {
+Obj x140166664089127 = PRIM_CAR(l);
 pushCont(co, 20, clofun5, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = x140246338971559;
+__arg1 = x140166664089127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8498,17 +8443,17 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140246338971623 = __arg1;
+Obj x140166664089159 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140246338971719 = makeCons(x140246338971623, res);
-Obj x140246338972103 = PRIM_CDR(l);
+Obj x140166664089223 = makeCons(x140166664089159, res);
+Obj x140166664089479 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symmap_45h);
-__arg1 = x140246338971719;
+__arg1 = x140166664089223;
 __arg2 = f;
-__arg3 = x140246338972103;
+__arg3 = x140166664089479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8520,15 +8465,15 @@ label21:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj x140246339320583 = PRIM_ISCONS(l);
-if (True == x140246339320583) {
-Obj x140246339321095 = PRIM_CAR(l);
-Obj x140246339321159 = makeCons(x140246339321095, res);
-Obj x140246339321383 = PRIM_CDR(l);
+Obj x140166664086535 = PRIM_ISCONS(l);
+if (True == x140166664086535) {
+Obj x140166664087079 = PRIM_CAR(l);
+Obj x140166664087143 = makeCons(x140166664087079, res);
+Obj x140166664087367 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = x140246339321159;
-__arg2 = x140246339321383;
+__arg1 = x140166664087143;
+__arg2 = x140166664087367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8546,9 +8491,9 @@ goto *jumpTable[co->ctx.pc.label];
 label22:
 {
 Obj x = __arg1;
-Obj x140246339319975 = PRIM_ISCONS(x);
+Obj x140166664085927 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = x140246339319975;
+__arg1 = x140166664085927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8557,14 +8502,14 @@ goto *jumpTable[co->ctx.pc.label];
 label23:
 {
 Obj exp = __arg1;
-Obj x140246339318183 = PRIM_ISCONS(exp);
-if (True == x140246339318183) {
-Obj x140246339318727 = PRIM_CAR(exp);
-Obj x140246339319271 = PRIM_CDR(exp);
-pushCont(co, 24, clofun5, 1, x140246339318727);
+Obj x140166664116839 = PRIM_ISCONS(exp);
+if (True == x140166664116839) {
+Obj x140166664117415 = PRIM_CAR(exp);
+Obj x140166664117959 = PRIM_CDR(exp);
+pushCont(co, 24, clofun5, 1, x140166664117415);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = x140246339319271;
+__arg1 = x140166664117959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8581,13 +8526,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label24:
 {
-Obj x140246339319303 = __arg1;
-Obj x140246339318727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140246339319367 = makeCons(x140246339319303, Nil);
-Obj x140246339319399 = makeCons(x140246339318727, x140246339319367);
-Obj x140246339319431 = makeCons(symcons, x140246339319399);
+Obj x140166664117991 = __arg1;
+Obj x140166664117415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140166664118055 = makeCons(x140166664117991, Nil);
+Obj x140166664118087 = makeCons(x140166664117415, x140166664118055);
+Obj x140166664118119 = makeCons(symcons, x140166664118087);
 __nargs = 2;
-__arg1 = x140246339319431;
+__arg1 = x140166664118119;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8596,11 +8541,11 @@ goto *jumpTable[co->ctx.pc.label];
 label25:
 {
 Obj x = __arg1;
-Obj x140246339374855 = PRIM_CDR(x);
-Obj x140246339374887 = PRIM_CDR(x140246339374855);
-Obj x140246339374919 = PRIM_CDR(x140246339374887);
+Obj x140166664116135 = PRIM_CDR(x);
+Obj x140166664116167 = PRIM_CDR(x140166664116135);
+Obj x140166664116199 = PRIM_CDR(x140166664116167);
 __nargs = 2;
-__arg1 = x140246339374919;
+__arg1 = x140166664116199;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8609,12 +8554,12 @@ goto *jumpTable[co->ctx.pc.label];
 label26:
 {
 Obj x = __arg1;
-Obj x140246339373895 = PRIM_CDR(x);
-Obj x140246339373927 = PRIM_CDR(x140246339373895);
-Obj x140246339373959 = PRIM_CDR(x140246339373927);
-Obj x140246339373991 = PRIM_CAR(x140246339373959);
+Obj x140166664115143 = PRIM_CDR(x);
+Obj x140166664115175 = PRIM_CDR(x140166664115143);
+Obj x140166664115207 = PRIM_CDR(x140166664115175);
+Obj x140166664115239 = PRIM_CAR(x140166664115207);
 __nargs = 2;
-__arg1 = x140246339373991;
+__arg1 = x140166664115239;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8623,11 +8568,11 @@ goto *jumpTable[co->ctx.pc.label];
 label27:
 {
 Obj x = __arg1;
-Obj x140246339372807 = PRIM_CDR(x);
-Obj x140246339372839 = PRIM_CDR(x140246339372807);
-Obj x140246339372871 = PRIM_CAR(x140246339372839);
+Obj x140166664134439 = PRIM_CDR(x);
+Obj x140166664134471 = PRIM_CDR(x140166664134439);
+Obj x140166664134503 = PRIM_CAR(x140166664134471);
 __nargs = 2;
-__arg1 = x140246339372871;
+__arg1 = x140166664134503;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8636,10 +8581,10 @@ goto *jumpTable[co->ctx.pc.label];
 label28:
 {
 Obj x = __arg1;
-Obj x140246339371911 = PRIM_CDR(x);
-Obj x140246339371943 = PRIM_CDR(x140246339371911);
+Obj x140166664133319 = PRIM_CDR(x);
+Obj x140166664133351 = PRIM_CDR(x140166664133319);
 __nargs = 2;
-__arg1 = x140246339371943;
+__arg1 = x140166664133351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8648,10 +8593,10 @@ goto *jumpTable[co->ctx.pc.label];
 label29:
 {
 Obj x = __arg1;
-Obj x140246339371175 = PRIM_CAR(x);
-Obj x140246339371207 = PRIM_CDR(x140246339371175);
+Obj x140166664132423 = PRIM_CAR(x);
+Obj x140166664132455 = PRIM_CDR(x140166664132423);
 __nargs = 2;
-__arg1 = x140246339371207;
+__arg1 = x140166664132455;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8660,10 +8605,10 @@ goto *jumpTable[co->ctx.pc.label];
 label30:
 {
 Obj x = __arg1;
-Obj x140246339624391 = PRIM_CAR(x);
-Obj x140246339624423 = PRIM_CAR(x140246339624391);
+Obj x140166664131495 = PRIM_CAR(x);
+Obj x140166664131527 = PRIM_CAR(x140166664131495);
 __nargs = 2;
-__arg1 = x140246339624423;
+__arg1 = x140166664131527;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8672,10 +8617,10 @@ goto *jumpTable[co->ctx.pc.label];
 label31:
 {
 Obj x = __arg1;
-Obj x140246339623655 = PRIM_CDR(x);
-Obj x140246339623687 = PRIM_CAR(x140246339623655);
+Obj x140166664294311 = PRIM_CDR(x);
+Obj x140166664294343 = PRIM_CAR(x140166664294311);
 __nargs = 2;
-__arg1 = x140246339623687;
+__arg1 = x140166664294343;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8684,9 +8629,9 @@ goto *jumpTable[co->ctx.pc.label];
 label32:
 {
 Obj x = __arg1;
-Obj x140246339622951 = PRIM_EQ(x, Nil);
+Obj x140166664293383 = PRIM_EQ(x, Nil);
 __nargs = 2;
-__arg1 = x140246339622951;
+__arg1 = x140166664293383;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];

--- a/init.c
+++ b/init.c
@@ -6,8 +6,10 @@ static void clofun1(struct Cora* co);
 static void clofun2(struct Cora* co);
 static void clofun3(struct Cora* co);
 static void clofun4(struct Cora* co);
+static void clofun5(struct Cora* co);
 
 
+static Obj symcora_47init_35assq;
 static Obj symcora_47init_35append;
 static Obj symcora_47init_35filter;
 static Obj symcora_47init_35length;
@@ -50,7 +52,6 @@ static Obj symtry;
 static Obj symload;
 static Obj symload_45so;
 static Obj symapply;
-static Obj symvalue_45or;
 static Obj symvalue;
 static Obj symread_45file_45as_45sexp;
 static Obj symbytes_45length;
@@ -59,13 +60,30 @@ static Obj symvector_45length;
 static Obj symvector_45ref;
 static Obj symvector_45set_33;
 static Obj symvector;
-static Obj symsymbol_45_62string;
-static Obj symintern;
-static Obj symstring_45append;
-static Obj symnumber_63;
 static Obj symcora_47init_35_42ns_45export_42;
+static Obj symnumber_63;
+static Obj symcora_47init_35builtin_63;
+static Obj symassq;
+static Obj symstring_63;
+static Obj syminteger_63;
+static Obj symsymbol_63;
+static Obj symgensym;
+static Obj sym_60;
+static Obj sym_62;
+static Obj sym_47;
+static Obj sym_42;
+static Obj sym_45;
+static Obj sym_43;
+static Obj symset;
+static Obj symcora_47init_35_42builtin_45prims_42;
+static Obj symvalue_45or;
+static Obj symcora_47init_35lookup_45var;
+static Obj symsymbol_45_62string;
+static Obj symstring_45append;
+static Obj symintern;
+static Obj symsymbol_45cooked_63;
+static Obj symcora_47init_35var_45with_45ns;
 static Obj sym_42ns_45export_42;
-static Obj symns;
 static Obj symdefine_45library;
 static Obj symcora_47init_35parse_45define_45library;
 static Obj symimport;
@@ -77,6 +95,9 @@ static Obj symcora_47init_35rewrite_45backquote;
 static Obj symbegin;
 static Obj symdo;
 static Obj symcora_47init_35rewrite_45begin;
+static Obj symcora_47init_35parse;
+static Obj symns;
+static Obj symcora_47init_35rewrite_45namespace;
 static Obj symcora_47init_35propagate_45boolean;
 static Obj symnot;
 static Obj symcora_47init_35propagate_45boolean0;
@@ -148,6 +169,7 @@ static Obj symcaar;
 static Obj symcadr;
 static Obj symnull_63;
 void entry(struct Cora *co) {
+symcora_47init_35assq = intern("cora/init#assq");
 symcora_47init_35append = intern("cora/init#append");
 symcora_47init_35filter = intern("cora/init#filter");
 symcora_47init_35length = intern("cora/init#length");
@@ -190,7 +212,6 @@ symtry = intern("try");
 symload = intern("load");
 symload_45so = intern("load-so");
 symapply = intern("apply");
-symvalue_45or = intern("value-or");
 symvalue = intern("value");
 symread_45file_45as_45sexp = intern("read-file-as-sexp");
 symbytes_45length = intern("bytes-length");
@@ -199,13 +220,30 @@ symvector_45length = intern("vector-length");
 symvector_45ref = intern("vector-ref");
 symvector_45set_33 = intern("vector-set!");
 symvector = intern("vector");
-symsymbol_45_62string = intern("symbol->string");
-symintern = intern("intern");
-symstring_45append = intern("string-append");
-symnumber_63 = intern("number?");
 symcora_47init_35_42ns_45export_42 = intern("cora/init#*ns-export*");
+symnumber_63 = intern("number?");
+symcora_47init_35builtin_63 = intern("cora/init#builtin?");
+symassq = intern("assq");
+symstring_63 = intern("string?");
+syminteger_63 = intern("integer?");
+symsymbol_63 = intern("symbol?");
+symgensym = intern("gensym");
+sym_60 = intern("<");
+sym_62 = intern(">");
+sym_47 = intern("/");
+sym_42 = intern("*");
+sym_45 = intern("-");
+sym_43 = intern("+");
+symset = intern("set");
+symcora_47init_35_42builtin_45prims_42 = intern("cora/init#*builtin-prims*");
+symvalue_45or = intern("value-or");
+symcora_47init_35lookup_45var = intern("cora/init#lookup-var");
+symsymbol_45_62string = intern("symbol->string");
+symstring_45append = intern("string-append");
+symintern = intern("intern");
+symsymbol_45cooked_63 = intern("symbol-cooked?");
+symcora_47init_35var_45with_45ns = intern("cora/init#var-with-ns");
 sym_42ns_45export_42 = intern("*ns-export*");
-symns = intern("ns");
 symdefine_45library = intern("define-library");
 symcora_47init_35parse_45define_45library = intern("cora/init#parse-define-library");
 symimport = intern("import");
@@ -217,6 +255,9 @@ symcora_47init_35rewrite_45backquote = intern("cora/init#rewrite-backquote");
 symbegin = intern("begin");
 symdo = intern("do");
 symcora_47init_35rewrite_45begin = intern("cora/init#rewrite-begin");
+symcora_47init_35parse = intern("cora/init#parse");
+symns = intern("ns");
+symcora_47init_35rewrite_45namespace = intern("cora/init#rewrite-namespace");
 symcora_47init_35propagate_45boolean = intern("cora/init#propagate-boolean");
 symnot = intern("not");
 symcora_47init_35propagate_45boolean0 = intern("cora/init#propagate-boolean0");
@@ -302,17 +343,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f41124ebf40 = primSet(co, symnull_63, makeNative(25, clofun4, 1, 0));
-Obj v0x7f41124d9220 = primSet(co, symcadr, makeNative(24, clofun4, 1, 0));
-Obj v0x7f41124d9500 = primSet(co, symcaar, makeNative(23, clofun4, 1, 0));
-Obj v0x7f41124d97e0 = primSet(co, symcdar, makeNative(22, clofun4, 1, 0));
-Obj v0x7f41124d9ac0 = primSet(co, symcddr, makeNative(21, clofun4, 1, 0));
-Obj v0x7f41124d9e60 = primSet(co, symcaddr, makeNative(20, clofun4, 1, 0));
-Obj v0x7f41124cb2c0 = primSet(co, symcadddr, makeNative(19, clofun4, 1, 0));
-Obj v0x7f41124cb660 = primSet(co, symcdddr, makeNative(18, clofun4, 1, 0));
-Obj v0x7f41124cbda0 = primSet(co, symrcons, makeNative(16, clofun4, 1, 0));
-Obj v0x7f4112570020 = primSet(co, sympair_63, makeNative(15, clofun4, 1, 0));
-Obj v0x7f41125705a0 = primSet(co, symcora_47init_35reverse_45h, makeNative(14, clofun4, 2, 0));
+Obj x140246339622983 = primSet(co, symnull_63, makeNative(32, clofun5, 1, 0));
+Obj x140246339623719 = primSet(co, symcadr, makeNative(31, clofun5, 1, 0));
+Obj x140246339624455 = primSet(co, symcaar, makeNative(30, clofun5, 1, 0));
+Obj x140246339371239 = primSet(co, symcdar, makeNative(29, clofun5, 1, 0));
+Obj x140246339371975 = primSet(co, symcddr, makeNative(28, clofun5, 1, 0));
+Obj x140246339372903 = primSet(co, symcaddr, makeNative(27, clofun5, 1, 0));
+Obj x140246339374023 = primSet(co, symcadddr, makeNative(26, clofun5, 1, 0));
+Obj x140246339374951 = primSet(co, symcdddr, makeNative(25, clofun5, 1, 0));
+Obj x140246339319463 = primSet(co, symrcons, makeNative(23, clofun5, 1, 0));
+Obj x140246339320007 = primSet(co, sympair_63, makeNative(22, clofun5, 1, 0));
+Obj x140246339321415 = primSet(co, symcora_47init_35reverse_45h, makeNative(21, clofun5, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
@@ -326,19 +367,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f4112570760 = __arg1;
-Obj v0x7f4112570780 = primSet(co, symreverse, v0x7f4112570760);
-Obj v0x7f4112570e80 = primSet(co, symmap_45h, makeNative(12, clofun4, 3, 0));
-Obj v0x7f41125630c0 = primSet(co, symmap, makeNative(11, clofun4, 2, 0));
-Obj v0x7f41125631e0 = primSet(co, sym_42macros_42, Nil);
-Obj v0x7f4112563380 = primGenSym();
-Obj v0x7f41125633a0 = primSet(co, sym_42protect_45symbol_42, v0x7f4112563380);
-Obj v0x7f41125637a0 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(10, clofun4, 2, 0));
-Obj v0x7f411252cb60 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(8, clofun4, 2, 0));
-Obj v0x7f411252ce00 = primSet(co, symcora_47init_35macroexpand1, makeNative(7, clofun4, 1, 0));
-Obj v0x7f4112512500 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(1, clofun4, 1, 0));
-Obj v0x7f4112512620 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj v0x7f4112512fe0 = primSet(co, symdefmacro_45macro, makeNative(47, clofun3, 1, 0));
+Obj x140246338969639 = __arg1;
+Obj x140246338969703 = primSet(co, symreverse, x140246338969639);
+Obj x140246338972327 = primSet(co, symmap_45h, makeNative(19, clofun5, 3, 0));
+Obj x140246338973031 = primSet(co, symmap, makeNative(18, clofun5, 2, 0));
+Obj x140246338973383 = primSet(co, sym_42macros_42, Nil);
+Obj x140246338949543 = primGenSym();
+Obj x140246338949607 = primSet(co, sym_42protect_45symbol_42, x140246338949543);
+Obj x140246338950855 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(17, clofun5, 2, 0));
+Obj x140246338824519 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(15, clofun5, 2, 0));
+Obj x140246338825063 = primSet(co, symcora_47init_35macroexpand1, makeNative(14, clofun5, 1, 0));
+Obj x140246338702727 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(8, clofun5, 1, 0));
+Obj x140246338703015 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
+Obj x140246338627719 = primSet(co, symdefmacro_45macro, makeNative(4, clofun5, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -353,12 +394,12 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f41124eb100 = __arg1;
+Obj x140246338628007 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlist;
-__arg2 = makeNative(46, clofun3, 1, 0);
+__arg2 = makeNative(3, clofun5, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -368,12 +409,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41124eb3c0 = __arg1;
+Obj x140246338628711 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symdefun;
-__arg2 = makeNative(42, clofun3, 1, 0);
+__arg2 = makeNative(49, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -383,15 +424,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41124ebca0 = __arg1;
-Obj v0x7f41124d9300 = primSet(co, symelem_63, makeNative(41, clofun3, 2, 0));
-Obj v0x7f41124d9640 = primSet(co, symatom_63, makeNative(40, clofun3, 1, 0));
-Obj v0x7f41124cb200 = primSet(co, symcora_47init_35rewrite_45let, makeNative(35, clofun3, 1, 0));
+Obj x140246338602311 = __arg1;
+Obj x140246338603783 = primSet(co, symelem_63, makeNative(48, clofun4, 2, 0));
+Obj x140246338551975 = primSet(co, symatom_63, makeNative(47, clofun4, 1, 0));
+Obj x140246339748807 = primSet(co, symcora_47init_35rewrite_45let, makeNative(42, clofun4, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlet;
-__arg2 = makeNative(34, clofun3, 1, 0);
+__arg2 = makeNative(41, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -401,12 +442,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41124c41e0 = __arg1;
+Obj x140246339749511 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symcond;
-__arg2 = makeNative(30, clofun3, 1, 0);
+__arg2 = makeNative(37, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -416,13 +457,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f41124c4e80 = __arg1;
-Obj v0x7f41124ada00 = primSet(co, symcora_47init_35rewrite_45or, makeNative(28, clofun3, 1, 0));
+Obj x140246339711783 = __arg1;
+Obj x140246339714727 = primSet(co, symcora_47init_35rewrite_45or, makeNative(35, clofun4, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symor;
-__arg2 = makeNative(27, clofun3, 1, 0);
+__arg2 = makeNative(34, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -432,13 +473,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f41124adcc0 = __arg1;
-Obj v0x7f411248c840 = primSet(co, symcora_47init_35rewrite_45and, makeNative(25, clofun3, 1, 0));
+Obj x140246339621223 = __arg1;
+Obj x140246339624327 = primSet(co, symcora_47init_35rewrite_45and, makeNative(32, clofun4, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symand;
-__arg2 = makeNative(24, clofun3, 1, 0);
+__arg2 = makeNative(31, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -448,14 +489,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f411248cb00 = __arg1;
-Obj v0x7f4112570220 = primSet(co, symboolean_63, makeNative(23, clofun3, 1, 0));
-Obj v0x7f4112570be0 = primSet(co, symcora_47init_35rcons1, makeNative(20, clofun3, 1, 0));
+Obj x140246339371271 = __arg1;
+Obj x140246339372295 = primSet(co, symboolean_63, makeNative(30, clofun4, 1, 0));
+Obj x140246339374823 = primSet(co, symcora_47init_35rcons1, makeNative(27, clofun4, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlist_45rest;
-__arg2 = makeNative(19, clofun3, 1, 0);
+__arg2 = makeNative(26, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -465,17 +506,17 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f4112570f40 = __arg1;
-Obj v0x7f41124eb560 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(1, clofun3, 4, 0));
-Obj v0x7f41124cbea0 = primSet(co, symcora_47init_35match1, makeNative(45, clofun2, 4, 0));
-Obj v0x7f41124ad960 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(37, clofun2, 2, 0));
-Obj v0x7f4112570280 = primSet(co, symcora_47init_35match_45helper, makeNative(21, clofun2, 2, 0));
-Obj v0x7f411252c4a0 = primSet(co, symcora_47init_35rewrite_45match, makeNative(14, clofun2, 1, 0));
+Obj x140246339318343 = __arg1;
+Obj x140246338701447 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(8, clofun4, 4, 0));
+Obj x140246338552135 = primSet(co, symcora_47init_35match1, makeNative(2, clofun4, 4, 0));
+Obj x140246338497895 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(44, clofun3, 2, 0));
+Obj x140246339750119 = primSet(co, symcora_47init_35match_45helper, makeNative(28, clofun3, 2, 0));
+Obj x140246339622599 = primSet(co, symcora_47init_35rewrite_45match, makeNative(21, clofun3, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symmatch;
-__arg2 = makeNative(13, clofun2, 1, 0);
+__arg2 = makeNative(20, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -485,22 +526,22 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f411252c820 = __arg1;
-Obj v0x7f41124cbd20 = primSet(co, symcora_47init_35extract_45rules1, makeNative(6, clofun2, 3, 0));
-Obj v0x7f41124c4020 = primSet(co, symcora_47init_35extract_45rules, makeNative(5, clofun2, 1, 0));
-Obj v0x7f41124c47e0 = primSet(co, symcora_47init_35rules_45patterns, makeNative(2, clofun2, 2, 0));
-Obj v0x7f41124c4ea0 = primSet(co, symcora_47init_35length_45h, makeNative(1, clofun2, 2, 0));
-Obj v0x7f41124ad120 = primSet(co, symlength, makeNative(0, clofun2, 1, 0));
-Obj v0x7f41124ade60 = primSet(co, symcora_47init_35filter_45h, makeNative(48, clofun1, 3, 0));
-Obj v0x7f411248c120 = primSet(co, symfilter, makeNative(47, clofun1, 2, 0));
-Obj v0x7f411248c8e0 = primSet(co, symappend, makeNative(45, clofun1, 2, 0));
-Obj v0x7f411248a760 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(38, clofun1, 1, 0));
-Obj v0x7f411248ada0 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(36, clofun1, 1, 0));
+Obj x140246339623271 = __arg1;
+Obj x140246338825255 = primSet(co, symcora_47init_35extract_45rules1, makeNative(13, clofun3, 3, 0));
+Obj x140246338825959 = primSet(co, symcora_47init_35extract_45rules, makeNative(12, clofun3, 1, 0));
+Obj x140246338701063 = primSet(co, symcora_47init_35rules_45patterns, makeNative(9, clofun3, 2, 0));
+Obj x140246338702855 = primSet(co, symcora_47init_35length_45h, makeNative(8, clofun3, 2, 0));
+Obj x140246338625671 = primSet(co, symlength, makeNative(7, clofun3, 1, 0));
+Obj x140246338629031 = primSet(co, symcora_47init_35filter_45h, makeNative(5, clofun3, 3, 0));
+Obj x140246338601063 = primSet(co, symfilter, makeNative(4, clofun3, 2, 0));
+Obj x140246338602951 = primSet(co, symappend, makeNative(2, clofun3, 2, 0));
+Obj x140246338554567 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(45, clofun2, 1, 0));
+Obj x140246338494727 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(43, clofun2, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symfunc;
-__arg2 = makeNative(30, clofun1, 1, 0);
+__arg2 = makeNative(37, clofun2, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -510,16 +551,17 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f4112485060 = __arg1;
-Obj v0x7f4112563280 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(18, clofun1, 1, 0));
-Obj v0x7f41125cfaa0 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(45, clofun0, 1, 0));
-Obj v0x7f41125cfd60 = primSet(co, symmacroexpand, makeNative(43, clofun0, 1, 0));
-Obj v0x7f41125d68e0 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(38, clofun0, 1, 0));
+Obj x140246338498407 = __arg1;
+Obj x140246338168039 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(25, clofun2, 1, 0));
+Obj x140246338495975 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(2, clofun2, 1, 0));
+Obj x140246338449831 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(1, clofun2, 1, 0));
+Obj x140246338451047 = primSet(co, symmacroexpand, makeNative(48, clofun1, 1, 0));
+Obj x140246338252295 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(43, clofun1, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symbegin;
-__arg2 = makeNative(37, clofun0, 1, 0);
+__arg2 = makeNative(42, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -529,13 +571,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f41125d6ba0 = __arg1;
-Obj v0x7f41125cfa20 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(31, clofun0, 1, 0));
+Obj x140246338228743 = __arg1;
+Obj x140246338166887 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(36, clofun1, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symbackquote;
-__arg2 = makeNative(29, clofun0, 1, 0);
+__arg2 = makeNative(34, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -545,14 +587,14 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f41125cfd00 = __arg1;
-Obj v0x7f41125c0860 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(24, clofun0, 4, 0));
-Obj v0x7f41125c0c00 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(23, clofun0, 2, 0));
+Obj x140246338167591 = __arg1;
+Obj x140246337888199 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(29, clofun1, 4, 0));
+Obj x140246339850791 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(28, clofun1, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symdefine_45library;
-__arg2 = makeNative(15, clofun0, 1, 0);
+__arg2 = makeNative(20, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -562,84 +604,159 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f4112563d40 = __arg1;
-Obj v0x7f41124ebae0 = makeCons(symappend, Nil);
-Obj v0x7f41124ebb00 = makeCons(symfilter, v0x7f41124ebae0);
-Obj v0x7f41124ebb40 = makeCons(symlength, v0x7f41124ebb00);
-Obj v0x7f41124ebb60 = makeCons(symelem_63, v0x7f41124ebb40);
-Obj v0x7f41124ebba0 = makeCons(symmacroexpand, v0x7f41124ebb60);
-Obj v0x7f41124ebdc0 = makeCons(symmap, v0x7f41124ebba0);
-Obj v0x7f41124ebde0 = makeCons(symreverse, v0x7f41124ebdc0);
-Obj v0x7f41124ebe00 = makeCons(symthrow, v0x7f41124ebde0);
-Obj v0x7f41124ebe20 = makeCons(symtry, v0x7f41124ebe00);
-Obj v0x7f41124ebe40 = makeCons(symload, v0x7f41124ebe20);
-Obj v0x7f41124ebe60 = makeCons(symimport, v0x7f41124ebe40);
-Obj v0x7f41124ebe80 = makeCons(symload_45so, v0x7f41124ebe60);
-Obj v0x7f41124ebea0 = makeCons(symapply, v0x7f41124ebe80);
-Obj v0x7f41124ebec0 = makeCons(symvalue_45or, v0x7f41124ebea0);
-Obj v0x7f41124ebf00 = makeCons(symvalue, v0x7f41124ebec0);
-Obj v0x7f41124ebf60 = makeCons(symread_45file_45as_45sexp, v0x7f41124ebf00);
-Obj v0x7f41124ebfc0 = makeCons(symbytes_45length, v0x7f41124ebf60);
-Obj v0x7f41124ebfe0 = makeCons(symbytes, v0x7f41124ebfc0);
-Obj v0x7f41124d9000 = makeCons(symvector_45length, v0x7f41124ebfe0);
-Obj v0x7f41124d9020 = makeCons(symvector_45ref, v0x7f41124d9000);
-Obj v0x7f41124d9040 = makeCons(symvector_45set_33, v0x7f41124d9020);
-Obj v0x7f41124d9060 = makeCons(symvector, v0x7f41124d9040);
-Obj v0x7f41124d9260 = makeCons(symsymbol_45_62string, v0x7f41124d9060);
-Obj v0x7f41124d9280 = makeCons(symintern, v0x7f41124d9260);
-Obj v0x7f41124d92a0 = makeCons(symstring_45append, v0x7f41124d9280);
-Obj v0x7f41124d92c0 = makeCons(symnull_63, v0x7f41124d92a0);
-Obj v0x7f41124d9320 = makeCons(symnumber_63, v0x7f41124d92c0);
-Obj v0x7f41124d9340 = makeCons(symboolean_63, v0x7f41124d9320);
-Obj v0x7f41124d9360 = makeCons(symatom_63, v0x7f41124d9340);
-Obj v0x7f41124d9380 = makeCons(sympair_63, v0x7f41124d9360);
-Obj v0x7f41124d9400 = makeCons(symcdddr, v0x7f41124d9380);
-Obj v0x7f41124d9420 = makeCons(symcadddr, v0x7f41124d9400);
-Obj v0x7f41124d9440 = makeCons(symcaddr, v0x7f41124d9420);
-Obj v0x7f41124d9460 = makeCons(symcddr, v0x7f41124d9440);
-Obj v0x7f41124d9480 = makeCons(symcdar, v0x7f41124d9460);
-Obj v0x7f41124d94a0 = makeCons(symcaar, v0x7f41124d9480);
-Obj v0x7f41124d9520 = makeCons(symcadr, v0x7f41124d94a0);
-Obj v0x7f41124d9560 = primSet(co, symcora_47init_35_42ns_45export_42, v0x7f41124d9520);
-Obj v0x7f41124d98c0 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj v0x7f41124d9c20 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj v0x7f41124d9ec0 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj v0x7f41124cb0c0 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj v0x7f41124cb360 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj v0x7f41124cb700 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj v0x7f41124cb8e0 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj v0x7f41124cba00 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj v0x7f41124cbde0 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj v0x7f41124cbf60 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj v0x7f41124c4160 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj v0x7f41124c4340 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj v0x7f41124c4460 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj v0x7f41124c4840 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj v0x7f41124c4980 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj v0x7f41124c4c00 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj v0x7f41124c4d40 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj v0x7f41124c4fc0 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj v0x7f41124ad180 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj v0x7f41124ad3e0 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj v0x7f41124ad580 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj v0x7f41124ad7a0 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj v0x7f41124adac0 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj v0x7f41124adc80 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj v0x7f41124adee0 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj v0x7f411248c140 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj v0x7f411248c300 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj v0x7f411248c480 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj v0x7f411248c640 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj v0x7f411248c940 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj v0x7f411248cac0 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj v0x7f411248ccc0 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj v0x7f411248cea0 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj v0x7f411248a000 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj v0x7f411248a300 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj v0x7f411248a440 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj v0x7f411248a560 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj x140246339859751 = __arg1;
+Obj x140246339861447 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(15, clofun1, 2, 0));
+Obj x140246339873767 = primSet(co, symcora_47init_35lookup_45var, makeNative(5, clofun1, 3, 0));
+Obj x140246339874791 = makeCons(makeCString("primSet"), Nil);
+Obj x140246339858439 = makeCons(MAKE_NUMBER(2), x140246339874791);
+Obj x140246339858471 = makeCons(symset, x140246339858439);
+Obj x140246339859335 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x140246339859463 = makeCons(MAKE_NUMBER(1), x140246339859335);
+Obj x140246339859591 = makeCons(symcar, x140246339859463);
+Obj x140246339860583 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x140246339860647 = makeCons(MAKE_NUMBER(1), x140246339860583);
+Obj x140246339860679 = makeCons(symcdr, x140246339860647);
+Obj x140246339861607 = makeCons(makeCString("makeCons"), Nil);
+Obj x140246339861639 = makeCons(MAKE_NUMBER(2), x140246339861607);
+Obj x140246339861671 = makeCons(symcons, x140246339861639);
+Obj x140246339862471 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x140246339862503 = makeCons(MAKE_NUMBER(1), x140246339862471);
+Obj x140246339850247 = makeCons(symcons_63, x140246339862503);
+Obj x140246339851079 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x140246339851111 = makeCons(MAKE_NUMBER(2), x140246339851079);
+Obj x140246339851143 = makeCons(sym_43, x140246339851111);
+Obj x140246339852039 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x140246339852071 = makeCons(MAKE_NUMBER(2), x140246339852039);
+Obj x140246339852103 = makeCons(sym_45, x140246339852071);
+Obj x140246339852935 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x140246339852967 = makeCons(MAKE_NUMBER(2), x140246339852935);
+Obj x140246339852999 = makeCons(sym_42, x140246339852967);
+Obj x140246339853799 = makeCons(makeCString("primDiv"), Nil);
+Obj x140246339853831 = makeCons(MAKE_NUMBER(2), x140246339853799);
+Obj x140246339853863 = makeCons(sym_47, x140246339853831);
+Obj x140246339789223 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x140246339789255 = makeCons(MAKE_NUMBER(2), x140246339789223);
+Obj x140246339789287 = makeCons(sym_61, x140246339789255);
+Obj x140246339790279 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x140246339790311 = makeCons(MAKE_NUMBER(2), x140246339790279);
+Obj x140246339790343 = makeCons(sym_62, x140246339790311);
+Obj x140246339791399 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x140246339791431 = makeCons(MAKE_NUMBER(2), x140246339791399);
+Obj x140246339791463 = makeCons(sym_60, x140246339791431);
+Obj x140246339792263 = makeCons(makeCString("primGenSym"), Nil);
+Obj x140246339792455 = makeCons(MAKE_NUMBER(0), x140246339792263);
+Obj x140246339792487 = makeCons(symgensym, x140246339792455);
+Obj x140246339748455 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x140246339748487 = makeCons(MAKE_NUMBER(1), x140246339748455);
+Obj x140246339748519 = makeCons(symsymbol_63, x140246339748487);
+Obj x140246339750151 = makeCons(makeCString("primNot"), Nil);
+Obj x140246339750183 = makeCons(MAKE_NUMBER(1), x140246339750151);
+Obj x140246339750215 = makeCons(symnot, x140246339750183);
+Obj x140246339751367 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x140246339751431 = makeCons(MAKE_NUMBER(1), x140246339751367);
+Obj x140246339751463 = makeCons(syminteger_63, x140246339751431);
+Obj x140246339711975 = makeCons(makeCString("primIsString"), Nil);
+Obj x140246339712007 = makeCons(MAKE_NUMBER(1), x140246339711975);
+Obj x140246339712039 = makeCons(symstring_63, x140246339712007);
+Obj x140246339712135 = makeCons(x140246339712039, Nil);
+Obj x140246339712167 = makeCons(x140246339751463, x140246339712135);
+Obj x140246339712199 = makeCons(x140246339750215, x140246339712167);
+Obj x140246339712231 = makeCons(x140246339748519, x140246339712199);
+Obj x140246339712263 = makeCons(x140246339792487, x140246339712231);
+Obj x140246339712295 = makeCons(x140246339791463, x140246339712263);
+Obj x140246339712327 = makeCons(x140246339790343, x140246339712295);
+Obj x140246339712455 = makeCons(x140246339789287, x140246339712327);
+Obj x140246339712487 = makeCons(x140246339853863, x140246339712455);
+Obj x140246339712519 = makeCons(x140246339852999, x140246339712487);
+Obj x140246339712551 = makeCons(x140246339852103, x140246339712519);
+Obj x140246339712647 = makeCons(x140246339851143, x140246339712551);
+Obj x140246339712679 = makeCons(x140246339850247, x140246339712647);
+Obj x140246339712711 = makeCons(x140246339861671, x140246339712679);
+Obj x140246339712743 = makeCons(x140246339860679, x140246339712711);
+Obj x140246339712775 = makeCons(x140246339859591, x140246339712743);
+Obj x140246339712839 = makeCons(x140246339858471, x140246339712775);
+Obj x140246339712935 = primSet(co, symcora_47init_35_42builtin_45prims_42, x140246339712839);
+Obj x140246339374503 = primSet(co, symassq, makeNative(1, clofun1, 2, 0));
+Obj x140246339319015 = primSet(co, symcora_47init_35builtin_63, makeNative(48, clofun0, 1, 0));
+Obj x140246339960615 = primSet(co, symcora_47init_35parse, makeNative(15, clofun0, 4, 0));
+Obj x140246339988231 = makeCons(symappend, Nil);
+Obj x140246339988263 = makeCons(symfilter, x140246339988231);
+Obj x140246339988295 = makeCons(symlength, x140246339988263);
+Obj x140246339988327 = makeCons(symelem_63, x140246339988295);
+Obj x140246339988359 = makeCons(symmacroexpand, x140246339988327);
+Obj x140246339988391 = makeCons(symmap, x140246339988359);
+Obj x140246339988423 = makeCons(symreverse, x140246339988391);
+Obj x140246339988455 = makeCons(symthrow, x140246339988423);
+Obj x140246339988487 = makeCons(symtry, x140246339988455);
+Obj x140246339988519 = makeCons(symload, x140246339988487);
+Obj x140246339988551 = makeCons(symimport, x140246339988519);
+Obj x140246339988583 = makeCons(symload_45so, x140246339988551);
+Obj x140246339988615 = makeCons(symapply, x140246339988583);
+Obj x140246339988647 = makeCons(symvalue_45or, x140246339988615);
+Obj x140246339988679 = makeCons(symvalue, x140246339988647);
+Obj x140246339988711 = makeCons(symread_45file_45as_45sexp, x140246339988679);
+Obj x140246339988743 = makeCons(symbytes_45length, x140246339988711);
+Obj x140246339988775 = makeCons(symbytes, x140246339988743);
+Obj x140246339988807 = makeCons(symvector_45length, x140246339988775);
+Obj x140246339988839 = makeCons(symvector_45ref, x140246339988807);
+Obj x140246339988871 = makeCons(symvector_45set_33, x140246339988839);
+Obj x140246339988903 = makeCons(symvector, x140246339988871);
+Obj x140246339988935 = makeCons(symsymbol_45_62string, x140246339988903);
+Obj x140246339988967 = makeCons(symintern, x140246339988935);
+Obj x140246339988999 = makeCons(symstring_45append, x140246339988967);
+Obj x140246339989031 = makeCons(symnull_63, x140246339988999);
+Obj x140246339989063 = makeCons(symnumber_63, x140246339989031);
+Obj x140246339989095 = makeCons(symboolean_63, x140246339989063);
+Obj x140246339989127 = makeCons(symatom_63, x140246339989095);
+Obj x140246339989159 = makeCons(sympair_63, x140246339989127);
+Obj x140246339989191 = makeCons(symcdddr, x140246339989159);
+Obj x140246339989223 = makeCons(symcadddr, x140246339989191);
+Obj x140246339989255 = makeCons(symcaddr, x140246339989223);
+Obj x140246339989287 = makeCons(symcddr, x140246339989255);
+Obj x140246339989319 = makeCons(symcdar, x140246339989287);
+Obj x140246339989351 = makeCons(symcaar, x140246339989319);
+Obj x140246339989383 = makeCons(symcadr, x140246339989351);
+Obj x140246339989415 = primSet(co, symcora_47init_35_42ns_45export_42, x140246339989383);
+Obj x140246339956999 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
+Obj x140246339957287 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
+Obj x140246339957671 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
+Obj x140246339957959 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
+Obj x140246339958311 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
+Obj x140246339958599 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
+Obj x140246339958887 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
+Obj x140246339959207 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
+Obj x140246339959495 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
+Obj x140246339959815 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
+Obj x140246339960135 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
+Obj x140246339960455 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
+Obj x140246339960775 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
+Obj x140246339940583 = primSet(co, symcora_47init_35intern, globalRef(symintern));
+Obj x140246339940903 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
+Obj x140246339941319 = primSet(co, symcora_47init_35vector, globalRef(symvector));
+Obj x140246339941607 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
+Obj x140246339941895 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
+Obj x140246339942183 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
+Obj x140246339942535 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
+Obj x140246339942823 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
+Obj x140246339943111 = primSet(co, symcora_47init_35value, globalRef(symvalue));
+Obj x140246339943431 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
+Obj x140246339943719 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
+Obj x140246339944071 = primSet(co, symcora_47init_35apply, globalRef(symapply));
+Obj x140246339944423 = primSet(co, symcora_47init_35load, globalRef(symload));
+Obj x140246339928359 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
+Obj x140246339928711 = primSet(co, symcora_47init_35import, globalRef(symimport));
+Obj x140246339928999 = primSet(co, symcora_47init_35try, globalRef(symtry));
+Obj x140246339929351 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
+Obj x140246339929703 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
+Obj x140246339929991 = primSet(co, symcora_47init_35map, globalRef(symmap));
+Obj x140246339930375 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
+Obj x140246339930663 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
+Obj x140246339931047 = primSet(co, symcora_47init_35length, globalRef(symlength));
+Obj x140246339931335 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
+Obj x140246339931751 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj x140246339931975 = primSet(co, symcora_47init_35assq, globalRef(symassq));
 __nargs = 2;
-__arg1 = v0x7f411248a560;
+__arg1 = x140246339931975;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -647,11 +764,19 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj sexp = __arg1;
-pushCont(co, 16, clofun0, 1, sexp);
+Obj x140246338949383 = __arg1;
+Obj x140246338949415 = __arg2;
+Obj x140246338949447 = __arg3;
+Obj x140246338949479 = co->args[4];
+Obj x140246338949831 = makeNative(19, clofun0, 0, 4, x140246338949383, x140246338949415, x140246338949447, x140246338949479);
+Obj __ = x140246338949383;
+__ = x140246338949415;
+__ = x140246338949447;
+Obj x = x140246338949479;
+pushCont(co, 16, clofun0, 2, x, x140246338949831);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = sexp;
+__arg0 = globalRef(symnumber_63);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -661,129 +786,354 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f41125c0fa0 = __arg1;
-Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = v0x7f41125c0fa0;
-pushCont(co, 17, clofun0, 1, path);
+Obj x140246339959175 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246339959175) {
+if (True == True) {
 __nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = sexp;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+Obj x140246339959559 = primIsString(x);
+if (True == x140246339959559) {
+if (True == True) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 17, clofun0, 2, x, x140246338949831);
+__nargs = 2;
+__arg0 = globalRef(symboolean_63);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label17:
 {
-Obj v0x7f4112570320 = __arg1;
-Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 18, clofun0, 1, path);
+Obj x140246339959943 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246339959943) {
+if (True == True) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35parse_45define_45library);
-__arg1 = v0x7f4112570320;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 18, clofun0, 2, x, x140246338949831);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label18:
 {
-Obj v0x7f4112570340 = __arg1;
-Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339960327 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338949831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246339960327) {
+if (True == True) {
 __nargs = 2;
-__arg0 = v0x7f4112570340;
-__arg1 = makeNative(19, clofun0, 3, 1, path);
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label19:
 {
-Obj import = __arg1;
-Obj export = __arg2;
-Obj body = __arg3;
-Obj v0x7f4112570940 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 20, clofun0, 3, export, body, v0x7f4112570940);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = makeNative(22, clofun0, 1, 0);
-__arg2 = import;
+Obj x140246338950535 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj __ = closureRef(co, 0);
+__ = closureRef(co, 1);
+__ = closureRef(co, 2);
+Obj x140246339943303 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246339943303) {
+Obj x140246339943751 = PRIM_CAR(closureRef(co, 3));
+Obj x140246339943783 = PRIM_EQ(symquote, x140246339943751);
+if (True == x140246339943783) {
+Obj x140246339944199 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339944231 = PRIM_ISCONS(x140246339944199);
+if (True == x140246339944231) {
+Obj x140246339956935 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339956967 = PRIM_CAR(x140246339956935);
+Obj x = x140246339956967;
+Obj x140246339957575 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339957607 = PRIM_CDR(x140246339957575);
+Obj x140246339957639 = PRIM_EQ(Nil, x140246339957607);
+if (True == x140246339957639) {
+Obj x140246339958055 = makeCons(x, Nil);
+Obj x140246339958087 = makeCons(symquote, x140246339958055);
+__nargs = 2;
+__arg1 = x140246339958087;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338950535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label20:
 {
-Obj v0x7f4112563220 = __arg1;
-Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112570940= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125639c0 = makeCons(export, Nil);
-Obj v0x7f4112563a20 = makeCons(symbackquote, v0x7f41125639c0);
-Obj v0x7f4112563b00 = makeCons(v0x7f4112563a20, Nil);
-Obj v0x7f4112563b20 = makeCons(sym_42ns_45export_42, v0x7f4112563b00);
-Obj v0x7f4112563b40 = makeCons(symdef, v0x7f4112563b20);
-Obj v0x7f4112563b80 = makeCons(v0x7f4112563b40, body);
-pushCont(co, 21, clofun0, 1, v0x7f4112570940);
+Obj x140246338951495 = makeNative(22, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x = closureRef(co, 3);
+Obj x140246339942215 = primIsSymbol(x);
+if (True == x140246339942215) {
+pushCont(co, 21, clofun0, 3, x, ns, import);
 __nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = v0x7f4112563220;
-__arg2 = v0x7f4112563b80;
+__arg0 = globalRef(symelem_63);
+__arg1 = x;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338951495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label21:
 {
-Obj v0x7f4112563c40 = __arg1;
-Obj v0x7f4112570940= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112563c60 = makeCons(symbegin, v0x7f4112563c40);
-Obj v0x7f4112563cc0 = makeCons(v0x7f4112563c60, Nil);
-Obj v0x7f4112563ce0 = makeCons(v0x7f4112570940, v0x7f4112563cc0);
-Obj v0x7f4112563d00 = makeCons(closureRef(co, 0), v0x7f4112563ce0);
-Obj v0x7f4112563d20 = makeCons(symns, v0x7f4112563d00);
+Obj x140246339942503 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140246339942503) {
 __nargs = 2;
-__arg1 = v0x7f4112563d20;
+__arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35lookup_45var);
+__arg1 = x;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label22:
 {
-Obj imp = __arg1;
-Obj v0x7f4112563180 = makeCons(imp, Nil);
-Obj v0x7f41125631c0 = makeCons(symimport, v0x7f4112563180);
-__nargs = 2;
-__arg1 = v0x7f41125631c0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140246338952167 = makeNative(25, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x140246339928167 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246339928167) {
+Obj x140246339928615 = PRIM_CAR(closureRef(co, 3));
+Obj x140246339928647 = PRIM_EQ(symlambda, x140246339928615);
+if (True == x140246339928647) {
+Obj x140246339929063 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339929095 = PRIM_ISCONS(x140246339929063);
+if (True == x140246339929095) {
+Obj x140246339929511 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339929543 = PRIM_CAR(x140246339929511);
+Obj args = x140246339929543;
+Obj x140246339930119 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339930151 = PRIM_CDR(x140246339930119);
+Obj x140246339930183 = PRIM_ISCONS(x140246339930151);
+if (True == x140246339930183) {
+Obj x140246339930759 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339930791 = PRIM_CDR(x140246339930759);
+Obj x140246339930823 = PRIM_CAR(x140246339930791);
+Obj body = x140246339930823;
+Obj x140246339931591 = PRIM_CDR(closureRef(co, 3));
+Obj x140246339931623 = PRIM_CDR(x140246339931591);
+Obj x140246339931655 = PRIM_CDR(x140246339931623);
+Obj x140246339931687 = PRIM_EQ(Nil, x140246339931655);
+if (True == x140246339931687) {
+pushCont(co, 23, clofun0, 4, ns, import, body, args);
+__nargs = 3;
+__arg0 = globalRef(symappend);
+__arg1 = args;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338952167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338952167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338952167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338952167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338952167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label23:
 {
-Obj data = __arg1;
-Obj k = __arg2;
+Obj x140246339940807 = __arg1;
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 24, clofun0, 1, args);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
-__arg1 = data;
-__arg2 = Nil;
-__arg3 = Nil;
-co->args[4] = k;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = x140246339940807;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -793,123 +1143,81 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f411252cfe0 = __arg1;
-Obj v0x7f4112529000 = __arg2;
-Obj v0x7f4112529020 = __arg3;
-Obj v0x7f4112529060 = co->args[4];
-Obj v0x7f41125291c0 = makeNative(25, clofun0, 0, 4, v0x7f411252cfe0, v0x7f4112529000, v0x7f4112529020, v0x7f4112529060);
-Obj v0x7f41125c1160 = PRIM_ISCONS(v0x7f411252cfe0);
-if (True == v0x7f41125c1160) {
-Obj v0x7f41125c13a0 = PRIM_CAR(v0x7f411252cfe0);
-Obj v0x7f41125c13c0 = PRIM_ISCONS(v0x7f41125c13a0);
-if (True == v0x7f41125c13c0) {
-Obj v0x7f41125c1620 = PRIM_CAR(v0x7f411252cfe0);
-Obj v0x7f41125c1640 = PRIM_CAR(v0x7f41125c1620);
-Obj v0x7f41125c1660 = PRIM_EQ(symimport, v0x7f41125c1640);
-if (True == v0x7f41125c1660) {
-Obj v0x7f41125c1900 = PRIM_CAR(v0x7f411252cfe0);
-Obj v0x7f41125c1920 = PRIM_CDR(v0x7f41125c1900);
-Obj v0x7f41125c1940 = PRIM_ISCONS(v0x7f41125c1920);
-if (True == v0x7f41125c1940) {
-Obj v0x7f41125c1be0 = PRIM_CAR(v0x7f411252cfe0);
-Obj v0x7f41125c1c00 = PRIM_CDR(v0x7f41125c1be0);
-Obj v0x7f41125c1c20 = PRIM_CAR(v0x7f41125c1c00);
-Obj lib = v0x7f41125c1c20;
-Obj v0x7f41125c1fa0 = PRIM_CAR(v0x7f411252cfe0);
-Obj v0x7f41125c1fc0 = PRIM_CDR(v0x7f41125c1fa0);
-Obj v0x7f41125c1fe0 = PRIM_CDR(v0x7f41125c1fc0);
-Obj v0x7f41125c0000 = PRIM_EQ(Nil, v0x7f41125c1fe0);
-if (True == v0x7f41125c0000) {
-Obj v0x7f41125c0100 = PRIM_CDR(v0x7f411252cfe0);
-Obj rest = v0x7f41125c0100;
-Obj imports = v0x7f4112529000;
-Obj exports = v0x7f4112529020;
-Obj k = v0x7f4112529060;
-Obj v0x7f41125c0460 = makeCons(lib, imports);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
-__arg1 = rest;
-__arg2 = v0x7f41125c0460;
-__arg3 = exports;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125291c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125291c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125291c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125291c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125291c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x140246339940935 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339940999 = makeCons(x140246339940935, Nil);
+Obj x140246339941031 = makeCons(args, x140246339940999);
+Obj x140246339941063 = makeCons(symlambda, x140246339941031);
+__nargs = 2;
+__arg1 = x140246339941063;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label25:
 {
-Obj v0x7f411252c580 = makeNative(26, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41125cd4e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cd4e0) {
-Obj v0x7f41125cd6c0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cd6e0 = PRIM_ISCONS(v0x7f41125cd6c0);
-if (True == v0x7f41125cd6e0) {
-Obj v0x7f41125cd9c0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cd9e0 = PRIM_CAR(v0x7f41125cd9c0);
-Obj v0x7f41125cda00 = PRIM_EQ(symexport, v0x7f41125cd9e0);
-if (True == v0x7f41125cda00) {
-Obj v0x7f41125cdbe0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cdc00 = PRIM_CDR(v0x7f41125cdbe0);
-Obj more = v0x7f41125cdc00;
-Obj v0x7f41125cdd00 = PRIM_CDR(closureRef(co, 0));
-Obj rest = v0x7f41125cdd00;
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
+Obj x140246338822279 = makeNative(28, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x140246338205447 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246338205447) {
+Obj x140246338206023 = PRIM_CAR(closureRef(co, 3));
+Obj x140246338206151 = PRIM_EQ(symdo, x140246338206023);
+if (True == x140246338206151) {
+Obj x140246338206567 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338206695 = PRIM_ISCONS(x140246338206567);
+if (True == x140246338206695) {
+Obj x140246338207399 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338207431 = PRIM_CAR(x140246338207399);
+Obj x140246338207463 = PRIM_ISCONS(x140246338207431);
+if (True == x140246338207463) {
+Obj x140246338167463 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338167495 = PRIM_CAR(x140246338167463);
+Obj x140246338167527 = PRIM_CAR(x140246338167495);
+Obj x140246338167623 = PRIM_EQ(symimport, x140246338167527);
+if (True == x140246338167623) {
+Obj x140246338168391 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338168423 = PRIM_CAR(x140246338168391);
+Obj x140246338168455 = PRIM_CDR(x140246338168423);
+Obj x140246338168487 = PRIM_ISCONS(x140246338168455);
+if (True == x140246338168487) {
+Obj x140246338169255 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338169287 = PRIM_CAR(x140246338169255);
+Obj x140246338169319 = PRIM_CDR(x140246338169287);
+Obj x140246338169351 = PRIM_CAR(x140246338169319);
+Obj pkg = x140246338169351;
+Obj x140246338170407 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338170439 = PRIM_CAR(x140246338170407);
+Obj x140246338170471 = PRIM_CDR(x140246338170439);
+Obj x140246338170631 = PRIM_CDR(x140246338170471);
+Obj x140246338170663 = PRIM_EQ(Nil, x140246338170631);
+if (True == x140246338170663) {
+Obj x140246337970695 = PRIM_CDR(closureRef(co, 3));
+Obj x140246337970727 = PRIM_CDR(x140246337970695);
+Obj x140246337970759 = PRIM_ISCONS(x140246337970727);
+if (True == x140246337970759) {
+Obj x140246337971431 = PRIM_CDR(closureRef(co, 3));
+Obj x140246337971463 = PRIM_CDR(x140246337971431);
+Obj x140246337971495 = PRIM_CAR(x140246337971463);
+Obj y = x140246337971495;
+Obj x140246337972487 = PRIM_CDR(closureRef(co, 3));
+Obj x140246337972519 = PRIM_CDR(x140246337972487);
+Obj x140246337972551 = PRIM_CDR(x140246337972519);
+Obj x140246337972583 = PRIM_EQ(Nil, x140246337972551);
+if (True == x140246337972583) {
+Obj x140246337972935 = primIsString(pkg);
+if (True == x140246337972935) {
+Obj x140246337974247 = makeCons(pkg, Nil);
+Obj x140246337885159 = makeCons(symimport, x140246337974247);
+pushCont(co, 26, clofun0, 5, pkg, import, env, ns, y);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
-__arg1 = rest;
-__arg2 = imports;
-__arg3 = more;
-co->args[4] = k;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = x140246337885159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -917,16 +1225,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c580;
+__arg0 = x140246338822279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -935,7 +1234,79 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c580;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338822279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -946,15 +1317,20 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411252c9c0 = makeNative(28, clofun0, 0, 0);
-Obj body = closureRef(co, 0);
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-pushCont(co, 27, clofun0, 3, k, exports, body);
-__nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = imports;
+Obj x140246337885191 = __arg1;
+Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140246337886055 = makeCons(pkg, import);
+pushCont(co, 27, clofun0, 1, x140246337885191);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = x140246337886055;
+co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -964,54 +1340,166 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f41125cd360 = __arg1;
-Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 4;
-__arg0 = k;
-__arg1 = v0x7f41125cd360;
-__arg2 = exports;
-__arg3 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140246337886119 = __arg1;
+Obj x140246337885191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246337886183 = makeCons(x140246337886119, Nil);
+Obj x140246337886215 = makeCons(x140246337885191, x140246337886183);
+Obj x140246337886247 = makeCons(symdo, x140246337886215);
+__nargs = 2;
+__arg1 = x140246337886247;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label28:
 {
+Obj x140246338823463 = makeNative(38, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x140246338251239 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246338251239) {
+Obj x140246338251527 = PRIM_CAR(closureRef(co, 3));
+Obj op = x140246338251527;
+Obj x140246338252071 = PRIM_CDR(closureRef(co, 3));
+Obj args = x140246338252071;
+pushCont(co, 29, clofun0, 6, env, ns, import, args, op, x140246338823463);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(symcora_47init_35builtin_63);
+__arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338823463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label29:
 {
-Obj exp = __arg1;
-PUSH_CONT_0(co, 30, clofun0);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
+Obj x140246338252423 = __arg1;
+Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140246338823463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+if (True == x140246338252423) {
+if (True == True) {
+pushCont(co, 36, clofun0, 2, args, op);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338823463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+Obj x140246338229607 = PRIM_EQ(op, symif);
+if (True == x140246338229607) {
+if (True == True) {
+pushCont(co, 34, clofun0, 2, args, op);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338823463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+Obj x140246338231207 = PRIM_EQ(op, symdo);
+if (True == x140246338231207) {
+if (True == True) {
+pushCont(co, 32, clofun0, 2, args, op);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338823463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+pushCont(co, 30, clofun0, 2, args, op);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338823463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+}
 
 label30:
 {
-Obj v0x7f41125cfce0 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = v0x7f41125cfce0;
+Obj x140246338204487 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 31, clofun0, 1, op);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x140246338204487;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1021,138 +1509,69 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f411252c800 = __arg1;
-Obj v0x7f411252c8a0 = makeNative(32, clofun0, 0, 1, v0x7f411252c800);
-Obj x = v0x7f411252c800;
-Obj v0x7f41125cf780 = primIsSymbol(x);
-if (True == v0x7f41125cf780) {
-Obj v0x7f41125cf960 = makeCons(x, Nil);
-Obj v0x7f41125cf980 = makeCons(symquote, v0x7f41125cf960);
+Obj x140246338204551 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338204583 = makeCons(op, x140246338204551);
 __nargs = 2;
-__arg1 = v0x7f41125cf980;
+__arg1 = x140246338204583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c8a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label32:
 {
-Obj v0x7f411252c9a0 = makeNative(33, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d27c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d27c0) {
-Obj v0x7f41125d29c0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d29e0 = PRIM_EQ(symunquote, v0x7f41125d29c0);
-if (True == v0x7f41125d29e0) {
-Obj v0x7f41125d2bc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2be0 = PRIM_ISCONS(v0x7f41125d2bc0);
-if (True == v0x7f41125d2be0) {
-Obj v0x7f41125cf060 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cf0c0 = PRIM_CAR(v0x7f41125cf060);
-Obj x = v0x7f41125cf0c0;
-Obj v0x7f41125cf360 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cf380 = PRIM_CDR(v0x7f41125cf360);
-Obj v0x7f41125cf3a0 = PRIM_EQ(Nil, v0x7f41125cf380);
-if (True == v0x7f41125cf3a0) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c9a0;
+Obj x140246338232071 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 33, clofun0, 1, op);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x140246338232071;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c9a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c9a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c9a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label33:
 {
-Obj v0x7f411252cb80 = makeNative(35, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d20c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d20c0) {
-Obj v0x7f41125d21e0 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f41125d21e0;
-Obj v0x7f41125d2300 = PRIM_CDR(closureRef(co, 0));
-Obj more = v0x7f41125d2300;
-Obj v0x7f41125d2580 = makeCons(x, more);
-PUSH_CONT_0(co, 34, clofun0);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = v0x7f41125d2580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cb80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj v0x7f41125d25a0 = __arg1;
-Obj v0x7f41125d25c0 = makeCons(symlist, v0x7f41125d25a0);
+Obj x140246338232135 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338232167 = makeCons(op, x140246338232135);
 __nargs = 2;
-__arg1 = v0x7f41125d25c0;
+__arg1 = x140246338232167;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
+label34:
+{
+Obj x140246338230311 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 35, clofun0, 1, op);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x140246338230311;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label35:
 {
-Obj v0x7f411252cd20 = makeNative(36, clofun0, 0, 0);
-Obj x = closureRef(co, 0);
+Obj x140246338230375 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338230439 = makeCons(op, x140246338230375);
 __nargs = 2;
-__arg1 = x;
+__arg1 = x140246338230439;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1160,9 +1579,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label36:
 {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+Obj x140246338228839 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 37, clofun0, 1, op);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x140246338228839;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1172,37 +1596,72 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj exp = __arg1;
-Obj v0x7f41125d6b80 = PRIM_CDR(exp);
+Obj x140246338228903 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338228935 = makeCons(op, x140246338228903);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = v0x7f41125d6b80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246338228935;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label38:
 {
-Obj v0x7f411252c120 = __arg1;
-Obj v0x7f411252c1a0 = makeNative(39, clofun0, 0, 1, v0x7f411252c120);
-Obj v0x7f41125d64e0 = PRIM_ISCONS(v0x7f411252c120);
-if (True == v0x7f41125d64e0) {
-Obj v0x7f41125d65e0 = PRIM_CAR(v0x7f411252c120);
-Obj x = v0x7f41125d65e0;
-Obj v0x7f41125d67a0 = PRIM_CDR(v0x7f411252c120);
-Obj v0x7f41125d67c0 = PRIM_EQ(Nil, v0x7f41125d67a0);
-if (True == v0x7f41125d67c0) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140246338824199 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x140246338495751 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246338495751) {
+Obj x140246338496487 = PRIM_CAR(closureRef(co, 3));
+Obj x140246338496519 = PRIM_EQ(symlet, x140246338496487);
+if (True == x140246338496519) {
+Obj x140246338497159 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338497191 = PRIM_ISCONS(x140246338497159);
+if (True == x140246338497191) {
+Obj x140246338498023 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338498055 = PRIM_CAR(x140246338498023);
+Obj a = x140246338498055;
+Obj x140246338449863 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338449895 = PRIM_CDR(x140246338449863);
+Obj x140246338449927 = PRIM_ISCONS(x140246338449895);
+if (True == x140246338449927) {
+Obj x140246338450759 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338450823 = PRIM_CDR(x140246338450759);
+Obj x140246338450855 = PRIM_CAR(x140246338450823);
+Obj b = x140246338450855;
+Obj x140246338452007 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338452039 = PRIM_CDR(x140246338452007);
+Obj x140246338452071 = PRIM_CDR(x140246338452039);
+Obj x140246338452103 = PRIM_ISCONS(x140246338452071);
+if (True == x140246338452103) {
+Obj x140246338453319 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338453351 = PRIM_CDR(x140246338453319);
+Obj x140246338453415 = PRIM_CDR(x140246338453351);
+Obj x140246338351143 = PRIM_CAR(x140246338453415);
+Obj c = x140246338351143;
+Obj x140246338352807 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338352839 = PRIM_CDR(x140246338352807);
+Obj x140246338352871 = PRIM_CDR(x140246338352839);
+Obj x140246338352903 = PRIM_CDR(x140246338352871);
+Obj x140246338352967 = PRIM_EQ(Nil, x140246338352903);
+if (True == x140246338352967) {
+pushCont(co, 39, clofun0, 5, env, ns, import, c, a);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c1a0;
+__arg0 = x140246338824199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1211,7 +1670,43 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c1a0;
+__arg0 = x140246338824199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338824199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338824199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338824199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338824199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1222,71 +1717,90 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f411252c3a0 = makeNative(40, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d28a0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d28a0) {
-Obj v0x7f41125d29a0 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f41125d29a0;
-Obj v0x7f41125d2b40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2b60 = PRIM_ISCONS(v0x7f41125d2b40);
-if (True == v0x7f41125d2b60) {
-Obj v0x7f41125d2d00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2d20 = PRIM_CAR(v0x7f41125d2d00);
-Obj y = v0x7f41125d2d20;
-Obj v0x7f41125d2f80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2fa0 = PRIM_CDR(v0x7f41125d2f80);
-Obj v0x7f41125d2fc0 = PRIM_EQ(Nil, v0x7f41125d2fa0);
-if (True == v0x7f41125d2fc0) {
-Obj v0x7f41125d6220 = makeCons(y, Nil);
-Obj v0x7f41125d6240 = makeCons(x, v0x7f41125d6220);
-Obj v0x7f41125d6260 = makeCons(symdo, v0x7f41125d6240);
-__nargs = 2;
-__arg1 = v0x7f41125d6260;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c3a0;
+Obj x140246338354279 = __arg1;
+Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140246338248935 = makeCons(a, env);
+pushCont(co, 40, clofun0, 2, x140246338354279, a);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = x140246338248935;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c3a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c3a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label40:
 {
-Obj v0x7f411252c5c0 = makeNative(42, clofun0, 0, 0);
-Obj v0x7f41125d21c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d21c0) {
-Obj v0x7f41125d22c0 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f41125d22c0;
-Obj v0x7f41125d23c0 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f41125d23c0;
-pushCont(co, 41, clofun0, 1, x);
+Obj x140246338249063 = __arg1;
+Obj x140246338354279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338249415 = makeCons(x140246338249063, Nil);
+Obj x140246338249447 = makeCons(x140246338354279, x140246338249415);
+Obj x140246338249479 = makeCons(a, x140246338249447);
+Obj x140246338249511 = makeCons(symlet, x140246338249479);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = y;
+__arg1 = x140246338249511;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label41:
+{
+Obj x140246338825287 = makeNative(42, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj __ = closureRef(co, 1);
+__ = closureRef(co, 2);
+Obj x140246338625703 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246338625703) {
+Obj x140246338626375 = PRIM_CAR(closureRef(co, 3));
+Obj x140246338626439 = PRIM_EQ(symns, x140246338626375);
+if (True == x140246338626439) {
+Obj x140246338627207 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338627239 = PRIM_ISCONS(x140246338627207);
+if (True == x140246338627239) {
+Obj x140246338628263 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338628295 = PRIM_CAR(x140246338628263);
+Obj path = x140246338628295;
+Obj x140246338629447 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338629479 = PRIM_CDR(x140246338629447);
+Obj x140246338629511 = PRIM_ISCONS(x140246338629479);
+if (True == x140246338629511) {
+Obj x140246338601831 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338601863 = PRIM_CDR(x140246338601831);
+Obj x140246338601895 = PRIM_CAR(x140246338601863);
+Obj import = x140246338601895;
+Obj x140246338603847 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338603879 = PRIM_CDR(x140246338603847);
+Obj x140246338603943 = PRIM_CDR(x140246338603879);
+Obj x140246338603975 = PRIM_ISCONS(x140246338603943);
+if (True == x140246338603975) {
+Obj x140246338552775 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338552807 = PRIM_CDR(x140246338552775);
+Obj x140246338552839 = PRIM_CDR(x140246338552807);
+Obj x140246338552871 = PRIM_CAR(x140246338552839);
+Obj body = x140246338552871;
+Obj x140246338554407 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338554439 = PRIM_CDR(x140246338554407);
+Obj x140246338554471 = PRIM_CDR(x140246338554439);
+Obj x140246338554599 = PRIM_CDR(x140246338554471);
+Obj x140246338554631 = PRIM_EQ(Nil, x140246338554599);
+if (True == x140246338554631) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = path;
+__arg3 = import;
+co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1294,7 +1808,52 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c5c0;
+__arg0 = x140246338825287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338825287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338825287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338825287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338825287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338825287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1303,21 +1862,167 @@ goto *jumpTable[ps.label];
 }
 }
 
-label41:
+label42:
 {
-Obj v0x7f41125d26a0 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125d26e0 = makeCons(v0x7f41125d26a0, Nil);
-Obj v0x7f41125d2700 = makeCons(x, v0x7f41125d26e0);
-Obj v0x7f41125d2720 = makeCons(symdo, v0x7f41125d2700);
+Obj x140246338699399 = makeNative(45, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj x140246338973255 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140246338973255) {
+Obj x140246338950151 = PRIM_CAR(closureRef(co, 3));
+Obj x140246338950183 = PRIM_EQ(symdef, x140246338950151);
+if (True == x140246338950183) {
+Obj x140246338951175 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338951207 = PRIM_ISCONS(x140246338951175);
+if (True == x140246338951207) {
+Obj x140246338952103 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338952199 = PRIM_CAR(x140246338952103);
+Obj var = x140246338952199;
+Obj x140246338822343 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338822375 = PRIM_CDR(x140246338822343);
+Obj x140246338822407 = PRIM_ISCONS(x140246338822375);
+if (True == x140246338822407) {
+Obj x140246338823751 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338823943 = PRIM_CDR(x140246338823751);
+Obj x140246338823975 = PRIM_CAR(x140246338823943);
+Obj val = x140246338823975;
+Obj x140246338825223 = PRIM_CDR(closureRef(co, 3));
+Obj x140246338825319 = PRIM_CDR(x140246338825223);
+Obj x140246338825351 = PRIM_CDR(x140246338825319);
+Obj x140246338825383 = PRIM_EQ(Nil, x140246338825351);
+if (True == x140246338825383) {
+pushCont(co, 43, clofun0, 4, env, ns, import, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35var_45with_45ns);
+__arg1 = var;
+__arg2 = ns;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338699399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338699399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338699399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338699399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338699399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label43:
+{
+Obj x140246338825767 = __arg1;
+Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj var1 = x140246338825767;
+Obj x140246338700071 = makeCons(var1, Nil);
+Obj x140246338700103 = makeCons(symquote, x140246338700071);
+pushCont(co, 44, clofun0, 1, x140246338700103);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x140246338701191 = __arg1;
+Obj x140246338700103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338701287 = makeCons(x140246338701191, Nil);
+Obj x140246338701607 = makeCons(x140246338700103, x140246338701287);
+Obj x140246338701671 = makeCons(symset, x140246338701607);
 __nargs = 2;
-__arg1 = v0x7f41125d2720;
+__arg1 = x140246338701671;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label42:
+label45:
+{
+Obj x140246338700359 = makeNative(47, clofun0, 0, 0);
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj ls = closureRef(co, 3);
+pushCont(co, 46, clofun0, 1, ls);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x140246338972167 = __arg1;
+Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x140246338972167;
+__arg2 = ls;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
 {
 __nargs = 2;
 __arg0 = globalRef(symerror);
@@ -1329,252 +2034,28 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label43:
-{
-Obj exp = __arg1;
-PUSH_CONT_0(co, 44, clofun0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label44:
-{
-Obj v0x7f41125cfd40 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = v0x7f41125cfd40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj v0x7f411252c240 = __arg1;
-Obj v0x7f411252c2e0 = makeNative(46, clofun0, 0, 1, v0x7f411252c240);
-Obj v0x7f41125cdec0 = PRIM_ISCONS(v0x7f411252c240);
-if (True == v0x7f41125cdec0) {
-Obj v0x7f41125cf080 = PRIM_CAR(v0x7f411252c240);
-Obj v0x7f41125cf0a0 = PRIM_EQ(symquote, v0x7f41125cf080);
-if (True == v0x7f41125cf0a0) {
-Obj v0x7f41125cf240 = PRIM_CDR(v0x7f411252c240);
-Obj v0x7f41125cf260 = PRIM_ISCONS(v0x7f41125cf240);
-if (True == v0x7f41125cf260) {
-Obj v0x7f41125cf400 = PRIM_CDR(v0x7f411252c240);
-Obj v0x7f41125cf420 = PRIM_CAR(v0x7f41125cf400);
-Obj x = v0x7f41125cf420;
-Obj v0x7f41125cf680 = PRIM_CDR(v0x7f411252c240);
-Obj v0x7f41125cf6a0 = PRIM_CDR(v0x7f41125cf680);
-Obj v0x7f41125cf6c0 = PRIM_EQ(Nil, v0x7f41125cf6a0);
-if (True == v0x7f41125cf6c0) {
-Obj v0x7f41125cf860 = makeCons(x, Nil);
-Obj v0x7f41125cf880 = makeCons(symquote, v0x7f41125cf860);
-__nargs = 2;
-__arg1 = v0x7f41125cf880;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label46:
-{
-Obj v0x7f411252c4e0 = makeNative(48, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125cd060 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cd060) {
-Obj v0x7f41125cd220 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cd240 = PRIM_EQ(symcons_63, v0x7f41125cd220);
-if (True == v0x7f41125cd240) {
-Obj v0x7f41125cd3e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd400 = PRIM_ISCONS(v0x7f41125cd3e0);
-if (True == v0x7f41125cd400) {
-Obj v0x7f41125cd5a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd5c0 = PRIM_CAR(v0x7f41125cd5a0);
-Obj x = v0x7f41125cd5c0;
-Obj v0x7f41125cd820 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd840 = PRIM_CDR(v0x7f41125cd820);
-Obj v0x7f41125cd860 = PRIM_EQ(Nil, v0x7f41125cd840);
-if (True == v0x7f41125cd860) {
-PUSH_CONT_0(co, 47, clofun0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c4e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c4e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c4e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c4e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label47:
-{
-Obj v0x7f41125cd960 = __arg1;
-Obj x1 = v0x7f41125cd960;
-Obj v0x7f41125cdba0 = makeCons(x1, Nil);
-Obj v0x7f41125cdbc0 = makeCons(symcons_63, v0x7f41125cdba0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f41125cdbc0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label48:
 {
-Obj v0x7f411252c6c0 = makeNative(0, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411245bca0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411245bca0) {
-Obj v0x7f411245bec0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411245bee0 = PRIM_EQ(symcar, v0x7f411245bec0);
-if (True == v0x7f411245bee0) {
-Obj v0x7f411243c3e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243c400 = PRIM_ISCONS(v0x7f411243c3e0);
-if (True == v0x7f411243c400) {
-Obj v0x7f411243c5e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243c640 = PRIM_CAR(v0x7f411243c5e0);
-Obj x = v0x7f411243c640;
-Obj v0x7f411243c900 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243c920 = PRIM_CDR(v0x7f411243c900);
-Obj v0x7f411243c940 = PRIM_EQ(Nil, v0x7f411243c920);
-if (True == v0x7f411243c940) {
+Obj x = __arg1;
 PUSH_CONT_0(co, 49, clofun0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__nargs = 3;
+__arg0 = globalRef(symassq);
 __arg1 = x;
+__arg2 = globalRef(symcora_47init_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c6c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c6c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c6c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c6c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label49:
 {
-Obj v0x7f411243ca40 = __arg1;
-Obj x1 = v0x7f411243ca40;
-Obj v0x7f411243cd00 = makeCons(x1, Nil);
-Obj v0x7f411243cd20 = makeCons(symcar, v0x7f411243cd00);
+Obj x140246339318887 = __arg1;
+PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f411243cd20;
+__arg0 = globalRef(symnull_63);
+__arg1 = x140246339318887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1604,133 +2085,67 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f411252c880 = makeNative(2, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41124859e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124859e0) {
-Obj v0x7f4112485cc0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112485ce0 = PRIM_EQ(symcdr, v0x7f4112485cc0);
-if (True == v0x7f4112485ce0) {
-Obj v0x7f4112485e80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485ea0 = PRIM_ISCONS(v0x7f4112485e80);
-if (True == v0x7f4112485ea0) {
-Obj v0x7f411245b0a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b0c0 = PRIM_CAR(v0x7f411245b0a0);
-Obj x = v0x7f411245b0c0;
-Obj v0x7f411245b4a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b520 = PRIM_CDR(v0x7f411245b4a0);
-Obj v0x7f411245b540 = PRIM_EQ(Nil, v0x7f411245b520);
-if (True == v0x7f411245b540) {
-PUSH_CONT_0(co, 1, clofun1);
+Obj x140246339318919 = __arg1;
+Obj x140246339318983 = primNot(x140246339318919);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c880;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c880;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c880;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c880;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x140246339318983;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj v0x7f411245b640 = __arg1;
-Obj x1 = v0x7f411245b640;
-Obj v0x7f411245b900 = makeCons(x1, Nil);
-Obj v0x7f411245b920 = makeCons(symcdr, v0x7f411245b900);
+Obj x140246338970055 = __arg1;
+Obj x140246338970087 = __arg2;
+Obj x140246338970439 = makeNative(2, clofun1, 0, 2, x140246338970055, x140246338970087);
+Obj var = x140246338970055;
+Obj x140246339374279 = PRIM_EQ(Nil, x140246338970087);
+if (True == x140246339374279) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f411245b920;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338970439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj v0x7f411252ca60 = makeNative(5, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411248abc0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411248abc0) {
-Obj v0x7f411248ae00 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411248ae20 = PRIM_EQ(symand, v0x7f411248ae00);
-if (True == v0x7f411248ae20) {
-Obj v0x7f4112487020 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487060 = PRIM_ISCONS(v0x7f4112487020);
-if (True == v0x7f4112487060) {
-Obj v0x7f4112487340 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487360 = PRIM_CAR(v0x7f4112487340);
-Obj x = v0x7f4112487360;
-Obj v0x7f4112487660 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124876a0 = PRIM_CDR(v0x7f4112487660);
-Obj v0x7f41124876c0 = PRIM_ISCONS(v0x7f41124876a0);
-if (True == v0x7f41124876c0) {
-Obj v0x7f41124879e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487a00 = PRIM_CDR(v0x7f41124879e0);
-Obj v0x7f4112487a20 = PRIM_CAR(v0x7f4112487a00);
-Obj y = v0x7f4112487a20;
-Obj v0x7f4112487da0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487dc0 = PRIM_CDR(v0x7f4112487da0);
-Obj v0x7f4112487de0 = PRIM_CDR(v0x7f4112487dc0);
-Obj v0x7f4112487e00 = PRIM_EQ(Nil, v0x7f4112487de0);
-if (True == v0x7f4112487e00) {
-pushCont(co, 3, clofun1, 1, y);
+Obj x140246338970887 = makeNative(3, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj var = closureRef(co, 0);
+Obj x140246339622823 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140246339622823) {
+Obj x140246339623559 = PRIM_CAR(closureRef(co, 1));
+Obj x140246339623591 = PRIM_ISCONS(x140246339623559);
+if (True == x140246339623591) {
+Obj x140246339624359 = PRIM_CAR(closureRef(co, 1));
+Obj x140246339624487 = PRIM_CAR(x140246339624359);
+Obj x = x140246339624487;
+Obj x140246339371431 = PRIM_CAR(closureRef(co, 1));
+Obj x140246339371463 = PRIM_CDR(x140246339371431);
+Obj y = x140246339371463;
+Obj x140246339371783 = PRIM_CDR(closureRef(co, 1));
+Obj __ = x140246339371783;
+Obj x140246339372455 = PRIM_EQ(var, x);
+if (True == x140246339372455) {
+Obj x140246339372775 = makeCons(x, y);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246339372775;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252ca60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ca60;
+__arg0 = x140246338970887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1739,7 +2154,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252ca60;
+__arg0 = x140246338970887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1748,16 +2163,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252ca60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ca60;
+__arg0 = x140246338970887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1768,31 +2174,39 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41124850e0 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1 = v0x7f41124850e0;
-pushCont(co, 4, clofun1, 1, x1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = y;
+Obj x140246338971591 = makeNative(4, clofun1, 0, 0);
+Obj var = closureRef(co, 0);
+Obj x140246339620871 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140246339620871) {
+Obj x140246339621351 = PRIM_CAR(closureRef(co, 1));
+Obj __ = x140246339621351;
+Obj x140246339621607 = PRIM_CDR(closureRef(co, 1));
+Obj y = x140246339621607;
+__nargs = 3;
+__arg0 = globalRef(symassq);
+__arg1 = var;
+__arg2 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338971591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label4:
 {
-Obj v0x7f41124851e0 = __arg1;
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y1 = v0x7f41124851e0;
-Obj v0x7f4112485560 = makeCons(y1, Nil);
-Obj v0x7f4112485580 = makeCons(x1, v0x7f4112485560);
-Obj v0x7f41124855a0 = makeCons(symand, v0x7f4112485580);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f41124855a0;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1802,26 +2216,18 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f411252ccc0 = makeNative(7, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411248c540 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411248c540) {
-Obj v0x7f411248c7a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411248c880 = PRIM_EQ(symnull_63, v0x7f411248c7a0);
-if (True == v0x7f411248c880) {
-Obj v0x7f411248cba0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248cbc0 = PRIM_ISCONS(v0x7f411248cba0);
-if (True == v0x7f411248cbc0) {
-Obj v0x7f411248cd80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248cda0 = PRIM_CAR(v0x7f411248cd80);
-Obj x = v0x7f411248cda0;
-Obj v0x7f411248a0c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248a1a0 = PRIM_CDR(v0x7f411248a0c0);
-Obj v0x7f411248a1c0 = PRIM_EQ(Nil, v0x7f411248a1a0);
-if (True == v0x7f411248a1c0) {
-PUSH_CONT_0(co, 6, clofun1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
+Obj x140246338952487 = __arg1;
+Obj x140246338952519 = __arg2;
+Obj x140246338952551 = __arg3;
+Obj x140246338952807 = makeNative(6, clofun1, 0, 3, x140246338952487, x140246338952519, x140246338952551);
+Obj s = x140246338952487;
+Obj ns = x140246338952519;
+Obj x140246339873415 = PRIM_EQ(Nil, x140246338952551);
+if (True == x140246339873415) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35var_45with_45ns);
+__arg1 = s;
+__arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1829,34 +2235,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252ccc0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ccc0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ccc0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ccc0;
+__arg0 = x140246338952807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1867,94 +2246,66 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f411248a380 = __arg1;
-Obj x1 = v0x7f411248a380;
-Obj v0x7f411248a720 = makeCons(x1, Nil);
-Obj v0x7f411248a740 = makeCons(symnull_63, v0x7f411248a720);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f411248a740;
+Obj x140246338822215 = makeNative(14, clofun1, 0, 0);
+Obj s = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj x140246339870759 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140246339870759) {
+Obj x140246339871015 = PRIM_CAR(closureRef(co, 2));
+Obj import = x140246339871015;
+Obj x140246339871271 = PRIM_CDR(closureRef(co, 2));
+Obj more = x140246339871271;
+pushCont(co, 7, clofun1, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = import;
+__arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338822215;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label7:
 {
-Obj v0x7f411252cea0 = makeNative(9, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41124c4d80 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124c4d80) {
-Obj v0x7f41124ad0a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124ad0c0 = PRIM_EQ(symnot, v0x7f41124ad0a0);
-if (True == v0x7f41124ad0c0) {
-Obj v0x7f41124ad380 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ad3a0 = PRIM_ISCONS(v0x7f41124ad380);
-if (True == v0x7f41124ad3a0) {
-Obj v0x7f41124ad600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ad6a0 = PRIM_CAR(v0x7f41124ad600);
-Obj x = v0x7f41124ad6a0;
-Obj v0x7f41124adb20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124adb40 = PRIM_CDR(v0x7f41124adb20);
-Obj v0x7f41124adb80 = PRIM_EQ(Nil, v0x7f41124adb40);
-if (True == v0x7f41124adb80) {
-PUSH_CONT_0(co, 8, clofun1);
+Obj x140246339871879 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 8, clofun1, 4, import, s, ns, more);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
+__arg0 = globalRef(symintern);
+__arg1 = x140246339871879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cea0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cea0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cea0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cea0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label8:
 {
-Obj v0x7f41124adce0 = __arg1;
-Obj x1 = v0x7f41124adce0;
-Obj v0x7f411248c040 = makeCons(x1, Nil);
-Obj v0x7f411248c0e0 = makeCons(symnot, v0x7f411248c040);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f411248c0e0;
+Obj x140246339871911 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 9, clofun1, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(symvalue_45or);
+__arg1 = x140246339871911;
+__arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1964,134 +2315,64 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f4112529080 = makeNative(13, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41124eb380 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124eb380) {
-Obj v0x7f41124eb6e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124eb700 = PRIM_EQ(symif, v0x7f41124eb6e0);
-if (True == v0x7f41124eb700) {
-Obj v0x7f41124eb940 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb960 = PRIM_ISCONS(v0x7f41124eb940);
-if (True == v0x7f41124eb960) {
-Obj v0x7f41124ebc20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ebda0 = PRIM_CAR(v0x7f41124ebc20);
-Obj x = v0x7f41124ebda0;
-Obj v0x7f41124d9140 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9160 = PRIM_CDR(v0x7f41124d9140);
-Obj v0x7f41124d9180 = PRIM_ISCONS(v0x7f41124d9160);
-if (True == v0x7f41124d9180) {
-Obj v0x7f41124d9700 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9720 = PRIM_CDR(v0x7f41124d9700);
-Obj v0x7f41124d9760 = PRIM_CAR(v0x7f41124d9720);
-Obj y = v0x7f41124d9760;
-Obj v0x7f41124d9d20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9d40 = PRIM_CDR(v0x7f41124d9d20);
-Obj v0x7f41124d9d60 = PRIM_CDR(v0x7f41124d9d40);
-Obj v0x7f41124d9d80 = PRIM_ISCONS(v0x7f41124d9d60);
-if (True == v0x7f41124d9d80) {
-Obj v0x7f41124cb380 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cb3a0 = PRIM_CDR(v0x7f41124cb380);
-Obj v0x7f41124cb3c0 = PRIM_CDR(v0x7f41124cb3a0);
-Obj v0x7f41124cb3e0 = PRIM_CAR(v0x7f41124cb3c0);
-Obj z = v0x7f41124cb3e0;
-Obj v0x7f41124cba60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cbaa0 = PRIM_CDR(v0x7f41124cba60);
-Obj v0x7f41124cbb80 = PRIM_CDR(v0x7f41124cbaa0);
-Obj v0x7f41124cbbc0 = PRIM_CDR(v0x7f41124cbb80);
-Obj v0x7f41124cbbe0 = PRIM_EQ(Nil, v0x7f41124cbbc0);
-if (True == v0x7f41124cbbe0) {
-pushCont(co, 10, clofun1, 2, y, z);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
+Obj x140246339871975 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj export = x140246339871975;
+pushCont(co, 10, clofun1, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(symelem_63);
+__arg1 = s;
+__arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label10:
 {
-Obj v0x7f41124cbdc0 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x1 = v0x7f41124cbdc0;
-pushCont(co, 11, clofun1, 2, z, x1);
+Obj x140246339872263 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x140246339872263) {
+pushCont(co, 11, clofun1, 1, import);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = y;
+__arg0 = globalRef(symsymbol_45_62string);
+__arg1 = s;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35lookup_45var);
+__arg1 = s;
+__arg2 = ns;
+__arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label11:
 {
-Obj v0x7f41124cbf00 = __arg1;
-Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y1 = v0x7f41124cbf00;
-pushCont(co, 12, clofun1, 2, y1, x1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = z;
+Obj x140246339872999 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 12, clofun1, 1, import);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = makeCString("#");
+__arg2 = x140246339872999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2101,17 +2382,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f41124c4000 = __arg1;
-Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj z1 = v0x7f41124c4000;
-Obj v0x7f41124c45c0 = makeCons(z1, Nil);
-Obj v0x7f41124c45e0 = makeCons(y1, v0x7f41124c45c0);
-Obj v0x7f41124c4600 = makeCons(x1, v0x7f41124c45e0);
-Obj v0x7f41124c4640 = makeCons(symif, v0x7f41124c4600);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = v0x7f41124c4640;
+Obj x140246339873031 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 13, clofun1);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = import;
+__arg2 = x140246339873031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2121,123 +2398,45 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112529340 = makeNative(15, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411252cd80 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411252cd80) {
-Obj v0x7f411252cfc0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125290c0 = PRIM_EQ(symlambda, v0x7f411252cfc0);
-if (True == v0x7f41125290c0) {
-Obj v0x7f41125293a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125293c0 = PRIM_ISCONS(v0x7f41125293a0);
-if (True == v0x7f41125293c0) {
-Obj v0x7f41125296a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125296c0 = PRIM_CAR(v0x7f41125296a0);
-Obj args = v0x7f41125296c0;
-Obj v0x7f4112529a20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112529ae0 = PRIM_CDR(v0x7f4112529a20);
-Obj v0x7f4112529b00 = PRIM_ISCONS(v0x7f4112529ae0);
-if (True == v0x7f4112529b00) {
-Obj v0x7f4112512360 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512380 = PRIM_CDR(v0x7f4112512360);
-Obj v0x7f41125123a0 = PRIM_CAR(v0x7f4112512380);
-Obj body = v0x7f41125123a0;
-Obj v0x7f4112512800 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512820 = PRIM_CDR(v0x7f4112512800);
-Obj v0x7f4112512840 = PRIM_CDR(v0x7f4112512820);
-Obj v0x7f4112512860 = PRIM_EQ(Nil, v0x7f4112512840);
-if (True == v0x7f4112512860) {
-pushCont(co, 14, clofun1, 1, args);
+Obj x140246339873063 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = body;
+__arg0 = globalRef(symintern);
+__arg1 = x140246339873063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label14:
 {
-Obj v0x7f4112512ca0 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512ce0 = makeCons(v0x7f4112512ca0, Nil);
-Obj v0x7f4112512d00 = makeCons(args, v0x7f4112512ce0);
-Obj v0x7f4112512d20 = makeCons(symlambda, v0x7f4112512d00);
 __nargs = 2;
-__arg1 = v0x7f4112512d20;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj v0x7f41125295c0 = makeNative(16, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411252c180 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411252c180) {
-Obj v0x7f411252c4c0 = PRIM_CAR(closureRef(co, 0));
-Obj f = v0x7f411252c4c0;
-Obj v0x7f411252c640 = PRIM_CDR(closureRef(co, 0));
-Obj args = v0x7f411252c640;
-Obj v0x7f411252caa0 = makeCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35propagate_45boolean);
-__arg2 = v0x7f411252caa0;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj var = __arg1;
+Obj ns = __arg2;
+Obj x140246339860359 = PRIM_EQ(ns, makeCString(""));
+if (True == x140246339860359) {
+__nargs = 2;
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = v0x7f41125295c0;
+pushCont(co, 16, clofun1, 2, var, ns);
+__nargs = 2;
+__arg0 = globalRef(symsymbol_45cooked_63);
+__arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2248,20 +2447,37 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f4112529740 = makeNative(17, clofun1, 0, 0);
-Obj x = closureRef(co, 0);
+Obj x140246339860615 = __arg1;
+Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246339860615) {
 __nargs = 2;
-__arg1 = x;
+__arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 17, clofun1, 1, ns);
+__nargs = 2;
+__arg0 = globalRef(symsymbol_45_62string);
+__arg1 = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label17:
 {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+Obj x140246339861351 = __arg1;
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 18, clofun1, 1, ns);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = makeCString("#");
+__arg2 = x140246339861351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2271,1111 +2487,369 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f411252c220 = __arg1;
-Obj v0x7f411252c2a0 = makeNative(19, clofun1, 0, 1, v0x7f411252c220);
-Obj v0x7f41125c1740 = PRIM_ISCONS(v0x7f411252c220);
-if (True == v0x7f41125c1740) {
-Obj v0x7f41125c11e0 = PRIM_CAR(v0x7f411252c220);
-Obj v0x7f41125c1200 = PRIM_EQ(symcar, v0x7f41125c11e0);
-if (True == v0x7f41125c1200) {
-Obj v0x7f41125c1840 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c1860 = PRIM_ISCONS(v0x7f41125c1840);
-if (True == v0x7f41125c1860) {
-Obj v0x7f41125c1aa0 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c1ac0 = PRIM_CAR(v0x7f41125c1aa0);
-Obj v0x7f41125c1ae0 = PRIM_ISCONS(v0x7f41125c1ac0);
-if (True == v0x7f41125c1ae0) {
-Obj v0x7f41125c1de0 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c1e00 = PRIM_CAR(v0x7f41125c1de0);
-Obj v0x7f41125c1e20 = PRIM_CAR(v0x7f41125c1e00);
-Obj v0x7f41125c1e40 = PRIM_EQ(symcons, v0x7f41125c1e20);
-if (True == v0x7f41125c1e40) {
-Obj v0x7f41125c0120 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c0140 = PRIM_CAR(v0x7f41125c0120);
-Obj v0x7f41125c0160 = PRIM_CDR(v0x7f41125c0140);
-Obj v0x7f41125c0180 = PRIM_ISCONS(v0x7f41125c0160);
-if (True == v0x7f41125c0180) {
-Obj v0x7f41125c04e0 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c0500 = PRIM_CAR(v0x7f41125c04e0);
-Obj v0x7f41125c0520 = PRIM_CDR(v0x7f41125c0500);
-Obj v0x7f41125c0540 = PRIM_CAR(v0x7f41125c0520);
-Obj x = v0x7f41125c0540;
-Obj v0x7f41125c0960 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c0980 = PRIM_CAR(v0x7f41125c0960);
-Obj v0x7f41125c09a0 = PRIM_CDR(v0x7f41125c0980);
-Obj v0x7f41125c0a60 = PRIM_CDR(v0x7f41125c09a0);
-Obj v0x7f41125c0a80 = PRIM_ISCONS(v0x7f41125c0a60);
-if (True == v0x7f41125c0a80) {
-Obj v0x7f41125c0e00 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f41125c0e20 = PRIM_CAR(v0x7f41125c0e00);
-Obj v0x7f41125c0e40 = PRIM_CDR(v0x7f41125c0e20);
-Obj v0x7f41125c0e60 = PRIM_CDR(v0x7f41125c0e40);
-Obj v0x7f41125c0f40 = PRIM_CAR(v0x7f41125c0e60);
-Obj __ = v0x7f41125c0f40;
-Obj v0x7f41125705e0 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f4112570600 = PRIM_CAR(v0x7f41125705e0);
-Obj v0x7f4112570660 = PRIM_CDR(v0x7f4112570600);
-Obj v0x7f41125706a0 = PRIM_CDR(v0x7f4112570660);
-Obj v0x7f41125706c0 = PRIM_CDR(v0x7f41125706a0);
-Obj v0x7f41125706e0 = PRIM_EQ(Nil, v0x7f41125706c0);
-if (True == v0x7f41125706e0) {
-Obj v0x7f4112570a60 = PRIM_CDR(v0x7f411252c220);
-Obj v0x7f4112570a80 = PRIM_CDR(v0x7f4112570a60);
-Obj v0x7f4112570aa0 = PRIM_EQ(Nil, v0x7f4112570a80);
-if (True == v0x7f4112570aa0) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
+Obj x140246339861383 = __arg1;
+Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 19, clofun1);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = ns;
+__arg2 = x140246339861383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label19:
 {
-Obj v0x7f411252c600 = makeNative(20, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411245bf40 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411245bf40) {
-Obj v0x7f411243c440 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411243c460 = PRIM_EQ(symcdr, v0x7f411243c440);
-if (True == v0x7f411243c460) {
-Obj v0x7f411243c600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243c620 = PRIM_ISCONS(v0x7f411243c600);
-if (True == v0x7f411243c620) {
-Obj v0x7f411243c860 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243c880 = PRIM_CAR(v0x7f411243c860);
-Obj v0x7f411243c8a0 = PRIM_ISCONS(v0x7f411243c880);
-if (True == v0x7f411243c8a0) {
-Obj v0x7f411243cba0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243cbc0 = PRIM_CAR(v0x7f411243cba0);
-Obj v0x7f411243cbe0 = PRIM_CAR(v0x7f411243cbc0);
-Obj v0x7f411243cc00 = PRIM_EQ(symcons, v0x7f411243cbe0);
-if (True == v0x7f411243cc00) {
-Obj v0x7f411243cee0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411243cf00 = PRIM_CAR(v0x7f411243cee0);
-Obj v0x7f411243cf20 = PRIM_CDR(v0x7f411243cf00);
-Obj v0x7f411243cf40 = PRIM_ISCONS(v0x7f411243cf20);
-if (True == v0x7f411243cf40) {
-Obj v0x7f41125c01e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0200 = PRIM_CAR(v0x7f41125c01e0);
-Obj v0x7f41125c0220 = PRIM_CDR(v0x7f41125c0200);
-Obj v0x7f41125c0240 = PRIM_CAR(v0x7f41125c0220);
-Obj __ = v0x7f41125c0240;
-Obj v0x7f41125c05c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c05e0 = PRIM_CAR(v0x7f41125c05c0);
-Obj v0x7f41125c0600 = PRIM_CDR(v0x7f41125c05e0);
-Obj v0x7f41125c0620 = PRIM_CDR(v0x7f41125c0600);
-Obj v0x7f41125c0640 = PRIM_ISCONS(v0x7f41125c0620);
-if (True == v0x7f41125c0640) {
-Obj v0x7f41125c09c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c09e0 = PRIM_CAR(v0x7f41125c09c0);
-Obj v0x7f41125c0a00 = PRIM_CDR(v0x7f41125c09e0);
-Obj v0x7f41125c0a20 = PRIM_CDR(v0x7f41125c0a00);
-Obj v0x7f41125c0a40 = PRIM_CAR(v0x7f41125c0a20);
-Obj x = v0x7f41125c0a40;
-Obj v0x7f41125c0e80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0ea0 = PRIM_CAR(v0x7f41125c0e80);
-Obj v0x7f41125c0ec0 = PRIM_CDR(v0x7f41125c0ea0);
-Obj v0x7f41125c0ee0 = PRIM_CDR(v0x7f41125c0ec0);
-Obj v0x7f41125c0f00 = PRIM_CDR(v0x7f41125c0ee0);
-Obj v0x7f41125c0f20 = PRIM_EQ(Nil, v0x7f41125c0f00);
-if (True == v0x7f41125c0f20) {
-Obj v0x7f41125c1180 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c11a0 = PRIM_CDR(v0x7f41125c1180);
-Obj v0x7f41125c11c0 = PRIM_EQ(Nil, v0x7f41125c11a0);
-if (True == v0x7f41125c11c0) {
+Obj x140246339861415 = __arg1;
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
+__arg0 = globalRef(symintern);
+__arg1 = x140246339861415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c600;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label20:
 {
-Obj v0x7f411252c920 = makeNative(21, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f4112487040 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112487040) {
-Obj v0x7f4112487300 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112487320 = PRIM_EQ(symcons_63, v0x7f4112487300);
-if (True == v0x7f4112487320) {
-Obj v0x7f4112487520 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487540 = PRIM_ISCONS(v0x7f4112487520);
-if (True == v0x7f4112487540) {
-Obj v0x7f41124877e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487800 = PRIM_CAR(v0x7f41124877e0);
-Obj v0x7f4112487820 = PRIM_ISCONS(v0x7f4112487800);
-if (True == v0x7f4112487820) {
-Obj v0x7f4112487b80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487ba0 = PRIM_CAR(v0x7f4112487b80);
-Obj v0x7f4112487bc0 = PRIM_CAR(v0x7f4112487ba0);
-Obj v0x7f4112487be0 = PRIM_EQ(symcons, v0x7f4112487bc0);
-if (True == v0x7f4112487be0) {
-Obj v0x7f4112487f20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112487f60 = PRIM_CAR(v0x7f4112487f20);
-Obj v0x7f4112487fc0 = PRIM_CDR(v0x7f4112487f60);
-Obj v0x7f4112485080 = PRIM_ISCONS(v0x7f4112487fc0);
-if (True == v0x7f4112485080) {
-Obj v0x7f4112485360 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485380 = PRIM_CAR(v0x7f4112485360);
-Obj v0x7f41124853a0 = PRIM_CDR(v0x7f4112485380);
-Obj v0x7f41124853c0 = PRIM_CAR(v0x7f41124853a0);
-Obj __ = v0x7f41124853c0;
-Obj v0x7f4112485740 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485760 = PRIM_CAR(v0x7f4112485740);
-Obj v0x7f4112485780 = PRIM_CDR(v0x7f4112485760);
-Obj v0x7f41124857a0 = PRIM_CDR(v0x7f4112485780);
-Obj v0x7f41124857c0 = PRIM_ISCONS(v0x7f41124857a0);
-if (True == v0x7f41124857c0) {
-Obj v0x7f4112485ba0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485bc0 = PRIM_CAR(v0x7f4112485ba0);
-Obj v0x7f4112485be0 = PRIM_CDR(v0x7f4112485bc0);
-Obj v0x7f4112485c00 = PRIM_CDR(v0x7f4112485be0);
-Obj v0x7f4112485c20 = PRIM_CAR(v0x7f4112485c00);
-__ = v0x7f4112485c20;
-Obj v0x7f411245b100 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b120 = PRIM_CAR(v0x7f411245b100);
-Obj v0x7f411245b140 = PRIM_CDR(v0x7f411245b120);
-Obj v0x7f411245b160 = PRIM_CDR(v0x7f411245b140);
-Obj v0x7f411245b1e0 = PRIM_CDR(v0x7f411245b160);
-Obj v0x7f411245b200 = PRIM_EQ(Nil, v0x7f411245b1e0);
-if (True == v0x7f411245b200) {
-Obj v0x7f411245b4c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b4e0 = PRIM_CDR(v0x7f411245b4c0);
-Obj v0x7f411245b500 = PRIM_EQ(Nil, v0x7f411245b4e0);
-if (True == v0x7f411245b500) {
+Obj sexp = __arg1;
+pushCont(co, 21, clofun1, 1, sexp);
 __nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
+__arg0 = globalRef(symcadr);
+__arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c920;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label21:
 {
-Obj v0x7f411252cc40 = makeNative(22, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f411248c5a0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411248c5a0) {
-Obj v0x7f411248c900 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411248c920 = PRIM_EQ(symand, v0x7f411248c900);
-if (True == v0x7f411248c920) {
-Obj v0x7f411248cb60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248cb80 = PRIM_ISCONS(v0x7f411248cb60);
-if (True == v0x7f411248cb80) {
-Obj v0x7f411248ce20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248ce40 = PRIM_CAR(v0x7f411248ce20);
-Obj v0x7f411248ce60 = PRIM_EQ(True, v0x7f411248ce40);
-if (True == v0x7f411248ce60) {
-Obj v0x7f411248a0e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248a100 = PRIM_CDR(v0x7f411248a0e0);
-Obj v0x7f411248a180 = PRIM_ISCONS(v0x7f411248a100);
-if (True == v0x7f411248a180) {
-Obj v0x7f411248a580 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248a5a0 = PRIM_CDR(v0x7f411248a580);
-Obj v0x7f411248a5c0 = PRIM_CAR(v0x7f411248a5a0);
-Obj v0x7f411248a5e0 = PRIM_EQ(True, v0x7f411248a5c0);
-if (True == v0x7f411248a5e0) {
-Obj v0x7f411248a9e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248aa20 = PRIM_CDR(v0x7f411248a9e0);
-Obj v0x7f411248aa40 = PRIM_CDR(v0x7f411248aa20);
-Obj v0x7f411248aa60 = PRIM_EQ(Nil, v0x7f411248aa40);
-if (True == v0x7f411248aa60) {
+Obj x140246339851367 = __arg1;
+Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj path = x140246339851367;
+pushCont(co, 22, clofun1, 1, path);
 __nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
+__arg0 = globalRef(symcddr);
+__arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label22:
 {
-Obj v0x7f411252ce80 = makeNative(23, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41124ad3c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124ad3c0) {
-Obj v0x7f41124ad620 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124ad640 = PRIM_EQ(symnull_63, v0x7f41124ad620);
-if (True == v0x7f41124ad640) {
-Obj v0x7f41124ad860 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ad880 = PRIM_ISCONS(v0x7f41124ad860);
-if (True == v0x7f41124ad880) {
-Obj v0x7f41124add00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124add20 = PRIM_CAR(v0x7f41124add00);
-Obj v0x7f41124add40 = PRIM_EQ(Nil, v0x7f41124add20);
-if (True == v0x7f41124add40) {
-Obj v0x7f411248c060 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248c080 = PRIM_CDR(v0x7f411248c060);
-Obj v0x7f411248c0a0 = PRIM_EQ(Nil, v0x7f411248c080);
-if (True == v0x7f411248c0a0) {
+Obj x140246339851847 = __arg1;
+Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 23, clofun1, 1, path);
 __nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ce80;
+__arg0 = globalRef(symcora_47init_35parse_45define_45library);
+__arg1 = x140246339851847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ce80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ce80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ce80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252ce80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label23:
 {
-Obj v0x7f4112529040 = makeNative(24, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41124eb980 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124eb980) {
-Obj v0x7f41124ebd60 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124ebd80 = PRIM_EQ(symnull_63, v0x7f41124ebd60);
-if (True == v0x7f41124ebd80) {
-Obj v0x7f41124ebf80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ebfa0 = PRIM_ISCONS(v0x7f41124ebf80);
-if (True == v0x7f41124ebfa0) {
-Obj v0x7f41124d93a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d93c0 = PRIM_CAR(v0x7f41124d93a0);
-Obj v0x7f41124d93e0 = PRIM_ISCONS(v0x7f41124d93c0);
-if (True == v0x7f41124d93e0) {
-Obj v0x7f41124d9940 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9960 = PRIM_CAR(v0x7f41124d9940);
-Obj v0x7f41124d99c0 = PRIM_CAR(v0x7f41124d9960);
-Obj v0x7f41124d99e0 = PRIM_EQ(symcons, v0x7f41124d99c0);
-if (True == v0x7f41124d99e0) {
-Obj v0x7f41124d9fa0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9fc0 = PRIM_CAR(v0x7f41124d9fa0);
-Obj v0x7f41124d9fe0 = PRIM_CDR(v0x7f41124d9fc0);
-Obj v0x7f41124cb000 = PRIM_ISCONS(v0x7f41124d9fe0);
-if (True == v0x7f41124cb000) {
-Obj v0x7f41124cb520 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cb540 = PRIM_CAR(v0x7f41124cb520);
-Obj v0x7f41124cb560 = PRIM_CDR(v0x7f41124cb540);
-Obj v0x7f41124cb580 = PRIM_CAR(v0x7f41124cb560);
-Obj __ = v0x7f41124cb580;
-Obj v0x7f41124cbae0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cbb00 = PRIM_CAR(v0x7f41124cbae0);
-Obj v0x7f41124cbb20 = PRIM_CDR(v0x7f41124cbb00);
-Obj v0x7f41124cbb40 = PRIM_CDR(v0x7f41124cbb20);
-Obj v0x7f41124cbb60 = PRIM_ISCONS(v0x7f41124cbb40);
-if (True == v0x7f41124cbb60) {
-Obj v0x7f41124c4040 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c4060 = PRIM_CAR(v0x7f41124c4040);
-Obj v0x7f41124c4080 = PRIM_CDR(v0x7f41124c4060);
-Obj v0x7f41124c40a0 = PRIM_CDR(v0x7f41124c4080);
-Obj v0x7f41124c40c0 = PRIM_CAR(v0x7f41124c40a0);
-__ = v0x7f41124c40c0;
-Obj v0x7f41124c4680 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c46e0 = PRIM_CAR(v0x7f41124c4680);
-Obj v0x7f41124c4700 = PRIM_CDR(v0x7f41124c46e0);
-Obj v0x7f41124c4720 = PRIM_CDR(v0x7f41124c4700);
-Obj v0x7f41124c4740 = PRIM_CDR(v0x7f41124c4720);
-Obj v0x7f41124c4760 = PRIM_EQ(Nil, v0x7f41124c4740);
-if (True == v0x7f41124c4760) {
-Obj v0x7f41124c4aa0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c4ac0 = PRIM_CDR(v0x7f41124c4aa0);
-Obj v0x7f41124c4ae0 = PRIM_EQ(Nil, v0x7f41124c4ac0);
-if (True == v0x7f41124c4ae0) {
+Obj x140246339851879 = __arg1;
+Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
+__arg0 = x140246339851879;
+__arg1 = makeNative(24, clofun1, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529040;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label24:
 {
-Obj v0x7f4112529360 = makeNative(25, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f41125127e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125127e0) {
-Obj v0x7f41125129a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125129c0 = PRIM_EQ(symnot, v0x7f41125129a0);
-if (True == v0x7f41125129c0) {
-Obj v0x7f4112512c40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512c60 = PRIM_ISCONS(v0x7f4112512c40);
-if (True == v0x7f4112512c60) {
-Obj v0x7f41124eb020 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb080 = PRIM_CAR(v0x7f41124eb020);
-Obj v0x7f41124eb0a0 = PRIM_EQ(True, v0x7f41124eb080);
-if (True == v0x7f41124eb0a0) {
-Obj v0x7f41124eb420 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb440 = PRIM_CDR(v0x7f41124eb420);
-Obj v0x7f41124eb460 = PRIM_EQ(Nil, v0x7f41124eb440);
-if (True == v0x7f41124eb460) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529360;
+Obj import = __arg1;
+Obj export = __arg2;
+Obj body = __arg3;
+Obj x140246339852743 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 25, clofun1, 3, export, body, x140246339852743);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = makeNative(27, clofun1, 1, 0);
+__arg2 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529360;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529360;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529360;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529360;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label25:
 {
-Obj v0x7f4112529520 = makeNative(26, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f4112529160 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112529160) {
-Obj v0x7f4112529400 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112529420 = PRIM_EQ(symnot, v0x7f4112529400);
-if (True == v0x7f4112529420) {
-Obj v0x7f4112529700 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112529720 = PRIM_ISCONS(v0x7f4112529700);
-if (True == v0x7f4112529720) {
-Obj v0x7f4112529a80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112529aa0 = PRIM_CAR(v0x7f4112529a80);
-Obj v0x7f4112529ac0 = PRIM_EQ(False, v0x7f4112529aa0);
-if (True == v0x7f4112529ac0) {
-Obj v0x7f41125121a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125121c0 = PRIM_CDR(v0x7f41125121a0);
-Obj v0x7f41125121e0 = PRIM_EQ(Nil, v0x7f41125121c0);
-if (True == v0x7f41125121e0) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529520;
+Obj x140246339854023 = __arg1;
+Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339852743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140246339859271 = makeCons(export, Nil);
+Obj x140246339859303 = makeCons(symbackquote, x140246339859271);
+Obj x140246339859367 = makeCons(x140246339859303, Nil);
+Obj x140246339859399 = makeCons(sym_42ns_45export_42, x140246339859367);
+Obj x140246339859431 = makeCons(symdef, x140246339859399);
+Obj x140246339859495 = makeCons(x140246339859431, body);
+pushCont(co, 26, clofun1, 1, x140246339852743);
+__nargs = 3;
+__arg0 = globalRef(symappend);
+__arg1 = x140246339854023;
+__arg2 = x140246339859495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529520;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529520;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529520;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f4112529520;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label26:
 {
-Obj v0x7f41125296e0 = makeNative(27, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f4112570720 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112570720) {
-Obj v0x7f4112570980 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125709a0 = PRIM_EQ(symif, v0x7f4112570980);
-if (True == v0x7f41125709a0) {
-Obj v0x7f4112570c20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112570d00 = PRIM_ISCONS(v0x7f4112570c20);
-if (True == v0x7f4112570d00) {
-Obj v0x7f4112563000 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563020 = PRIM_CAR(v0x7f4112563000);
-Obj v0x7f4112563040 = PRIM_EQ(True, v0x7f4112563020);
-if (True == v0x7f4112563040) {
-Obj v0x7f41125633e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563400 = PRIM_CDR(v0x7f41125633e0);
-Obj v0x7f4112563420 = PRIM_ISCONS(v0x7f4112563400);
-if (True == v0x7f4112563420) {
-Obj v0x7f41125636e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563700 = PRIM_CDR(v0x7f41125636e0);
-Obj v0x7f41125637c0 = PRIM_CAR(v0x7f4112563700);
-Obj y = v0x7f41125637c0;
-Obj v0x7f4112563ba0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563bc0 = PRIM_CDR(v0x7f4112563ba0);
-Obj v0x7f4112563be0 = PRIM_CDR(v0x7f4112563bc0);
-Obj v0x7f4112563c20 = PRIM_ISCONS(v0x7f4112563be0);
-if (True == v0x7f4112563c20) {
-Obj v0x7f4112563fc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411252c020 = PRIM_CDR(v0x7f4112563fc0);
-Obj v0x7f411252c060 = PRIM_CDR(v0x7f411252c020);
-Obj v0x7f411252c0a0 = PRIM_CAR(v0x7f411252c060);
-Obj z = v0x7f411252c0a0;
-Obj v0x7f411252c860 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411252c8c0 = PRIM_CDR(v0x7f411252c860);
-Obj v0x7f411252c8e0 = PRIM_CDR(v0x7f411252c8c0);
-Obj v0x7f411252c900 = PRIM_CDR(v0x7f411252c8e0);
-Obj v0x7f411252c940 = PRIM_EQ(Nil, v0x7f411252c900);
-if (True == v0x7f411252c940) {
+Obj x140246339859527 = __arg1;
+Obj x140246339852743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339859559 = makeCons(symbegin, x140246339859527);
+Obj x140246339859623 = makeCons(x140246339859559, Nil);
+Obj x140246339859655 = makeCons(x140246339852743, x140246339859623);
+Obj x140246339859687 = makeCons(closureRef(co, 0), x140246339859655);
+Obj x140246339859719 = makeCons(symns, x140246339859687);
 __nargs = 2;
-__arg1 = y;
+__arg1 = x140246339859719;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125296e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label27:
 {
-Obj v0x7f41125299a0 = makeNative(28, clofun1, 0, 1, closureRef(co, 0));
-Obj v0x7f4112485900 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112485900) {
-Obj v0x7f4112485ac0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112485ae0 = PRIM_EQ(symif, v0x7f4112485ac0);
-if (True == v0x7f4112485ae0) {
-Obj v0x7f4112485c80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485ca0 = PRIM_ISCONS(v0x7f4112485c80);
-if (True == v0x7f4112485ca0) {
-Obj v0x7f4112485f00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112485f20 = PRIM_CAR(v0x7f4112485f00);
-Obj v0x7f4112485f40 = PRIM_EQ(False, v0x7f4112485f20);
-if (True == v0x7f4112485f40) {
-Obj v0x7f411245b180 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b1a0 = PRIM_CDR(v0x7f411245b180);
-Obj v0x7f411245b1c0 = PRIM_ISCONS(v0x7f411245b1a0);
-if (True == v0x7f411245b1c0) {
-Obj v0x7f411245b400 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b420 = PRIM_CDR(v0x7f411245b400);
-Obj v0x7f411245b440 = PRIM_CAR(v0x7f411245b420);
-Obj y = v0x7f411245b440;
-Obj v0x7f411245b720 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245b740 = PRIM_CDR(v0x7f411245b720);
-Obj v0x7f411245b760 = PRIM_CDR(v0x7f411245b740);
-Obj v0x7f411245b780 = PRIM_ISCONS(v0x7f411245b760);
-if (True == v0x7f411245b780) {
-Obj v0x7f411245ba60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245ba80 = PRIM_CDR(v0x7f411245ba60);
-Obj v0x7f411245baa0 = PRIM_CDR(v0x7f411245ba80);
-Obj v0x7f411245bac0 = PRIM_CAR(v0x7f411245baa0);
-Obj z = v0x7f411245bac0;
-Obj v0x7f411245be60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411245be80 = PRIM_CDR(v0x7f411245be60);
-Obj v0x7f411245bea0 = PRIM_CDR(v0x7f411245be80);
-Obj v0x7f4112570040 = PRIM_CDR(v0x7f411245bea0);
-Obj v0x7f4112570060 = PRIM_EQ(Nil, v0x7f4112570040);
-if (True == v0x7f4112570060) {
+Obj imp = __arg1;
+Obj x140246339853927 = makeCons(imp, Nil);
+Obj x140246339853959 = makeCons(symimport, x140246339853927);
 __nargs = 2;
-__arg1 = z;
+__arg1 = x140246339853959;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41125299a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label28:
 {
-Obj v0x7f4112529f20 = makeNative(29, clofun1, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj data = __arg1;
+Obj k = __arg2;
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
+__arg1 = data;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = k;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label29:
+{
+Obj x140246338973671 = __arg1;
+Obj x140246338949127 = __arg2;
+Obj x140246338949159 = __arg3;
+Obj x140246338949223 = co->args[4];
+Obj x140246338949575 = makeNative(30, clofun1, 0, 4, x140246338973671, x140246338949127, x140246338949159, x140246338949223);
+Obj x140246337971911 = PRIM_ISCONS(x140246338973671);
+if (True == x140246337971911) {
+Obj x140246337972391 = PRIM_CAR(x140246338973671);
+Obj x140246337972423 = PRIM_ISCONS(x140246337972391);
+if (True == x140246337972423) {
+Obj x140246337973127 = PRIM_CAR(x140246338973671);
+Obj x140246337973159 = PRIM_CAR(x140246337973127);
+Obj x140246337973191 = PRIM_EQ(symimport, x140246337973159);
+if (True == x140246337973191) {
+Obj x140246337973863 = PRIM_CAR(x140246338973671);
+Obj x140246337973895 = PRIM_CDR(x140246337973863);
+Obj x140246337973927 = PRIM_ISCONS(x140246337973895);
+if (True == x140246337973927) {
+Obj x140246337885383 = PRIM_CAR(x140246338973671);
+Obj x140246337885415 = PRIM_CDR(x140246337885383);
+Obj x140246337885447 = PRIM_CAR(x140246337885415);
+Obj lib = x140246337885447;
+Obj x140246337886343 = PRIM_CAR(x140246338973671);
+Obj x140246337886375 = PRIM_CDR(x140246337886343);
+Obj x140246337886407 = PRIM_CDR(x140246337886375);
+Obj x140246337886439 = PRIM_EQ(Nil, x140246337886407);
+if (True == x140246337886439) {
+Obj x140246337886695 = PRIM_CDR(x140246338973671);
+Obj rest = x140246337886695;
+Obj imports = x140246338949127;
+Obj exports = x140246338949159;
+Obj k = x140246338949223;
+Obj x140246337887399 = makeCons(lib, imports);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
+__arg1 = rest;
+__arg2 = x140246337887399;
+__arg3 = exports;
+co->args[4] = k;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label30:
+{
+Obj x140246338950663 = makeNative(31, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140246338169415 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338169415) {
+Obj x140246338169831 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338169863 = PRIM_ISCONS(x140246338169831);
+if (True == x140246338169863) {
+Obj x140246338170535 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338170567 = PRIM_CAR(x140246338170535);
+Obj x140246338170599 = PRIM_EQ(symexport, x140246338170567);
+if (True == x140246338170599) {
+Obj x140246337970343 = PRIM_CAR(closureRef(co, 0));
+Obj x140246337970375 = PRIM_CDR(x140246337970343);
+Obj more = x140246337970375;
+Obj x140246337970663 = PRIM_CDR(closureRef(co, 0));
+Obj rest = x140246337970663;
+Obj imports = closureRef(co, 1);
+Obj exports = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
+__arg1 = rest;
+__arg2 = imports;
+__arg3 = more;
+co->args[4] = k;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338950663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label31:
+{
+Obj x140246338951559 = makeNative(33, clofun1, 0, 0);
+Obj body = closureRef(co, 0);
+Obj imports = closureRef(co, 1);
+Obj exports = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+pushCont(co, 32, clofun1, 3, k, exports, body);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = imports;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label32:
+{
+Obj x140246338169095 = __arg1;
+Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+__nargs = 4;
+__arg0 = k;
+__arg1 = x140246338169095;
+__arg2 = exports;
+__arg3 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label33:
 {
 __nargs = 2;
 __arg0 = globalRef(symerror);
@@ -3387,75 +2861,10 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
-{
-Obj exp = __arg1;
-pushCont(co, 31, clofun1, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label31:
-{
-Obj v0x7f4112487160 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 32, clofun1, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = v0x7f4112487160;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj v0x7f4112487180 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = v0x7f4112487180;
-pushCont(co, 33, clofun1, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rules_45arg_45count);
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label33:
-{
-Obj v0x7f4112487280 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = v0x7f4112487280;
-pushCont(co, 34, clofun1, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = nargs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label34:
 {
-Obj v0x7f41124873a0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = v0x7f41124873a0;
-pushCont(co, 35, clofun1, 2, body, args);
+Obj exp = __arg1;
+PUSH_CONT_0(co, 35, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -3468,40 +2877,34 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f4112487600 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112487f40 = makeCons(symlist, args);
-Obj v0x7f4112487f80 = makeCons(v0x7f4112487f40, body);
-Obj v0x7f4112487fa0 = makeCons(symmatch, v0x7f4112487f80);
-Obj v0x7f4112487fe0 = makeCons(v0x7f4112487fa0, Nil);
-Obj v0x7f4112485000 = makeCons(args, v0x7f4112487fe0);
-Obj v0x7f4112485020 = makeCons(v0x7f4112487600, v0x7f4112485000);
-Obj v0x7f4112485040 = makeCons(symdefun, v0x7f4112485020);
+Obj x140246338167559 = __arg1;
 __nargs = 2;
-__arg1 = v0x7f4112485040;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47init_35rewrite_45backquote);
+__arg1 = x140246338167559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label36:
 {
-Obj n = __arg1;
-Obj v0x7f411248aa00 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == v0x7f411248aa00) {
+Obj x140246338971655 = __arg1;
+Obj x140246338971815 = makeNative(37, clofun1, 0, 1, x140246338971655);
+Obj x = x140246338971655;
+Obj x140246338207047 = primIsSymbol(x);
+if (True == x140246338207047) {
+Obj x140246338207559 = makeCons(x, Nil);
+Obj x140246338207591 = makeCons(symquote, x140246338207559);
 __nargs = 2;
-__arg1 = Nil;
+__arg1 = x140246338207591;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f411248aba0 = primGenSym();
-Obj v0x7f411248ad40 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 37, clofun1, 1, v0x7f411248aba0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = v0x7f411248ad40;
+__nargs = 1;
+__arg0 = x140246338971815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3512,76 +2915,123 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f411248ad60 = __arg1;
-Obj v0x7f411248aba0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411248ad80 = makeCons(v0x7f411248aba0, v0x7f411248ad60);
+Obj x140246338972071 = makeNative(38, clofun1, 0, 1, closureRef(co, 0));
+Obj x140246338203751 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338203751) {
+Obj x140246338204359 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338204391 = PRIM_EQ(symunquote, x140246338204359);
+if (True == x140246338204391) {
+Obj x140246338204807 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338204839 = PRIM_ISCONS(x140246338204807);
+if (True == x140246338204839) {
+Obj x140246338205287 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338205319 = PRIM_CAR(x140246338205287);
+Obj x = x140246338205319;
+Obj x140246338206055 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338206087 = PRIM_CDR(x140246338206055);
+Obj x140246338206119 = PRIM_EQ(Nil, x140246338206087);
+if (True == x140246338206119) {
 __nargs = 2;
-__arg1 = v0x7f411248ad80;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338972071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label38:
+{
+Obj x140246338972551 = makeNative(40, clofun1, 0, 1, closureRef(co, 0));
+Obj x140246338230407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338230407) {
+Obj x140246338230791 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140246338230791;
+Obj x140246338231239 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140246338231239;
+Obj x140246338231975 = makeCons(x, more);
+PUSH_CONT_0(co, 39, clofun1);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = globalRef(symcora_47init_35rewrite_45backquote);
+__arg2 = x140246338231975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338972551;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label39:
+{
+Obj x140246338232007 = __arg1;
+Obj x140246338232039 = makeCons(symlist, x140246338232007);
+__nargs = 2;
+__arg1 = x140246338232039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label38:
-{
-Obj rules = __arg1;
-PUSH_CONT_0(co, 39, clofun1);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = Nil;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label39:
-{
-Obj v0x7f411248cbe0 = __arg1;
-Obj pats = v0x7f411248cbe0;
-Obj len = makeNative(44, clofun1, 1, 0);
-PUSH_CONT_0(co, 40, clofun1);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = len;
-__arg2 = pats;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label40:
 {
-Obj v0x7f411248cee0 = __arg1;
-Obj counts = v0x7f411248cee0;
-Obj v0x7f411248cfe0 = PRIM_CAR(counts);
-Obj n = v0x7f411248cfe0;
-Obj dif = makeNative(43, clofun1, 1, 1, n);
-Obj v0x7f411248a620 = PRIM_CDR(counts);
-pushCont(co, 41, clofun1, 1, n);
-__nargs = 3;
-__arg0 = globalRef(symfilter);
-__arg1 = dif;
-__arg2 = v0x7f411248a620;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140246338972967 = makeNative(41, clofun1, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label41:
 {
-Obj v0x7f411248a640 = __arg1;
-Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 42, clofun1, 1, n);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = v0x7f411248a640;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3591,72 +3041,129 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f411248a680 = __arg1;
-Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411248a6a0 = primNot(v0x7f411248a680);
-if (True == v0x7f411248a6a0) {
+Obj exp = __arg1;
+Obj x140246338228711 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("inconsistent func rule args count");
+__arg0 = globalRef(symcora_47init_35rewrite_45begin);
+__arg1 = x140246338228711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = n;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
 }
 
 label43:
 {
-Obj x = __arg1;
-Obj v0x7f411248a240 = PRIM_EQ(closureRef(co, 0), x);
-Obj v0x7f411248a2e0 = primNot(v0x7f411248a240);
+Obj x140246338969895 = __arg1;
+Obj x140246338970023 = makeNative(44, clofun1, 0, 1, x140246338969895);
+Obj x140246338251047 = PRIM_ISCONS(x140246338969895);
+if (True == x140246338251047) {
+Obj x140246338251303 = PRIM_CAR(x140246338969895);
+Obj x = x140246338251303;
+Obj x140246338251911 = PRIM_CDR(x140246338969895);
+Obj x140246338251943 = PRIM_EQ(Nil, x140246338251911);
+if (True == x140246338251943) {
 __nargs = 2;
-__arg1 = v0x7f411248a2e0;
+__arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-}
-
-label44:
-{
-Obj x = __arg1;
-Obj v0x7f411248cdc0 = PRIM_CDR(x);
-__nargs = 2;
-__arg0 = globalRef(symlength);
-__arg1 = v0x7f411248cdc0;
+} else {
+__nargs = 1;
+__arg0 = x140246338970023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140246338970023;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
-label45:
+label44:
 {
-Obj l1 = __arg1;
-Obj l2 = __arg2;
-Obj v0x7f411248c460 = PRIM_EQ(l1, Nil);
-if (True == v0x7f411248c460) {
+Obj x140246338970535 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
+Obj x140246338352935 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338352935) {
+Obj x140246338353287 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140246338353287;
+Obj x140246338353991 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338354023 = PRIM_ISCONS(x140246338353991);
+if (True == x140246338354023) {
+Obj x140246338354631 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338354663 = PRIM_CAR(x140246338354631);
+Obj y = x140246338354663;
+Obj x140246338249095 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338249127 = PRIM_CDR(x140246338249095);
+Obj x140246338249159 = PRIM_EQ(Nil, x140246338249127);
+if (True == x140246338249159) {
+Obj x140246338250151 = makeCons(y, Nil);
+Obj x140246338250183 = makeCons(x, x140246338250151);
+Obj x140246338250215 = makeCons(symdo, x140246338250183);
 __nargs = 2;
-__arg1 = l2;
+__arg1 = x140246338250215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f411248c5e0 = PRIM_CAR(l1);
-Obj v0x7f411248c860 = PRIM_CDR(l1);
-pushCont(co, 46, clofun1, 1, v0x7f411248c5e0);
-__nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = v0x7f411248c860;
-__arg2 = l2;
+__nargs = 1;
+__arg0 = x140246338970535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label45:
+{
+Obj x140246338971079 = makeNative(47, clofun1, 0, 0);
+Obj x140246338452615 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338452615) {
+Obj x140246338453127 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140246338453127;
+Obj x140246338453383 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140246338453383;
+pushCont(co, 46, clofun1, 1, x);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45begin);
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338971079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3667,11 +3174,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f411248c8a0 = __arg1;
-Obj v0x7f411248c5e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411248c8c0 = makeCons(v0x7f411248c5e0, v0x7f411248c8a0);
+Obj x140246338352263 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338352359 = makeCons(x140246338352263, Nil);
+Obj x140246338352391 = makeCons(x, x140246338352359);
+Obj x140246338352423 = makeCons(symdo, x140246338352391);
 __nargs = 2;
-__arg1 = v0x7f411248c8c0;
+__arg1 = x140246338352423;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3679,13 +3188,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label47:
 {
-Obj fn = __arg1;
-Obj l = __arg2;
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = Nil;
-__arg2 = fn;
-__arg3 = l;
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3695,66 +3200,30 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj res = __arg1;
-Obj fn = __arg2;
-Obj l = __arg3;
-Obj v0x7f41124ad440 = PRIM_ISCONS(l);
-if (True == v0x7f41124ad440) {
-Obj v0x7f41124ad660 = PRIM_CAR(l);
-pushCont(co, 49, clofun1, 3, l, res, fn);
+Obj exp = __arg1;
+PUSH_CONT_0(co, 49, clofun1);
 __nargs = 2;
-__arg0 = fn;
-__arg1 = v0x7f41124ad660;
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = res;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label49:
 {
-Obj v0x7f41124ad680 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == v0x7f41124ad680) {
-Obj v0x7f41124ada20 = PRIM_CAR(l);
-Obj v0x7f41124ada60 = makeCons(v0x7f41124ada20, res);
-Obj v0x7f41124adb60 = PRIM_CDR(l);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = v0x7f41124ada60;
-__arg2 = fn;
-__arg3 = v0x7f41124adb60;
+Obj x140246338450951 = __arg1;
+PUSH_CONT_0(co, 0, clofun2);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45namespace);
+__arg1 = x140246338450951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj v0x7f41124add60 = PRIM_CDR(l);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = res;
-__arg2 = fn;
-__arg3 = v0x7f41124add60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 fail:
@@ -3779,11 +3248,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj l = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = MAKE_NUMBER(0);
-__arg2 = l;
+Obj x140246338450983 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x140246338450983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3793,66 +3261,196 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj i = __arg1;
-Obj l = __arg2;
-Obj v0x7f41124c4a80 = PRIM_EQ(l, Nil);
-if (True == v0x7f41124c4a80) {
-__nargs = 2;
-__arg1 = i;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124c4cc0 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj v0x7f41124c4de0 = PRIM_CDR(l);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = v0x7f41124c4cc0;
-__arg2 = v0x7f41124c4de0;
+Obj exp = __arg1;
+Obj x140246338496999 = PRIM_ISCONS(exp);
+if (True == x140246338496999) {
+Obj x140246338497479 = PRIM_CAR(exp);
+Obj x140246338497511 = PRIM_EQ(symns, x140246338497479);
+if (True == x140246338497511) {
+if (True == True) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = Nil;
+__arg2 = makeCString("");
+__arg3 = Nil;
+co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+if (True == False) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = Nil;
+__arg2 = makeCString("");
+__arg3 = Nil;
+co->args[4] = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+} else {
+if (True == False) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = Nil;
+__arg2 = makeCString("");
+__arg3 = Nil;
+co->args[4] = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 }
 
 label2:
 {
-Obj res = __arg1;
-Obj rules = __arg2;
-pushCont(co, 3, clofun2, 2, res, rules);
+Obj x140246338970183 = __arg1;
+Obj x140246338970343 = makeNative(3, clofun2, 0, 1, x140246338970183);
+Obj x140246338552967 = PRIM_ISCONS(x140246338970183);
+if (True == x140246338552967) {
+Obj x140246338553511 = PRIM_CAR(x140246338970183);
+Obj x140246338553543 = PRIM_EQ(symquote, x140246338553511);
+if (True == x140246338553543) {
+Obj x140246338554087 = PRIM_CDR(x140246338970183);
+Obj x140246338554119 = PRIM_ISCONS(x140246338554087);
+if (True == x140246338554119) {
+Obj x140246338554855 = PRIM_CDR(x140246338970183);
+Obj x140246338554887 = PRIM_CAR(x140246338554855);
+Obj x = x140246338554887;
+Obj x140246338555655 = PRIM_CDR(x140246338970183);
+Obj x140246338555687 = PRIM_CDR(x140246338555655);
+Obj x140246338555751 = PRIM_EQ(Nil, x140246338555687);
+if (True == x140246338555751) {
+Obj x140246338495111 = makeCons(x, Nil);
+Obj x140246338495143 = makeCons(symquote, x140246338495111);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = rules;
+__arg1 = x140246338495143;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338970343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140246338970343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label3:
 {
-Obj v0x7f41124c42e0 = __arg1;
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41124c42e0) {
+Obj x140246338970855 = makeNative(5, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338627815 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338627815) {
+Obj x140246338628423 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338628455 = PRIM_EQ(symcons_63, x140246338628423);
+if (True == x140246338628455) {
+Obj x140246338629319 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338629351 = PRIM_ISCONS(x140246338629319);
+if (True == x140246338629351) {
+Obj x140246338601223 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338601255 = PRIM_CAR(x140246338601223);
+Obj x = x140246338601255;
+Obj x140246338602471 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338602503 = PRIM_CDR(x140246338602471);
+Obj x140246338602535 = PRIM_EQ(Nil, x140246338602503);
+if (True == x140246338602535) {
+PUSH_CONT_0(co, 4, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = res;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41124c4620 = PRIM_CAR(rules);
-Obj v0x7f41124c4660 = makeCons(v0x7f41124c4620, res);
-pushCont(co, 4, clofun2, 1, v0x7f41124c4660);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = rules;
+__nargs = 1;
+__arg0 = x140246338970855;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970855;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970855;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3863,12 +3461,13 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41124c4780 = __arg1;
-Obj v0x7f41124c4660= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = v0x7f41124c4660;
-__arg2 = v0x7f41124c4780;
+Obj x140246338602823 = __arg1;
+Obj x1 = x140246338602823;
+Obj x140246338604103 = makeCons(x1, Nil);
+Obj x140246338604839 = makeCons(symcons_63, x140246338604103);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246338604839;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3878,88 +3477,107 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj input = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = input;
-__arg2 = Nil;
-__arg3 = Nil;
+Obj x140246338971335 = makeNative(7, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338826215 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338826215) {
+Obj x140246338699975 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338700007 = PRIM_EQ(symcar, x140246338699975);
+if (True == x140246338700007) {
+Obj x140246338700711 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338700775 = PRIM_ISCONS(x140246338700711);
+if (True == x140246338700775) {
+Obj x140246338701767 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338701799 = PRIM_CAR(x140246338701767);
+Obj x = x140246338701799;
+Obj x140246338702791 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338702887 = PRIM_CDR(x140246338702791);
+Obj x140246338702919 = PRIM_EQ(Nil, x140246338702887);
+if (True == x140246338702919) {
+PUSH_CONT_0(co, 6, clofun2);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338971335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label6:
 {
-Obj input = __arg1;
-Obj current = __arg2;
-Obj result = __arg3;
-Obj v0x7f411252c080 = makeNative(7, clofun2, 0, 3, input, current, result);
-Obj v0x7f41124cbba0 = PRIM_EQ(Nil, input);
-if (True == v0x7f41124cbba0) {
+Obj x140246338703239 = __arg1;
+Obj x1 = x140246338703239;
+Obj x140246338626183 = makeCons(x1, Nil);
+Obj x140246338626215 = makeCons(symcar, x140246338626183);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = result;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246338626215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label7:
 {
-Obj v0x7f411252c0e0 = makeNative(9, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj v0x7f4112512d40 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112512d40) {
-Obj v0x7f41124eb040 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124eb060 = PRIM_EQ(sym_61_62, v0x7f41124eb040);
-if (True == v0x7f41124eb060) {
-Obj v0x7f41124eb260 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb2a0 = PRIM_ISCONS(v0x7f41124eb260);
-if (True == v0x7f41124eb2a0) {
-Obj v0x7f41124eb4c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb580 = PRIM_CAR(v0x7f41124eb4c0);
-Obj act = v0x7f41124eb580;
-Obj v0x7f41124eb7e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb800 = PRIM_CDR(v0x7f41124eb7e0);
-Obj v0x7f41124eb820 = PRIM_ISCONS(v0x7f41124eb800);
-if (True == v0x7f41124eb820) {
-Obj v0x7f41124ebcc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ebce0 = PRIM_CDR(v0x7f41124ebcc0);
-Obj v0x7f41124ebd00 = PRIM_CAR(v0x7f41124ebce0);
-Obj v0x7f41124ebd20 = PRIM_EQ(symwhere, v0x7f41124ebd00);
-if (True == v0x7f41124ebd20) {
-Obj v0x7f41124d9080 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d90a0 = PRIM_CDR(v0x7f41124d9080);
-Obj v0x7f41124d90e0 = PRIM_CDR(v0x7f41124d90a0);
-Obj v0x7f41124d9120 = PRIM_ISCONS(v0x7f41124d90e0);
-if (True == v0x7f41124d9120) {
-Obj v0x7f41124d9660 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9680 = PRIM_CDR(v0x7f41124d9660);
-Obj v0x7f41124d96a0 = PRIM_CDR(v0x7f41124d9680);
-Obj v0x7f41124d96c0 = PRIM_CAR(v0x7f41124d96a0);
-Obj pred = v0x7f41124d96c0;
-Obj v0x7f41124d9ae0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9b00 = PRIM_CDR(v0x7f41124d9ae0);
-Obj v0x7f41124d9b20 = PRIM_CDR(v0x7f41124d9b00);
-Obj v0x7f41124d9b40 = PRIM_CDR(v0x7f41124d9b20);
-Obj remain = v0x7f41124d9b40;
-pushCont(co, 8, clofun2, 3, act, pred, remain);
+Obj x140246338971783 = makeNative(9, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338951111 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338951111) {
+Obj x140246338951975 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338952007 = PRIM_EQ(symcdr, x140246338951975);
+if (True == x140246338952007) {
+Obj x140246338952679 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338952743 = PRIM_ISCONS(x140246338952679);
+if (True == x140246338952743) {
+Obj x140246338822439 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338822471 = PRIM_CAR(x140246338822439);
+Obj x = x140246338822471;
+Obj x140246338823783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338823847 = PRIM_CDR(x140246338823783);
+Obj x140246338823879 = PRIM_EQ(Nil, x140246338823847);
+if (True == x140246338823879) {
+PUSH_CONT_0(co, 8, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = closureRef(co, 1);
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3967,16 +3585,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c0e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c0e0;
+__arg0 = x140246338971783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3985,7 +3594,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c0e0;
+__arg0 = x140246338971783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3994,7 +3603,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c0e0;
+__arg0 = x140246338971783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4003,16 +3612,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c0e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c0e0;
+__arg0 = x140246338971783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4023,22 +3623,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f41124d9dc0 = __arg1;
-Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41124d9de0 = makeCons(symlist, v0x7f41124d9dc0);
-Obj pat = v0x7f41124d9de0;
-Obj v0x7f41124cb420 = makeCons(act, Nil);
-Obj v0x7f41124cb440 = makeCons(pred, v0x7f41124cb420);
-Obj v0x7f41124cb460 = makeCons(symwhere, v0x7f41124cb440);
-Obj v0x7f41124cb5c0 = makeCons(pat, closureRef(co, 2));
-Obj v0x7f41124cb5e0 = makeCons(v0x7f41124cb460, v0x7f41124cb5c0);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = v0x7f41124cb5e0;
+Obj x140246338824231 = __arg1;
+Obj x1 = x140246338824231;
+Obj x140246338825127 = makeCons(x1, Nil);
+Obj x140246338825159 = makeCons(symcdr, x140246338825127);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246338825159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4048,25 +3639,35 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f411252c300 = makeNative(11, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj v0x7f4112529800 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112529800) {
-Obj v0x7f4112529a40 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112529a60 = PRIM_EQ(sym_61_62, v0x7f4112529a40);
-if (True == v0x7f4112529a60) {
-Obj v0x7f4112529fc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112529fe0 = PRIM_ISCONS(v0x7f4112529fc0);
-if (True == v0x7f4112529fe0) {
-Obj v0x7f4112512200 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512240 = PRIM_CAR(v0x7f4112512200);
-Obj act = v0x7f4112512240;
-Obj v0x7f4112512520 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512540 = PRIM_CDR(v0x7f4112512520);
-Obj remain = v0x7f4112512540;
-pushCont(co, 10, clofun2, 2, act, remain);
+Obj x140246338972263 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339373639 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339373639) {
+Obj x140246339374599 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339374695 = PRIM_EQ(symand, x140246339374599);
+if (True == x140246339374695) {
+Obj x140246339318215 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339318247 = PRIM_ISCONS(x140246339318215);
+if (True == x140246339318247) {
+Obj x140246339318823 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339318855 = PRIM_CAR(x140246339318823);
+Obj x = x140246339318855;
+Obj x140246339319783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339319847 = PRIM_CDR(x140246339319783);
+Obj x140246339319879 = PRIM_ISCONS(x140246339319847);
+if (True == x140246339319879) {
+Obj x140246339320839 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339320871 = PRIM_CDR(x140246339320839);
+Obj x140246339320903 = PRIM_CAR(x140246339320871);
+Obj y = x140246339320903;
+Obj x140246338970247 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338970311 = PRIM_CDR(x140246338970247);
+Obj x140246338970407 = PRIM_CDR(x140246338970311);
+Obj x140246338970471 = PRIM_EQ(Nil, x140246338970407);
+if (True == x140246338970471) {
+pushCont(co, 10, clofun2, 1, y);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = closureRef(co, 1);
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4074,16 +3675,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c300;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411252c300;
+__arg0 = x140246338972263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4092,7 +3684,34 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c300;
+__arg0 = x140246338972263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4103,18 +3722,13 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f4112512740 = __arg1;
-Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112512760 = makeCons(symlist, v0x7f4112512740);
-Obj pat = v0x7f4112512760;
-Obj v0x7f4112512a00 = makeCons(pat, closureRef(co, 2));
-Obj v0x7f4112512a20 = makeCons(act, v0x7f4112512a00);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = v0x7f4112512a20;
+Obj x140246338971047 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x1 = x140246338971047;
+pushCont(co, 11, clofun2, 1, x1);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4124,19 +3738,44 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f411252c440 = makeNative(12, clofun2, 0, 0);
-Obj v0x7f41125290a0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125290a0) {
-Obj v0x7f4112529200 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f4112529200;
-Obj v0x7f4112529320 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f4112529320;
-Obj v0x7f41125295a0 = makeCons(x, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = y;
-__arg2 = v0x7f41125295a0;
-__arg3 = closureRef(co, 2);
+Obj x140246338971495 = __arg1;
+Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y1 = x140246338971495;
+Obj x140246338973159 = makeCons(y1, Nil);
+Obj x140246338973191 = makeCons(x1, x140246338973159);
+Obj x140246338973223 = makeCons(symand, x140246338973191);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246338973223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj x140246338972871 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339621671 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339621671) {
+Obj x140246339622503 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339622535 = PRIM_EQ(symnull_63, x140246339622503);
+if (True == x140246339622535) {
+Obj x140246339623143 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339623335 = PRIM_ISCONS(x140246339623143);
+if (True == x140246339623335) {
+Obj x140246339623879 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339623911 = PRIM_CAR(x140246339623879);
+Obj x = x140246339623911;
+Obj x140246339371015 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339371047 = PRIM_CDR(x140246339371015);
+Obj x140246339371079 = PRIM_EQ(Nil, x140246339371047);
+if (True == x140246339371079) {
+PUSH_CONT_0(co, 13, clofun2);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4144,7 +3783,34 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411252c440;
+__arg0 = x140246338972871;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972871;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972871;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4153,7 +3819,399 @@ goto *jumpTable[ps.label];
 }
 }
 
-label12:
+label13:
+{
+Obj x140246339371527 = __arg1;
+Obj x1 = x140246339371527;
+Obj x140246339372519 = makeCons(x1, Nil);
+Obj x140246339372551 = makeCons(symnull_63, x140246339372519);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246339372551;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj x140246338973351 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339751399 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339751399) {
+Obj x140246339711079 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339711111 = PRIM_EQ(symnot, x140246339711079);
+if (True == x140246339711111) {
+Obj x140246339711879 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339711911 = PRIM_ISCONS(x140246339711879);
+if (True == x140246339711911) {
+Obj x140246339712359 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339712423 = PRIM_CAR(x140246339712359);
+Obj x = x140246339712423;
+Obj x140246339713447 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339713479 = PRIM_CDR(x140246339713447);
+Obj x140246339713511 = PRIM_EQ(Nil, x140246339713479);
+if (True == x140246339713511) {
+PUSH_CONT_0(co, 15, clofun2);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338973351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label15:
+{
+Obj x140246339713831 = __arg1;
+Obj x1 = x140246339713831;
+Obj x140246339714535 = makeCons(x1, Nil);
+Obj x140246339714759 = makeCons(symnot, x140246339714535);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246339714759;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj x140246338949255 = makeNative(20, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246337886887 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246337886887) {
+Obj x140246337887335 = PRIM_CAR(closureRef(co, 0));
+Obj x140246337887367 = PRIM_EQ(symif, x140246337887335);
+if (True == x140246337887367) {
+Obj x140246337887783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337887815 = PRIM_ISCONS(x140246337887783);
+if (True == x140246337887815) {
+Obj x140246337888231 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337862215 = PRIM_CAR(x140246337888231);
+Obj x = x140246337862215;
+Obj x140246339789319 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339789351 = PRIM_CDR(x140246339789319);
+Obj x140246339789383 = PRIM_ISCONS(x140246339789351);
+if (True == x140246339789383) {
+Obj x140246339789959 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339789991 = PRIM_CDR(x140246339789959);
+Obj x140246339790023 = PRIM_CAR(x140246339789991);
+Obj y = x140246339790023;
+Obj x140246339790439 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339790471 = PRIM_CDR(x140246339790439);
+Obj x140246339790503 = PRIM_CDR(x140246339790471);
+Obj x140246339790535 = PRIM_ISCONS(x140246339790503);
+if (True == x140246339790535) {
+Obj x140246339791271 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339791303 = PRIM_CDR(x140246339791271);
+Obj x140246339791335 = PRIM_CDR(x140246339791303);
+Obj x140246339791367 = PRIM_CAR(x140246339791335);
+Obj z = x140246339791367;
+Obj x140246339792295 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339792327 = PRIM_CDR(x140246339792295);
+Obj x140246339792359 = PRIM_CDR(x140246339792327);
+Obj x140246339792391 = PRIM_CDR(x140246339792359);
+Obj x140246339792423 = PRIM_EQ(Nil, x140246339792391);
+if (True == x140246339792423) {
+pushCont(co, 17, clofun2, 2, y, z);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949255;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label17:
+{
+Obj x140246339792679 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x1 = x140246339792679;
+pushCont(co, 18, clofun2, 2, z, x1);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj x140246339747879 = __arg1;
+Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj y1 = x140246339747879;
+pushCont(co, 19, clofun2, 2, y1, x1);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = z;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj x140246339748263 = __arg1;
+Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj z1 = x140246339748263;
+Obj x140246339749703 = makeCons(z1, Nil);
+Obj x140246339749735 = makeCons(y1, x140246339749703);
+Obj x140246339749767 = makeCons(x1, x140246339749735);
+Obj x140246339749799 = makeCons(symif, x140246339749767);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
+__arg1 = x140246339749799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj x140246338949959 = makeNative(22, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246337970855 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246337970855) {
+Obj x140246337971303 = PRIM_CAR(closureRef(co, 0));
+Obj x140246337971335 = PRIM_EQ(symlambda, x140246337971303);
+if (True == x140246337971335) {
+Obj x140246337971751 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337971783 = PRIM_ISCONS(x140246337971751);
+if (True == x140246337971783) {
+Obj x140246337972199 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337972231 = PRIM_CAR(x140246337972199);
+Obj args = x140246337972231;
+Obj x140246337972807 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337972839 = PRIM_CDR(x140246337972807);
+Obj x140246337972871 = PRIM_ISCONS(x140246337972839);
+if (True == x140246337972871) {
+Obj x140246337973447 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337973479 = PRIM_CDR(x140246337973447);
+Obj x140246337973511 = PRIM_CAR(x140246337973479);
+Obj body = x140246337973511;
+Obj x140246337885031 = PRIM_CDR(closureRef(co, 0));
+Obj x140246337885063 = PRIM_CDR(x140246337885031);
+Obj x140246337885095 = PRIM_CDR(x140246337885063);
+Obj x140246337885127 = PRIM_EQ(Nil, x140246337885095);
+if (True == x140246337885127) {
+pushCont(co, 21, clofun2, 1, args);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35propagate_45boolean);
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label21:
+{
+Obj x140246337885863 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246337885927 = makeCons(x140246337885863, Nil);
+Obj x140246337885959 = makeCons(args, x140246337885927);
+Obj x140246337885991 = makeCons(symlambda, x140246337885959);
+__nargs = 2;
+__arg1 = x140246337885991;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label22:
+{
+Obj x140246338950599 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338170247 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338170247) {
+Obj x140246338170503 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140246338170503;
+Obj x140246338170759 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140246338170759;
+Obj x140246337970471 = makeCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = globalRef(symcora_47init_35propagate_45boolean);
+__arg2 = x140246337970471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338950599;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label23:
+{
+Obj x140246338950983 = makeNative(24, clofun2, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label24:
 {
 __nargs = 2;
 __arg0 = globalRef(symerror);
@@ -4165,54 +4223,1128 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label25:
+{
+Obj x140246338970151 = __arg1;
+Obj x140246338970279 = makeNative(26, clofun2, 0, 1, x140246338970151);
+Obj x140246338353223 = PRIM_ISCONS(x140246338970151);
+if (True == x140246338353223) {
+Obj x140246338353895 = PRIM_CAR(x140246338970151);
+Obj x140246338353927 = PRIM_EQ(symcar, x140246338353895);
+if (True == x140246338353927) {
+Obj x140246338354343 = PRIM_CDR(x140246338970151);
+Obj x140246338354375 = PRIM_ISCONS(x140246338354343);
+if (True == x140246338354375) {
+Obj x140246338355175 = PRIM_CDR(x140246338970151);
+Obj x140246338248711 = PRIM_CAR(x140246338355175);
+Obj x140246338248743 = PRIM_ISCONS(x140246338248711);
+if (True == x140246338248743) {
+Obj x140246338249895 = PRIM_CDR(x140246338970151);
+Obj x140246338249927 = PRIM_CAR(x140246338249895);
+Obj x140246338249959 = PRIM_CAR(x140246338249927);
+Obj x140246338249991 = PRIM_EQ(symcons, x140246338249959);
+if (True == x140246338249991) {
+Obj x140246338250791 = PRIM_CDR(x140246338970151);
+Obj x140246338250823 = PRIM_CAR(x140246338250791);
+Obj x140246338250855 = PRIM_CDR(x140246338250823);
+Obj x140246338250887 = PRIM_ISCONS(x140246338250855);
+if (True == x140246338250887) {
+Obj x140246338251655 = PRIM_CDR(x140246338970151);
+Obj x140246338251687 = PRIM_CAR(x140246338251655);
+Obj x140246338251719 = PRIM_CDR(x140246338251687);
+Obj x140246338251751 = PRIM_CAR(x140246338251719);
+Obj x = x140246338251751;
+Obj x140246338252775 = PRIM_CDR(x140246338970151);
+Obj x140246338228231 = PRIM_CAR(x140246338252775);
+Obj x140246338228263 = PRIM_CDR(x140246338228231);
+Obj x140246338228295 = PRIM_CDR(x140246338228263);
+Obj x140246338228327 = PRIM_ISCONS(x140246338228295);
+if (True == x140246338228327) {
+Obj x140246338229415 = PRIM_CDR(x140246338970151);
+Obj x140246338229447 = PRIM_CAR(x140246338229415);
+Obj x140246338229479 = PRIM_CDR(x140246338229447);
+Obj x140246338229511 = PRIM_CDR(x140246338229479);
+Obj x140246338229543 = PRIM_CAR(x140246338229511);
+Obj __ = x140246338229543;
+Obj x140246338230855 = PRIM_CDR(x140246338970151);
+Obj x140246338230887 = PRIM_CAR(x140246338230855);
+Obj x140246338230919 = PRIM_CDR(x140246338230887);
+Obj x140246338230951 = PRIM_CDR(x140246338230919);
+Obj x140246338230983 = PRIM_CDR(x140246338230951);
+Obj x140246338231015 = PRIM_EQ(Nil, x140246338230983);
+if (True == x140246338231015) {
+Obj x140246338166791 = PRIM_CDR(x140246338970151);
+Obj x140246338166823 = PRIM_CDR(x140246338166791);
+Obj x140246338166855 = PRIM_EQ(Nil, x140246338166823);
+if (True == x140246338166855) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label26:
+{
+Obj x140246338971143 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338553831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338553831) {
+Obj x140246338554503 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338554535 = PRIM_EQ(symcdr, x140246338554503);
+if (True == x140246338554535) {
+Obj x140246338555047 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338555079 = PRIM_ISCONS(x140246338555047);
+if (True == x140246338555079) {
+Obj x140246338555783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338555815 = PRIM_CAR(x140246338555783);
+Obj x140246338555847 = PRIM_ISCONS(x140246338555815);
+if (True == x140246338555847) {
+Obj x140246338495495 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338495527 = PRIM_CAR(x140246338495495);
+Obj x140246338495559 = PRIM_CAR(x140246338495527);
+Obj x140246338495591 = PRIM_EQ(symcons, x140246338495559);
+if (True == x140246338495591) {
+Obj x140246338496647 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338496679 = PRIM_CAR(x140246338496647);
+Obj x140246338496711 = PRIM_CDR(x140246338496679);
+Obj x140246338496743 = PRIM_ISCONS(x140246338496711);
+if (True == x140246338496743) {
+Obj x140246338497575 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338497607 = PRIM_CAR(x140246338497575);
+Obj x140246338497639 = PRIM_CDR(x140246338497607);
+Obj x140246338497671 = PRIM_CAR(x140246338497639);
+Obj __ = x140246338497671;
+Obj x140246338449959 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338449991 = PRIM_CAR(x140246338449959);
+Obj x140246338450023 = PRIM_CDR(x140246338449991);
+Obj x140246338450055 = PRIM_CDR(x140246338450023);
+Obj x140246338450119 = PRIM_ISCONS(x140246338450055);
+if (True == x140246338450119) {
+Obj x140246338451143 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338451175 = PRIM_CAR(x140246338451143);
+Obj x140246338451207 = PRIM_CDR(x140246338451175);
+Obj x140246338451239 = PRIM_CDR(x140246338451207);
+Obj x140246338451271 = PRIM_CAR(x140246338451239);
+Obj x = x140246338451271;
+Obj x140246338452647 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338452679 = PRIM_CAR(x140246338452647);
+Obj x140246338452711 = PRIM_CDR(x140246338452679);
+Obj x140246338452743 = PRIM_CDR(x140246338452711);
+Obj x140246338452775 = PRIM_CDR(x140246338452743);
+Obj x140246338452871 = PRIM_EQ(Nil, x140246338452775);
+if (True == x140246338452871) {
+Obj x140246338351175 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338351207 = PRIM_CDR(x140246338351175);
+Obj x140246338351239 = PRIM_EQ(Nil, x140246338351207);
+if (True == x140246338351239) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label27:
+{
+Obj x140246338971943 = makeNative(28, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338825991 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338825991) {
+Obj x140246338699591 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338699623 = PRIM_EQ(symcons_63, x140246338699591);
+if (True == x140246338699623) {
+Obj x140246338700199 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338700231 = PRIM_ISCONS(x140246338700199);
+if (True == x140246338700231) {
+Obj x140246338701479 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338701511 = PRIM_CAR(x140246338701479);
+Obj x140246338701543 = PRIM_ISCONS(x140246338701511);
+if (True == x140246338701543) {
+Obj x140246338702503 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338702535 = PRIM_CAR(x140246338702503);
+Obj x140246338702567 = PRIM_CAR(x140246338702535);
+Obj x140246338702599 = PRIM_EQ(symcons, x140246338702567);
+if (True == x140246338702599) {
+Obj x140246338625831 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338625863 = PRIM_CAR(x140246338625831);
+Obj x140246338625895 = PRIM_CDR(x140246338625863);
+Obj x140246338625927 = PRIM_ISCONS(x140246338625895);
+if (True == x140246338625927) {
+Obj x140246338626951 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338626983 = PRIM_CAR(x140246338626951);
+Obj x140246338627015 = PRIM_CDR(x140246338626983);
+Obj x140246338627047 = PRIM_CAR(x140246338627015);
+Obj __ = x140246338627047;
+Obj x140246338628519 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338628551 = PRIM_CAR(x140246338628519);
+Obj x140246338628583 = PRIM_CDR(x140246338628551);
+Obj x140246338628615 = PRIM_CDR(x140246338628583);
+Obj x140246338628743 = PRIM_ISCONS(x140246338628615);
+if (True == x140246338628743) {
+Obj x140246338601287 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338601319 = PRIM_CAR(x140246338601287);
+Obj x140246338601351 = PRIM_CDR(x140246338601319);
+Obj x140246338601383 = PRIM_CDR(x140246338601351);
+Obj x140246338601415 = PRIM_CAR(x140246338601383);
+__ = x140246338601415;
+Obj x140246338603271 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338603335 = PRIM_CAR(x140246338603271);
+Obj x140246338603399 = PRIM_CDR(x140246338603335);
+Obj x140246338603431 = PRIM_CDR(x140246338603399);
+Obj x140246338603463 = PRIM_CDR(x140246338603431);
+Obj x140246338603495 = PRIM_EQ(Nil, x140246338603463);
+if (True == x140246338603495) {
+Obj x140246338604967 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338604999 = PRIM_CDR(x140246338604967);
+Obj x140246338605031 = PRIM_EQ(Nil, x140246338604999);
+if (True == x140246338605031) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338971943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label28:
+{
+Obj x140246338972743 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338973127 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338973127) {
+Obj x140246338949863 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338949895 = PRIM_EQ(symand, x140246338949863);
+if (True == x140246338949895) {
+Obj x140246338950407 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338950471 = PRIM_ISCONS(x140246338950407);
+if (True == x140246338950471) {
+Obj x140246338951655 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338951687 = PRIM_CAR(x140246338951655);
+Obj x140246338951719 = PRIM_EQ(True, x140246338951687);
+if (True == x140246338951719) {
+Obj x140246338952775 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338952839 = PRIM_CDR(x140246338952775);
+Obj x140246338952871 = PRIM_ISCONS(x140246338952839);
+if (True == x140246338952871) {
+Obj x140246338822919 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338823111 = PRIM_CDR(x140246338822919);
+Obj x140246338823143 = PRIM_CAR(x140246338823111);
+Obj x140246338823175 = PRIM_EQ(True, x140246338823143);
+if (True == x140246338823175) {
+Obj x140246338824391 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338824423 = PRIM_CDR(x140246338824391);
+Obj x140246338824455 = PRIM_CDR(x140246338824423);
+Obj x140246338824551 = PRIM_EQ(Nil, x140246338824455);
+if (True == x140246338824551) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338972743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label29:
+{
+Obj x140246338973319 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339319815 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339319815) {
+Obj x140246339320423 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339320455 = PRIM_EQ(symnull_63, x140246339320423);
+if (True == x140246339320455) {
+Obj x140246339321031 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339321063 = PRIM_ISCONS(x140246339321031);
+if (True == x140246339321063) {
+Obj x140246338969927 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338969959 = PRIM_CAR(x140246338969927);
+Obj x140246338969991 = PRIM_EQ(Nil, x140246338969959);
+if (True == x140246338969991) {
+Obj x140246338971271 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338971303 = PRIM_CDR(x140246338971271);
+Obj x140246338971367 = PRIM_EQ(Nil, x140246338971303);
+if (True == x140246338971367) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338973319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338973319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label30:
+{
+Obj x140246338949191 = makeNative(31, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339712103 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339712103) {
+Obj x140246339712583 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339712615 = PRIM_EQ(symnull_63, x140246339712583);
+if (True == x140246339712615) {
+Obj x140246339713255 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339713351 = PRIM_ISCONS(x140246339713255);
+if (True == x140246339713351) {
+Obj x140246339713991 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339714023 = PRIM_CAR(x140246339713991);
+Obj x140246339714055 = PRIM_ISCONS(x140246339714023);
+if (True == x140246339714055) {
+Obj x140246339620967 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339620999 = PRIM_CAR(x140246339620967);
+Obj x140246339621031 = PRIM_CAR(x140246339620999);
+Obj x140246339621063 = PRIM_EQ(symcons, x140246339621031);
+if (True == x140246339621063) {
+Obj x140246339621927 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339621959 = PRIM_CAR(x140246339621927);
+Obj x140246339621991 = PRIM_CDR(x140246339621959);
+Obj x140246339622023 = PRIM_ISCONS(x140246339621991);
+if (True == x140246339622023) {
+Obj x140246339623175 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339623207 = PRIM_CAR(x140246339623175);
+Obj x140246339623239 = PRIM_CDR(x140246339623207);
+Obj x140246339623303 = PRIM_CAR(x140246339623239);
+Obj __ = x140246339623303;
+Obj x140246339624583 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339624615 = PRIM_CAR(x140246339624583);
+Obj x140246339624647 = PRIM_CDR(x140246339624615);
+Obj x140246339624679 = PRIM_CDR(x140246339624647);
+Obj x140246339624711 = PRIM_ISCONS(x140246339624679);
+if (True == x140246339624711) {
+Obj x140246339372039 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339372071 = PRIM_CAR(x140246339372039);
+Obj x140246339372103 = PRIM_CDR(x140246339372071);
+Obj x140246339372135 = PRIM_CDR(x140246339372103);
+Obj x140246339372199 = PRIM_CAR(x140246339372135);
+__ = x140246339372199;
+Obj x140246339373671 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339373703 = PRIM_CAR(x140246339373671);
+Obj x140246339373735 = PRIM_CDR(x140246339373703);
+Obj x140246339373831 = PRIM_CDR(x140246339373735);
+Obj x140246339373863 = PRIM_CDR(x140246339373831);
+Obj x140246339374055 = PRIM_EQ(Nil, x140246339373863);
+if (True == x140246339374055) {
+Obj x140246339375079 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339317767 = PRIM_CDR(x140246339375079);
+Obj x140246339317799 = PRIM_EQ(Nil, x140246339317767);
+if (True == x140246339317799) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label31:
+{
+Obj x140246338949991 = makeNative(32, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246339748871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339748871) {
+Obj x140246339749319 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339749351 = PRIM_EQ(symnot, x140246339749319);
+if (True == x140246339749351) {
+Obj x140246339750055 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339750087 = PRIM_ISCONS(x140246339750055);
+if (True == x140246339750087) {
+Obj x140246339750855 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339750887 = PRIM_CAR(x140246339750855);
+Obj x140246339750919 = PRIM_EQ(True, x140246339750887);
+if (True == x140246339750919) {
+Obj x140246339751719 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339751751 = PRIM_CDR(x140246339751719);
+Obj x140246339751783 = PRIM_EQ(Nil, x140246339751751);
+if (True == x140246339751783) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338949991;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949991;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949991;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949991;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338949991;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label32:
+{
+Obj x140246338950439 = makeNative(33, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338205063 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338205063) {
+Obj x140246338205511 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338205543 = PRIM_EQ(symnot, x140246338205511);
+if (True == x140246338205543) {
+Obj x140246338205959 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338205991 = PRIM_ISCONS(x140246338205959);
+if (True == x140246338205991) {
+Obj x140246338206599 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338206631 = PRIM_CAR(x140246338206599);
+Obj x140246338206663 = PRIM_EQ(False, x140246338206631);
+if (True == x140246338206663) {
+Obj x140246338207271 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338207303 = PRIM_CDR(x140246338207271);
+Obj x140246338207335 = PRIM_EQ(Nil, x140246338207303);
+if (True == x140246338207335) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338950439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label33:
+{
+Obj x140246338950887 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338251559 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338251559) {
+Obj x140246338252007 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338252039 = PRIM_EQ(symif, x140246338252007);
+if (True == x140246338252039) {
+Obj x140246338252455 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338252487 = PRIM_ISCONS(x140246338252455);
+if (True == x140246338252487) {
+Obj x140246338228519 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338228551 = PRIM_CAR(x140246338228519);
+Obj x140246338228583 = PRIM_EQ(True, x140246338228551);
+if (True == x140246338228583) {
+Obj x140246338229159 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338229191 = PRIM_CDR(x140246338229159);
+Obj x140246338229223 = PRIM_ISCONS(x140246338229191);
+if (True == x140246338229223) {
+Obj x140246338229799 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338229831 = PRIM_CDR(x140246338229799);
+Obj x140246338229863 = PRIM_CAR(x140246338229831);
+Obj y = x140246338229863;
+Obj x140246338230599 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338230631 = PRIM_CDR(x140246338230599);
+Obj x140246338230663 = PRIM_CDR(x140246338230631);
+Obj x140246338230695 = PRIM_ISCONS(x140246338230663);
+if (True == x140246338230695) {
+Obj x140246338231431 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338231463 = PRIM_CDR(x140246338231431);
+Obj x140246338231495 = PRIM_CDR(x140246338231463);
+Obj x140246338231527 = PRIM_CAR(x140246338231495);
+Obj z = x140246338231527;
+Obj x140246338203783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338203815 = PRIM_CDR(x140246338203783);
+Obj x140246338203847 = PRIM_CDR(x140246338203815);
+Obj x140246338203879 = PRIM_CDR(x140246338203847);
+Obj x140246338203911 = PRIM_EQ(Nil, x140246338203879);
+if (True == x140246338203911) {
+__nargs = 2;
+__arg1 = y;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338950887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label34:
+{
+Obj x140246338951591 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
+Obj x140246338451783 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338451783) {
+Obj x140246338452263 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338452295 = PRIM_EQ(symif, x140246338452263);
+if (True == x140246338452295) {
+Obj x140246338452807 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338452839 = PRIM_ISCONS(x140246338452807);
+if (True == x140246338452839) {
+Obj x140246338453447 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338453479 = PRIM_CAR(x140246338453447);
+Obj x140246338351111 = PRIM_EQ(False, x140246338453479);
+if (True == x140246338351111) {
+Obj x140246338351911 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338351943 = PRIM_CDR(x140246338351911);
+Obj x140246338351975 = PRIM_ISCONS(x140246338351943);
+if (True == x140246338351975) {
+Obj x140246338352647 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338352679 = PRIM_CDR(x140246338352647);
+Obj x140246338352711 = PRIM_CAR(x140246338352679);
+Obj y = x140246338352711;
+Obj x140246338353511 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338353543 = PRIM_CDR(x140246338353511);
+Obj x140246338353575 = PRIM_CDR(x140246338353543);
+Obj x140246338353607 = PRIM_ISCONS(x140246338353575);
+if (True == x140246338353607) {
+Obj x140246338354439 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338354471 = PRIM_CDR(x140246338354439);
+Obj x140246338354503 = PRIM_CDR(x140246338354471);
+Obj x140246338354535 = PRIM_CAR(x140246338354503);
+Obj z = x140246338354535;
+Obj x140246338249191 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338249223 = PRIM_CDR(x140246338249191);
+Obj x140246338249255 = PRIM_CDR(x140246338249223);
+Obj x140246338249287 = PRIM_CDR(x140246338249255);
+Obj x140246338249351 = PRIM_EQ(Nil, x140246338249287);
+if (True == x140246338249351) {
+__nargs = 2;
+__arg1 = z;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338951591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label35:
+{
+Obj x140246338952295 = makeNative(36, clofun2, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label36:
+{
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
 {
 Obj exp = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45match);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj exp = __arg1;
-pushCont(co, 15, clofun2, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj v0x7f4112570620 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 16, clofun2, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = v0x7f4112570620;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj v0x7f4112570640 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = v0x7f4112570640;
-pushCont(co, 17, clofun2, 1, value);
+pushCont(co, 38, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -4223,625 +5355,30 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
-{
-Obj v0x7f41125707a0 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = v0x7f41125707a0;
-Obj v0x7f4112570900 = PRIM_ISCONS(value);
-if (True == v0x7f4112570900) {
-Obj v0x7f4112570c40 = PRIM_CAR(value);
-Obj v0x7f4112570ca0 = PRIM_EQ(symcons, v0x7f4112570c40);
-Obj v0x7f4112570ce0 = primNot(v0x7f4112570ca0);
-if (True == v0x7f4112570ce0) {
-if (True == True) {
-Obj v0x7f4112570de0 = primGenSym();
-Obj val = v0x7f4112570de0;
-pushCont(co, 20, clofun2, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj v0x7f4112563520 = primGenSym();
-Obj val = v0x7f4112563520;
-pushCont(co, 19, clofun2, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-Obj v0x7f4112563c80 = primGenSym();
-Obj val = v0x7f4112563c80;
-pushCont(co, 18, clofun2, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label18:
-{
-Obj v0x7f411252c1c0 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f411252c200 = makeCons(v0x7f411252c1c0, Nil);
-Obj v0x7f411252c260 = makeCons(value, v0x7f411252c200);
-Obj v0x7f411252c2c0 = makeCons(val, v0x7f411252c260);
-Obj v0x7f411252c320 = makeCons(symlet, v0x7f411252c2c0);
-__nargs = 2;
-__arg1 = v0x7f411252c320;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj v0x7f41125639e0 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112563a40 = makeCons(v0x7f41125639e0, Nil);
-Obj v0x7f4112563a60 = makeCons(value, v0x7f4112563a40);
-Obj v0x7f4112563a80 = makeCons(val, v0x7f4112563a60);
-Obj v0x7f4112563aa0 = makeCons(symlet, v0x7f4112563a80);
-__nargs = 2;
-__arg1 = v0x7f4112563aa0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj v0x7f4112563260 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125632a0 = makeCons(v0x7f4112563260, Nil);
-Obj v0x7f41125632e0 = makeCons(value, v0x7f41125632a0);
-Obj v0x7f4112563300 = makeCons(val, v0x7f41125632e0);
-Obj v0x7f4112563320 = makeCons(symlet, v0x7f4112563300);
-__nargs = 2;
-__arg1 = v0x7f4112563320;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label21:
-{
-Obj value = __arg1;
-Obj rules = __arg2;
-pushCont(co, 22, clofun2, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label22:
-{
-Obj v0x7f41124adc40 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41124adc40) {
-Obj v0x7f41124ade20 = makeCons(makeCString("no match-help found!"), Nil);
-Obj v0x7f41124ade40 = makeCons(symerror, v0x7f41124ade20);
-__nargs = 2;
-__arg1 = v0x7f41124ade40;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 23, clofun2, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label23:
-{
-Obj v0x7f41124adfa0 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41124adfa0) {
-Obj v0x7f411248c180 = PRIM_CDR(rules);
-pushCont(co, 28, clofun2, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = v0x7f411248c180;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
-Obj v0x7f41124872e0 = PRIM_CAR(rules);
-Obj pat = v0x7f41124872e0;
-Obj v0x7f41124873c0 = primGenSym();
-Obj cc = v0x7f41124873c0;
-pushCont(co, 24, clofun2, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label24:
-{
-Obj v0x7f41124874e0 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = v0x7f41124874e0;
-pushCont(co, 25, clofun2, 4, action, rules, value, cc);
-__nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label25:
-{
-Obj v0x7f4112487680 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 26, clofun2, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = v0x7f4112487680;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label26:
-{
-Obj v0x7f4112487700 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = v0x7f4112487700;
-Obj v0x7f4112487960 = PRIM_CDR(rules);
-Obj v0x7f4112487980 = PRIM_CDR(v0x7f4112487960);
-pushCont(co, 27, clofun2, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = v0x7f4112487980;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label27:
-{
-Obj v0x7f41124879a0 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = v0x7f41124879a0;
-Obj v0x7f4112487e20 = makeCons(rest, Nil);
-Obj v0x7f4112487e40 = makeCons(Nil, v0x7f4112487e20);
-Obj v0x7f4112487e60 = makeCons(symlambda, v0x7f4112487e40);
-Obj v0x7f4112570100 = makeCons(curr, Nil);
-Obj v0x7f4112570120 = makeCons(v0x7f4112487e60, v0x7f4112570100);
-Obj v0x7f4112570140 = makeCons(cc, v0x7f4112570120);
-Obj v0x7f4112570160 = makeCons(symlet, v0x7f4112570140);
-__nargs = 2;
-__arg1 = v0x7f4112570160;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label28:
-{
-Obj v0x7f411248c1a0 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f411248c1a0) {
-if (True == True) {
-Obj v0x7f411248c2e0 = PRIM_CAR(rules);
-Obj pat = v0x7f411248c2e0;
-Obj v0x7f411248c3c0 = primGenSym();
-Obj cc = v0x7f411248c3c0;
-pushCont(co, 33, clofun2, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj v0x7f411248a460 = PRIM_CAR(rules);
-Obj pat = v0x7f411248a460;
-Obj v0x7f411248a540 = primGenSym();
-Obj cc = v0x7f411248a540;
-pushCont(co, 29, clofun2, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label29:
-{
-Obj v0x7f411248a660 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = v0x7f411248a660;
-pushCont(co, 30, clofun2, 4, action, rules, value, cc);
-__nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj v0x7f411248a800 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 31, clofun2, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = v0x7f411248a800;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label31:
-{
-Obj v0x7f411248a880 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = v0x7f411248a880;
-Obj v0x7f411248aae0 = PRIM_CDR(rules);
-Obj v0x7f411248ab00 = PRIM_CDR(v0x7f411248aae0);
-pushCont(co, 32, clofun2, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = v0x7f411248ab00;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj v0x7f411248ab20 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = v0x7f411248ab20;
-Obj v0x7f411248afa0 = makeCons(rest, Nil);
-Obj v0x7f411248afc0 = makeCons(Nil, v0x7f411248afa0);
-Obj v0x7f411248afe0 = makeCons(symlambda, v0x7f411248afc0);
-Obj v0x7f41124870e0 = makeCons(curr, Nil);
-Obj v0x7f4112487100 = makeCons(v0x7f411248afe0, v0x7f41124870e0);
-Obj v0x7f4112487120 = makeCons(cc, v0x7f4112487100);
-Obj v0x7f4112487140 = makeCons(symlet, v0x7f4112487120);
-__nargs = 2;
-__arg1 = v0x7f4112487140;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label33:
-{
-Obj v0x7f411248c500 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = v0x7f411248c500;
-pushCont(co, 34, clofun2, 4, action, rules, value, cc);
-__nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label34:
-{
-Obj v0x7f411248c6c0 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 35, clofun2, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = v0x7f411248c6c0;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label35:
-{
-Obj v0x7f411248c740 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = v0x7f411248c740;
-Obj v0x7f411248ca40 = PRIM_CDR(rules);
-Obj v0x7f411248ca60 = PRIM_CDR(v0x7f411248ca40);
-pushCont(co, 36, clofun2, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = v0x7f411248ca60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label36:
-{
-Obj v0x7f411248caa0 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = v0x7f411248caa0;
-Obj v0x7f411248a120 = makeCons(rest, Nil);
-Obj v0x7f411248a140 = makeCons(Nil, v0x7f411248a120);
-Obj v0x7f411248a160 = makeCons(symlambda, v0x7f411248a140);
-Obj v0x7f411248a260 = makeCons(curr, Nil);
-Obj v0x7f411248a280 = makeCons(v0x7f411248a160, v0x7f411248a260);
-Obj v0x7f411248a2a0 = makeCons(cc, v0x7f411248a280);
-Obj v0x7f411248a2c0 = makeCons(symlet, v0x7f411248a2a0);
-__nargs = 2;
-__arg1 = v0x7f411248a2c0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label37:
-{
-Obj rules = __arg1;
-Obj cc = __arg2;
-Obj v0x7f41124c4180 = PRIM_CDR(rules);
-Obj v0x7f41124c41a0 = PRIM_CAR(v0x7f41124c4180);
-Obj action = v0x7f41124c41a0;
-pushCont(co, 38, clofun2, 2, cc, action);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label38:
 {
-Obj v0x7f41124c4320 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41124c4320) {
-Obj v0x7f41124c44c0 = PRIM_CAR(action);
-Obj v0x7f41124c4540 = PRIM_EQ(v0x7f41124c44c0, symwhere);
-if (True == v0x7f41124c4540) {
-if (True == True) {
-pushCont(co, 43, clofun2, 2, action, cc);
+Obj x140246338495623 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 39, clofun2, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
+__arg0 = globalRef(symcora_47init_35extract_45rules);
+__arg1 = x140246338495623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 41, clofun2, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-} else {
-if (True == False) {
-pushCont(co, 39, clofun2, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
 }
 
 label39:
 {
-Obj v0x7f41124ad540 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 40, clofun2, 2, cc, v0x7f41124ad540);
+Obj x140246338495655 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body = x140246338495655;
+pushCont(co, 40, clofun2, 2, exp, body);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
+__arg0 = globalRef(symcora_47init_35rules_45arg_45count);
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4851,30 +5388,31 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41124ad6e0 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124ad540= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124ad8a0 = makeCons(cc, Nil);
-Obj v0x7f41124ad8e0 = makeCons(v0x7f41124ad8a0, Nil);
-Obj v0x7f41124ad900 = makeCons(v0x7f41124ad6e0, v0x7f41124ad8e0);
-Obj v0x7f41124ad920 = makeCons(v0x7f41124ad540, v0x7f41124ad900);
-Obj v0x7f41124ad940 = makeCons(symif, v0x7f41124ad920);
+Obj x140246338495943 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj nargs = x140246338495943;
+pushCont(co, 41, clofun2, 2, exp, body);
 __nargs = 2;
-__arg1 = v0x7f41124ad940;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47init_35gen_45paramenters);
+__arg1 = nargs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label41:
 {
-Obj v0x7f41124c4ec0 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 42, clofun2, 2, cc, v0x7f41124c4ec0);
+Obj x140246338496231 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj args = x140246338496231;
+pushCont(co, 42, clofun2, 2, body, args);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4884,16 +5422,18 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f41124ad040 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124c4ec0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124ad200 = makeCons(cc, Nil);
-Obj v0x7f41124ad240 = makeCons(v0x7f41124ad200, Nil);
-Obj v0x7f41124ad260 = makeCons(v0x7f41124ad040, v0x7f41124ad240);
-Obj v0x7f41124ad2a0 = makeCons(v0x7f41124c4ec0, v0x7f41124ad260);
-Obj v0x7f41124ad2e0 = makeCons(symif, v0x7f41124ad2a0);
+Obj x140246338496935 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338498119 = makeCons(symlist, args);
+Obj x140246338498183 = makeCons(x140246338498119, body);
+Obj x140246338498215 = makeCons(symmatch, x140246338498183);
+Obj x140246338498279 = makeCons(x140246338498215, Nil);
+Obj x140246338498311 = makeCons(args, x140246338498279);
+Obj x140246338498343 = makeCons(x140246338496935, x140246338498311);
+Obj x140246338498375 = makeCons(symdefun, x140246338498343);
 __nargs = 2;
-__arg1 = v0x7f41124ad2e0;
+__arg1 = x140246338498375;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4901,32 +5441,36 @@ goto *jumpTable[co->ctx.pc.label];
 
 label43:
 {
-Obj v0x7f41124c47a0 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 44, clofun2, 2, cc, v0x7f41124c47a0);
+Obj n = __arg1;
+Obj x140246338555239 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == x140246338555239) {
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338555591 = primGenSym();
+Obj x140246338494599 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 44, clofun2, 1, x140246338555591);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35gen_45paramenters);
+__arg1 = x140246338494599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label44:
 {
-Obj v0x7f41124c4940 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124c47a0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124c4b00 = makeCons(cc, Nil);
-Obj v0x7f41124c4b40 = makeCons(v0x7f41124c4b00, Nil);
-Obj v0x7f41124c4b80 = makeCons(v0x7f41124c4940, v0x7f41124c4b40);
-Obj v0x7f41124c4ba0 = makeCons(v0x7f41124c47a0, v0x7f41124c4b80);
-Obj v0x7f41124c4bc0 = makeCons(symif, v0x7f41124c4ba0);
+Obj x140246338494631 = __arg1;
+Obj x140246338555591= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338494663 = makeCons(x140246338555591, x140246338494631);
 __nargs = 2;
-__arg1 = v0x7f41124c4bc0;
+__arg1 = x140246338494663;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4934,15 +5478,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label45:
 {
-Obj pat = __arg1;
-Obj expr = __arg2;
-Obj body = __arg3;
-Obj cc = co->args[4];
-Obj literal_63 = makeNative(49, clofun2, 1, 0);
-pushCont(co, 46, clofun2, 4, expr, body, cc, pat);
-__nargs = 2;
-__arg0 = literal_63;
-__arg1 = pat;
+Obj rules = __arg1;
+PUSH_CONT_0(co, 46, clofun2);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rules_45patterns);
+__arg1 = Nil;
+__arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4952,130 +5493,49 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f41124ebb20 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == v0x7f41124ebb20) {
-Obj v0x7f41124ebd40 = PRIM_EQ(pat, expr);
-if (True == v0x7f41124ebd40) {
-__nargs = 2;
-__arg1 = body;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124d91a0 = makeCons(expr, Nil);
-Obj v0x7f41124d91c0 = makeCons(pat, v0x7f41124d91a0);
-Obj v0x7f41124d9240 = makeCons(sym_61, v0x7f41124d91c0);
-Obj v0x7f41124d9540 = makeCons(cc, Nil);
-Obj v0x7f41124d9580 = makeCons(v0x7f41124d9540, Nil);
-Obj v0x7f41124d95a0 = makeCons(body, v0x7f41124d9580);
-Obj v0x7f41124d95c0 = makeCons(v0x7f41124d9240, v0x7f41124d95a0);
-Obj v0x7f41124d95e0 = makeCons(symif, v0x7f41124d95c0);
-__nargs = 2;
-__arg1 = v0x7f41124d95e0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-Obj v0x7f41124d9740 = primIsSymbol(pat);
-if (True == v0x7f41124d9740) {
-Obj v0x7f41124d9b80 = makeCons(body, Nil);
-Obj v0x7f41124d9ba0 = makeCons(expr, v0x7f41124d9b80);
-Obj v0x7f41124d9bc0 = makeCons(pat, v0x7f41124d9ba0);
-Obj v0x7f41124d9be0 = makeCons(symlet, v0x7f41124d9bc0);
-__nargs = 2;
-__arg1 = v0x7f41124d9be0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 47, clofun2, 4, expr, body, cc, pat);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = pat;
+Obj x140246338603911 = __arg1;
+Obj pats = x140246338603911;
+Obj len = makeNative(1, clofun3, 1, 0);
+PUSH_CONT_0(co, 47, clofun2);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = len;
+__arg2 = pats;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-}
 }
 
 label47:
 {
-Obj v0x7f41124d9d00 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == v0x7f41124d9d00) {
-Obj v0x7f41124d9f40 = PRIM_CAR(pat);
-Obj v0x7f41124d9f80 = PRIM_EQ(v0x7f41124d9f40, symquote);
-if (True == v0x7f41124d9f80) {
-Obj v0x7f41124cb4c0 = makeCons(expr, Nil);
-Obj v0x7f41124cb4e0 = makeCons(pat, v0x7f41124cb4c0);
-Obj v0x7f41124cb500 = makeCons(sym_61, v0x7f41124cb4e0);
-Obj v0x7f41124cb7e0 = makeCons(cc, Nil);
-Obj v0x7f41124cb820 = makeCons(v0x7f41124cb7e0, Nil);
-Obj v0x7f41124cb840 = makeCons(body, v0x7f41124cb820);
-Obj v0x7f41124cb860 = makeCons(v0x7f41124cb500, v0x7f41124cb840);
-Obj v0x7f41124cb880 = makeCons(symif, v0x7f41124cb860);
-__nargs = 2;
-__arg1 = v0x7f41124cb880;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124cba40 = PRIM_CAR(pat);
-Obj v0x7f41124cba80 = PRIM_EQ(v0x7f41124cba40, symcons);
-if (True == v0x7f41124cba80) {
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match_45cons_45expander);
-__arg1 = pat;
-__arg2 = expr;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-PUSH_CONT_0(co, 48, clofun2);
+Obj x140246338552487 = __arg1;
+Obj counts = x140246338552487;
+Obj x140246338552743 = PRIM_CAR(counts);
+Obj n = x140246338552743;
+Obj dif = makeNative(0, clofun3, 1, 1, n);
+Obj x140246338554247 = PRIM_CDR(counts);
+pushCont(co, 48, clofun2, 1, n);
 __nargs = 3;
-__arg0 = globalRef(symstr);
-__arg1 = makeCString("match fail ");
-__arg2 = pat;
+__arg0 = globalRef(symfilter);
+__arg1 = dif;
+__arg2 = x140246338554247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label48:
 {
-Obj v0x7f41124cbe80 = __arg1;
+Obj x140246338554279 = __arg1;
+Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 49, clofun2, 1, n);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = v0x7f41124cbe80;
+__arg0 = globalRef(symnull_63);
+__arg1 = x140246338554279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5085,16 +5545,25 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x = __arg1;
-pushCont(co, 0, clofun3, 1, x);
+Obj x140246338554343 = __arg1;
+Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338554375 = primNot(x140246338554343);
+if (True == x140246338554375) {
 __nargs = 2;
-__arg0 = globalRef(symatom_63);
-__arg1 = x;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("inconsistent func rule args count");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = n;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 fail:
@@ -5119,43 +5588,23 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f41124eb840 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41124eb840) {
-Obj v0x7f41124eb9e0 = primIsSymbol(x);
-Obj v0x7f41124eba20 = primNot(v0x7f41124eb9e0);
-if (True == v0x7f41124eba20) {
+Obj x = __arg1;
+Obj x140246338553351 = PRIM_EQ(closureRef(co, 0), x);
+Obj x140246338553383 = primNot(x140246338553351);
 __nargs = 2;
-__arg1 = True;
+__arg1 = x140246338553383;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
 }
 
 label1:
 {
-Obj pat = __arg1;
-Obj expr = __arg2;
-Obj body = __arg3;
-Obj cc = co->args[4];
-pushCont(co, 2, clofun3, 4, pat, expr, body, cc);
+Obj x = __arg1;
+Obj x140246338551847 = PRIM_CDR(x);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = pat;
+__arg0 = globalRef(symlength);
+__arg1 = x140246338551847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5165,146 +5614,52 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f41125631a0 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = v0x7f41125631a0;
-pushCont(co, 3, clofun3, 4, expr, body, x, cc);
+Obj l1 = __arg1;
+Obj l2 = __arg2;
+Obj x140246338601703 = PRIM_EQ(l1, Nil);
+if (True == x140246338601703) {
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = pat;
+__arg1 = l2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338602407 = PRIM_CAR(l1);
+Obj x140246338602791 = PRIM_CDR(l1);
+pushCont(co, 3, clofun3, 1, x140246338602407);
+__nargs = 3;
+__arg0 = globalRef(symappend);
+__arg1 = x140246338602791;
+__arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label3:
 {
-Obj v0x7f41125632c0 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = v0x7f41125632c0;
-Obj v0x7f4112563440 = PRIM_ISCONS(expr);
-if (True == v0x7f4112563440) {
-Obj v0x7f41125635e0 = PRIM_CAR(expr);
-Obj v0x7f4112563620 = PRIM_EQ(v0x7f41125635e0, symcons);
-if (True == v0x7f4112563620) {
-if (True == True) {
-pushCont(co, 16, clofun3, 5, expr, y, body, x, cc);
+Obj x140246338602855 = __arg1;
+Obj x140246338602407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338602919 = makeCons(x140246338602407, x140246338602855);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj v0x7f4112563e20 = makeCons(expr, Nil);
-Obj v0x7f4112563e40 = makeCons(symcons_63, v0x7f4112563e20);
-Obj v0x7f411252c340 = makeCons(expr, Nil);
-Obj v0x7f411252c360 = makeCons(symcar, v0x7f411252c340);
-Obj v0x7f411252c700 = makeCons(expr, Nil);
-Obj v0x7f411252c720 = makeCons(symcdr, v0x7f411252c700);
-pushCont(co, 14, clofun3, 4, x, v0x7f411252c360, cc, v0x7f4112563e40);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = v0x7f411252c720;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 11, clofun3, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj v0x7f4112529500 = makeCons(expr, Nil);
-Obj v0x7f4112529540 = makeCons(symcons_63, v0x7f4112529500);
-Obj v0x7f4112529940 = makeCons(expr, Nil);
-Obj v0x7f4112529960 = makeCons(symcar, v0x7f4112529940);
-Obj v0x7f4112529f80 = makeCons(expr, Nil);
-Obj v0x7f4112529fa0 = makeCons(symcdr, v0x7f4112529f80);
-pushCont(co, 9, clofun3, 4, x, v0x7f4112529960, cc, v0x7f4112529540);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = v0x7f4112529fa0;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-pushCont(co, 6, clofun3, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj v0x7f4112512aa0 = makeCons(expr, Nil);
-Obj v0x7f4112512ac0 = makeCons(symcons_63, v0x7f4112512aa0);
-Obj v0x7f4112512e60 = makeCons(expr, Nil);
-Obj v0x7f4112512e80 = makeCons(symcar, v0x7f4112512e60);
-Obj v0x7f41124eb200 = makeCons(expr, Nil);
-Obj v0x7f41124eb220 = makeCons(symcdr, v0x7f41124eb200);
-pushCont(co, 4, clofun3, 4, x, v0x7f4112512e80, cc, v0x7f4112512ac0);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = v0x7f41124eb220;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
+__arg1 = x140246338602919;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj v0x7f41124eb280 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512e80= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112512ac0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 5, clofun3, 2, cc, v0x7f4112512ac0);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = v0x7f4112512e80;
-__arg3 = v0x7f41124eb280;
-co->args[4] = cc;
+Obj fn = __arg1;
+Obj l = __arg2;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = Nil;
+__arg2 = fn;
+__arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5314,57 +5669,75 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41124eb2c0 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512ac0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124eb4a0 = makeCons(cc, Nil);
-Obj v0x7f41124eb4e0 = makeCons(v0x7f41124eb4a0, Nil);
-Obj v0x7f41124eb500 = makeCons(v0x7f41124eb2c0, v0x7f41124eb4e0);
-Obj v0x7f41124eb520 = makeCons(v0x7f4112512ac0, v0x7f41124eb500);
-Obj v0x7f41124eb540 = makeCons(symif, v0x7f41124eb520);
+Obj res = __arg1;
+Obj fn = __arg2;
+Obj l = __arg3;
+Obj x140246338626247 = PRIM_ISCONS(l);
+if (True == x140246338626247) {
+Obj x140246338626855 = PRIM_CAR(l);
+pushCont(co, 6, clofun3, 3, l, res, fn);
 __nargs = 2;
-__arg1 = v0x7f41124eb540;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj v0x7f4112512420 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = v0x7f4112512420;
-pushCont(co, 7, clofun3, 5, y, body, x, e1, cc);
+__arg0 = fn;
+__arg1 = x140246338626855;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
+__arg0 = globalRef(symreverse);
+__arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label6:
+{
+Obj x140246338626887 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140246338626887) {
+Obj x140246338627847 = PRIM_CAR(l);
+Obj x140246338627911 = makeCons(x140246338627847, res);
+Obj x140246338628231 = PRIM_CDR(l);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = x140246338627911;
+__arg2 = fn;
+__arg3 = x140246338628231;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338628647 = PRIM_CDR(l);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = res;
+__arg2 = fn;
+__arg3 = x140246338628647;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label7:
 {
-Obj v0x7f4112512560 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = v0x7f4112512560;
-pushCont(co, 8, clofun3, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
+Obj l = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35length_45h);
+__arg1 = MAKE_NUMBER(0);
+__arg2 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5374,37 +5747,38 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f4112512780 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = v0x7f4112512780;
-co->args[4] = cc;
+Obj i = __arg1;
+Obj l = __arg2;
+Obj x140246338702023 = PRIM_EQ(l, Nil);
+if (True == x140246338702023) {
+__nargs = 2;
+__arg1 = i;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338702471 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x140246338702823 = PRIM_CDR(l);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35length_45h);
+__arg1 = x140246338702471;
+__arg2 = x140246338702823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label9:
 {
-Obj v0x7f4112512000 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112529960= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112529540= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 10, clofun3, 2, cc, v0x7f4112529540);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = v0x7f4112529960;
-__arg3 = v0x7f4112512000;
-co->args[4] = cc;
+Obj res = __arg1;
+Obj rules = __arg2;
+pushCont(co, 10, clofun3, 2, res, rules);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5414,34 +5788,41 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f4112512060 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112529540= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112512220 = makeCons(cc, Nil);
-Obj v0x7f4112512280 = makeCons(v0x7f4112512220, Nil);
-Obj v0x7f41125122a0 = makeCons(v0x7f4112512060, v0x7f4112512280);
-Obj v0x7f4112512300 = makeCons(v0x7f4112529540, v0x7f41125122a0);
-Obj v0x7f4112512320 = makeCons(symif, v0x7f4112512300);
+Obj x140246338699751 = __arg1;
+Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246338699751) {
 __nargs = 2;
-__arg1 = v0x7f4112512320;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symreverse);
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338700647 = PRIM_CAR(rules);
+Obj x140246338700743 = makeCons(x140246338700647, res);
+pushCont(co, 11, clofun3, 1, x140246338700743);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label11:
 {
-Obj v0x7f411252cca0 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = v0x7f411252cca0;
-pushCont(co, 12, clofun3, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
+Obj x140246338700967 = __arg1;
+Obj x140246338700743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rules_45patterns);
+__arg1 = x140246338700743;
+__arg2 = x140246338700967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5451,20 +5832,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f411252cde0 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = v0x7f411252cde0;
-pushCont(co, 13, clofun3, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
+Obj input = __arg1;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = input;
+__arg2 = Nil;
+__arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5474,74 +5847,152 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112529100 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = v0x7f4112529100;
-co->args[4] = cc;
+Obj input = __arg1;
+Obj current = __arg2;
+Obj result = __arg3;
+Obj x140246338969735 = makeNative(14, clofun3, 0, 3, input, current, result);
+Obj x140246338824903 = PRIM_EQ(Nil, input);
+if (True == x140246338824903) {
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = result;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338969735;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label14:
 {
-Obj v0x7f411252c780 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411252c360= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112563e40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 15, clofun3, 2, cc, v0x7f4112563e40);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = v0x7f411252c360;
-__arg3 = v0x7f411252c780;
-co->args[4] = cc;
+Obj x140246338969831 = makeNative(16, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140246339320135 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339320135) {
+Obj x140246339320711 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339320743 = PRIM_EQ(sym_61_62, x140246339320711);
+if (True == x140246339320743) {
+Obj x140246339321255 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339321287 = PRIM_ISCONS(x140246339321255);
+if (True == x140246339321287) {
+Obj x140246339321799 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339321831 = PRIM_CAR(x140246339321799);
+Obj act = x140246339321831;
+Obj x140246338970823 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338970919 = PRIM_CDR(x140246338970823);
+Obj x140246338970951 = PRIM_ISCONS(x140246338970919);
+if (True == x140246338970951) {
+Obj x140246338972199 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338972231 = PRIM_CDR(x140246338972199);
+Obj x140246338972295 = PRIM_CAR(x140246338972231);
+Obj x140246338972359 = PRIM_EQ(symwhere, x140246338972295);
+if (True == x140246338972359) {
+Obj x140246338973479 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338973543 = PRIM_CDR(x140246338973479);
+Obj x140246338949319 = PRIM_CDR(x140246338973543);
+Obj x140246338949351 = PRIM_ISCONS(x140246338949319);
+if (True == x140246338949351) {
+Obj x140246338950503 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338950567 = PRIM_CDR(x140246338950503);
+Obj x140246338950631 = PRIM_CDR(x140246338950567);
+Obj x140246338950695 = PRIM_CAR(x140246338950631);
+Obj pred = x140246338950695;
+Obj x140246338951783 = PRIM_CDR(closureRef(co, 0));
+Obj x140246338951815 = PRIM_CDR(x140246338951783);
+Obj x140246338951847 = PRIM_CDR(x140246338951815);
+Obj x140246338951943 = PRIM_CDR(x140246338951847);
+Obj remain = x140246338951943;
+pushCont(co, 15, clofun3, 3, act, pred, remain);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338969831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label15:
 {
-Obj v0x7f411252c7c0 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112563e40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f411252ca80 = makeCons(cc, Nil);
-Obj v0x7f411252cac0 = makeCons(v0x7f411252ca80, Nil);
-Obj v0x7f411252cae0 = makeCons(v0x7f411252c7c0, v0x7f411252cac0);
-Obj v0x7f411252cb00 = makeCons(v0x7f4112563e40, v0x7f411252cae0);
-Obj v0x7f411252cb20 = makeCons(symif, v0x7f411252cb00);
-__nargs = 2;
-__arg1 = v0x7f411252cb20;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj v0x7f4112563740 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = v0x7f4112563740;
-pushCont(co, 17, clofun3, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
+Obj x140246338952583 = __arg1;
+Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140246338952615 = makeCons(symlist, x140246338952583);
+Obj pat = x140246338952615;
+Obj x140246338822983 = makeCons(act, Nil);
+Obj x140246338823015 = makeCons(pred, x140246338822983);
+Obj x140246338823079 = makeCons(symwhere, x140246338823015);
+Obj x140246338823335 = makeCons(pat, closureRef(co, 2));
+Obj x140246338823367 = makeCons(x140246338823079, x140246338823335);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = x140246338823367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5549,22 +6000,75 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label16:
+{
+Obj x140246338970375 = makeNative(18, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140246339372647 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339372647) {
+Obj x140246339373287 = PRIM_CAR(closureRef(co, 0));
+Obj x140246339373319 = PRIM_EQ(sym_61_62, x140246339373287);
+if (True == x140246339373319) {
+Obj x140246339373767 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339373799 = PRIM_ISCONS(x140246339373767);
+if (True == x140246339373799) {
+Obj x140246339374407 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339374439 = PRIM_CAR(x140246339374407);
+Obj act = x140246339374439;
+Obj x140246339317831 = PRIM_CDR(closureRef(co, 0));
+Obj x140246339317863 = PRIM_CDR(x140246339317831);
+Obj remain = x140246339317863;
+pushCont(co, 17, clofun3, 2, act, remain);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338970375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140246338970375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label17:
 {
-Obj v0x7f41125638a0 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = v0x7f41125638a0;
-pushCont(co, 18, clofun3, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
+Obj x140246339318407 = __arg1;
+Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339318439 = makeCons(symlist, x140246339318407);
+Obj pat = x140246339318439;
+Obj x140246339319143 = makeCons(pat, closureRef(co, 2));
+Obj x140246339319175 = makeCons(act, x140246339319143);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = x140246339319175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5574,30 +6078,40 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f4112563ac0 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = v0x7f4112563ac0;
-co->args[4] = cc;
+Obj x140246338970695 = makeNative(19, clofun3, 0, 0);
+Obj x140246339624903 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246339624903) {
+Obj x140246339371367 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140246339371367;
+Obj x140246339371623 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140246339371623;
+Obj x140246339372167 = makeCons(x, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = y;
+__arg2 = x140246339372167;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140246338970695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label19:
 {
-Obj exp = __arg1;
-Obj v0x7f4112570f20 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = v0x7f4112570f20;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5607,12 +6121,10 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj pat = __arg1;
-Obj v0x7f4112570560 = PRIM_CDR(pat);
-pushCont(co, 21, clofun3, 1, pat);
+Obj exp = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = v0x7f4112570560;
+__arg0 = globalRef(symcora_47init_35rewrite_45match);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5622,235 +6134,8 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f41125705c0 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41125705c0) {
-Obj v0x7f4112570680 = PRIM_CAR(pat);
-__nargs = 2;
-__arg1 = v0x7f4112570680;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41125708e0 = PRIM_CAR(pat);
-Obj v0x7f4112570b20 = PRIM_CDR(pat);
-pushCont(co, 22, clofun3, 1, v0x7f41125708e0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = v0x7f4112570b20;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label22:
-{
-Obj v0x7f4112570b40 = __arg1;
-Obj v0x7f41125708e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112570b80 = makeCons(v0x7f4112570b40, Nil);
-Obj v0x7f4112570ba0 = makeCons(v0x7f41125708e0, v0x7f4112570b80);
-Obj v0x7f4112570bc0 = makeCons(symcons, v0x7f4112570ba0);
-__nargs = 2;
-__arg1 = v0x7f4112570bc0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label23:
-{
-Obj x = __arg1;
-Obj v0x7f41125700e0 = PRIM_EQ(x, True);
-if (True == v0x7f41125700e0) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f4112570200 = PRIM_EQ(x, False);
-if (True == v0x7f4112570200) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-}
-
-label24:
-{
 Obj exp = __arg1;
-Obj v0x7f411248cae0 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = v0x7f411248cae0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label25:
-{
-Obj l = __arg1;
-Obj v0x7f41124adf20 = PRIM_EQ(Nil, l);
-if (True == v0x7f41124adf20) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f411248c0c0 = PRIM_CAR(l);
-Obj v0x7f411248c100 = PRIM_EQ(v0x7f411248c0c0, False);
-if (True == v0x7f411248c100) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f411248c2a0 = PRIM_CDR(l);
-pushCont(co, 26, clofun3, 1, l);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = v0x7f411248c2a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label26:
-{
-Obj v0x7f411248c2c0 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = v0x7f411248c2c0;
-Obj v0x7f411248c3e0 = PRIM_EQ(more, False);
-if (True == v0x7f411248c3e0) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f411248c600 = PRIM_CAR(l);
-Obj v0x7f411248c7c0 = makeCons(False, Nil);
-Obj v0x7f411248c7e0 = makeCons(more, v0x7f411248c7c0);
-Obj v0x7f411248c800 = makeCons(v0x7f411248c600, v0x7f411248c7e0);
-Obj v0x7f411248c820 = makeCons(symif, v0x7f411248c800);
-__nargs = 2;
-__arg1 = v0x7f411248c820;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label27:
-{
-Obj exp = __arg1;
-Obj v0x7f41124adca0 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = v0x7f41124adca0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label28:
-{
-Obj l = __arg1;
-Obj v0x7f41124ad0e0 = PRIM_EQ(l, Nil);
-if (True == v0x7f41124ad0e0) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124ad280 = PRIM_CAR(l);
-Obj v0x7f41124ad2c0 = PRIM_EQ(v0x7f41124ad280, True);
-if (True == v0x7f41124ad2c0) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124ad460 = PRIM_CDR(l);
-pushCont(co, 29, clofun3, 1, l);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = v0x7f41124ad460;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label29:
-{
-Obj v0x7f41124ad480 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = v0x7f41124ad480;
-Obj v0x7f41124ad5a0 = PRIM_EQ(more, True);
-if (True == v0x7f41124ad5a0) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124ad7c0 = PRIM_CAR(l);
-Obj v0x7f41124ad980 = makeCons(more, Nil);
-Obj v0x7f41124ad9a0 = makeCons(True, v0x7f41124ad980);
-Obj v0x7f41124ad9c0 = makeCons(v0x7f41124ad7c0, v0x7f41124ad9a0);
-Obj v0x7f41124ad9e0 = makeCons(symif, v0x7f41124ad9c0);
-__nargs = 2;
-__arg1 = v0x7f41124ad9e0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label30:
-{
-Obj exp = __arg1;
-Obj v0x7f41124c44e0 = PRIM_CDR(exp);
-Obj v0x7f41124c4500 = PRIM_EQ(Nil, v0x7f41124c44e0);
-if (True == v0x7f41124c4500) {
-Obj v0x7f41124c46a0 = makeCons(makeCString("no cond match"), Nil);
-Obj v0x7f41124c46c0 = makeCons(symerror, v0x7f41124c46a0);
-__nargs = 2;
-__arg1 = v0x7f41124c46c0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 31, clofun3, 1, exp);
+pushCont(co, 22, clofun3, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -5860,18 +6145,273 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+
+label22:
+{
+Obj x140246339750983 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 23, clofun3, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = x140246339750983;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label23:
+{
+Obj x140246339751047 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value = x140246339751047;
+pushCont(co, 24, clofun3, 1, value);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label24:
+{
+Obj x140246339751303 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules = x140246339751303;
+Obj x140246339751655 = PRIM_ISCONS(value);
+if (True == x140246339751655) {
+Obj x140246339711335 = PRIM_CAR(value);
+Obj x140246339711367 = PRIM_EQ(symcons, x140246339711335);
+Obj x140246339711399 = primNot(x140246339711367);
+if (True == x140246339711399) {
+if (True == True) {
+Obj x140246339711847 = primGenSym();
+Obj val = x140246339711847;
+pushCont(co, 27, clofun3, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = val;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj x140246339713543 = primGenSym();
+Obj val = x140246339713543;
+pushCont(co, 26, clofun3, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = val;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+Obj x140246339621095 = primGenSym();
+Obj val = x140246339621095;
+pushCont(co, 25, clofun3, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = val;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label25:
+{
+Obj x140246339622151 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339622215 = makeCons(x140246339622151, Nil);
+Obj x140246339622279 = makeCons(value, x140246339622215);
+Obj x140246339622343 = makeCons(val, x140246339622279);
+Obj x140246339622375 = makeCons(symlet, x140246339622343);
+__nargs = 2;
+__arg1 = x140246339622375;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label26:
+{
+Obj x140246339714567 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339714791 = makeCons(x140246339714567, Nil);
+Obj x140246339714823 = makeCons(value, x140246339714791);
+Obj x140246339714855 = makeCons(val, x140246339714823);
+Obj x140246339714887 = makeCons(symlet, x140246339714855);
+__nargs = 2;
+__arg1 = x140246339714887;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label27:
+{
+Obj x140246339712903 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339712967 = makeCons(x140246339712903, Nil);
+Obj x140246339712999 = makeCons(value, x140246339712967);
+Obj x140246339713031 = makeCons(val, x140246339712999);
+Obj x140246339713063 = makeCons(symlet, x140246339713031);
+__nargs = 2;
+__arg1 = x140246339713063;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label28:
+{
+Obj value = __arg1;
+Obj rules = __arg2;
+pushCont(co, 29, clofun3, 2, rules, value);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj x140246338498471 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246338498471) {
+Obj x140246338449735 = makeCons(makeCString("no match-help found!"), Nil);
+Obj x140246338449767 = makeCons(symerror, x140246338449735);
+__nargs = 2;
+__arg1 = x140246338449767;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 30, clofun3, 2, rules, value);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label30:
+{
+Obj x140246338450087 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246338450087) {
+Obj x140246338450503 = PRIM_CDR(rules);
+pushCont(co, 35, clofun3, 2, rules, value);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = x140246338450503;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+if (True == False) {
+Obj x140246338249319 = PRIM_CAR(rules);
+Obj pat = x140246338249319;
+Obj x140246338249543 = primGenSym();
+Obj cc = x140246338249543;
+pushCont(co, 31, clofun3, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
+__arg1 = rules;
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label31:
 {
-Obj v0x7f41124c47c0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = v0x7f41124c47c0;
-Obj v0x7f41124c49e0 = PRIM_CAR(curr);
-pushCont(co, 32, clofun3, 2, exp, v0x7f41124c49e0);
+Obj x140246338249831 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj action = x140246338249831;
+pushCont(co, 32, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = curr;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5881,13 +6421,18 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f41124c4b60 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124c49e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 33, clofun3, 2, v0x7f41124c4b60, v0x7f41124c49e0);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
+Obj x140246338250247 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 33, clofun3, 3, rules, value, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x140246338250247;
+__arg2 = value;
+__arg3 = action;
+co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5897,84 +6442,138 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41124c4da0 = __arg1;
-Obj v0x7f41124c4b60= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124c49e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124c4dc0 = makeCons(symcond, v0x7f41124c4da0);
-Obj v0x7f41124c4e00 = makeCons(v0x7f41124c4dc0, Nil);
-Obj v0x7f41124c4e20 = makeCons(v0x7f41124c4b60, v0x7f41124c4e00);
-Obj v0x7f41124c4e40 = makeCons(v0x7f41124c49e0, v0x7f41124c4e20);
-Obj v0x7f41124c4e60 = makeCons(symif, v0x7f41124c4e40);
-__nargs = 2;
-__arg1 = v0x7f41124c4e60;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140246338250375 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj curr = x140246338250375;
+Obj x140246339747975 = PRIM_CDR(rules);
+Obj x140246339748007 = PRIM_CDR(x140246339747975);
+pushCont(co, 34, clofun3, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = x140246339748007;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label34:
 {
-Obj exp = __arg1;
-Obj v0x7f41124c41c0 = PRIM_CDR(exp);
+Obj x140246339748071 = __arg1;
+Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj rest = x140246339748071;
+Obj x140246339749447 = makeCons(rest, Nil);
+Obj x140246339749543 = makeCons(Nil, x140246339749447);
+Obj x140246339749575 = makeCons(symlambda, x140246339749543);
+Obj x140246339749831 = makeCons(curr, Nil);
+Obj x140246339749863 = makeCons(x140246339749575, x140246339749831);
+Obj x140246339749895 = makeCons(cc, x140246339749863);
+Obj x140246339749927 = makeCons(symlet, x140246339749895);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = v0x7f41124c41c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246339749927;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label35:
 {
-Obj exp = __arg1;
-Obj v0x7f41124d9980 = PRIM_CDR(exp);
-pushCont(co, 36, clofun3, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = v0x7f41124d9980;
+Obj x140246338450535 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246338450535) {
+if (True == True) {
+Obj x140246338450791 = PRIM_CAR(rules);
+Obj pat = x140246338450791;
+Obj x140246338451015 = primGenSym();
+Obj cc = x140246338451015;
+pushCont(co, 40, clofun3, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
+__arg1 = rules;
+__arg2 = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj x140246338352103 = PRIM_CAR(rules);
+Obj pat = x140246338352103;
+Obj x140246338352327 = primGenSym();
+Obj cc = x140246338352327;
+pushCont(co, 36, clofun3, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
+__arg1 = rules;
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label36:
 {
-Obj v0x7f41124d99a0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41124d99a0) {
-Obj v0x7f41124d9a60 = PRIM_CAR(exp);
+Obj x140246338352615 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj action = x140246338352615;
+pushCont(co, 37, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
-__arg1 = v0x7f41124d9a60;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124d9ce0 = PRIM_CAR(exp);
-pushCont(co, 37, clofun3, 2, exp, v0x7f41124d9ce0);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
 
 label37:
 {
-Obj v0x7f41124d9ee0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124d9ce0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 38, clofun3, 2, v0x7f41124d9ee0, v0x7f41124d9ce0);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
+Obj x140246338353031 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 38, clofun3, 3, rules, value, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x140246338353031;
+__arg2 = value;
+__arg3 = action;
+co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5984,13 +6583,18 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41124cb100 = __arg1;
-Obj v0x7f41124d9ee0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124d9ce0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 39, clofun3, 2, v0x7f41124d9ee0, v0x7f41124d9ce0);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = v0x7f41124cb100;
+Obj x140246338353159 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj curr = x140246338353159;
+Obj x140246338353767 = PRIM_CDR(rules);
+Obj x140246338353799 = PRIM_CDR(x140246338353767);
+pushCont(co, 39, clofun3, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = x140246338353799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6000,15 +6604,19 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f41124cb120 = __arg1;
-Obj v0x7f41124d9ee0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124d9ce0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124cb160 = makeCons(v0x7f41124cb120, Nil);
-Obj v0x7f41124cb180 = makeCons(v0x7f41124d9ee0, v0x7f41124cb160);
-Obj v0x7f41124cb1a0 = makeCons(v0x7f41124d9ce0, v0x7f41124cb180);
-Obj v0x7f41124cb1c0 = makeCons(symlet, v0x7f41124cb1a0);
+Obj x140246338353831 = __arg1;
+Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj rest = x140246338353831;
+Obj x140246338354983 = makeCons(rest, Nil);
+Obj x140246338355015 = makeCons(Nil, x140246338354983);
+Obj x140246338355047 = makeCons(symlambda, x140246338355015);
+Obj x140246338248807 = makeCons(curr, Nil);
+Obj x140246338248839 = makeCons(x140246338355047, x140246338248807);
+Obj x140246338248871 = makeCons(cc, x140246338248839);
+Obj x140246338248903 = makeCons(symlet, x140246338248871);
 __nargs = 2;
-__arg1 = v0x7f41124cb1c0;
+__arg1 = x140246338248903;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6016,58 +6624,58 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x = __arg1;
-Obj v0x7f41124d9600 = PRIM_ISCONS(x);
-Obj v0x7f41124d9620 = primNot(v0x7f41124d9600);
+Obj x140246338451303 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj action = x140246338451303;
+pushCont(co, 41, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
-__arg1 = v0x7f41124d9620;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label41:
-{
-Obj x = __arg1;
-Obj l = __arg2;
-Obj v0x7f41124ebee0 = PRIM_ISCONS(l);
-if (True == v0x7f41124ebee0) {
-Obj v0x7f41124d90c0 = PRIM_CAR(l);
-Obj v0x7f41124d9100 = PRIM_EQ(v0x7f41124d90c0, x);
-if (True == v0x7f41124d9100) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f41124d92e0 = PRIM_CDR(l);
-__nargs = 3;
-__arg0 = globalRef(symelem_63);
-__arg1 = x;
-__arg2 = v0x7f41124d92e0;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
+
+label41:
+{
+Obj x140246338451719 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 42, clofun3, 3, rules, value, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x140246338451719;
+__arg2 = value;
+__arg3 = action;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label42:
 {
-Obj exp = __arg1;
-pushCont(co, 43, clofun3, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
+Obj x140246338451847 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj curr = x140246338451847;
+Obj x140246338452455 = PRIM_CDR(rules);
+Obj x140246338452487 = PRIM_CDR(x140246338452455);
+pushCont(co, 43, clofun3, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = value;
+__arg2 = x140246338452487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6077,28 +6685,35 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41124eb720 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 44, clofun3, 2, exp, v0x7f41124eb720);
+Obj x140246338452519 = __arg1;
+Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj rest = x140246338452519;
+Obj x140246338351271 = makeCons(rest, Nil);
+Obj x140246338351303 = makeCons(Nil, x140246338351271);
+Obj x140246338351335 = makeCons(symlambda, x140246338351303);
+Obj x140246338351591 = makeCons(curr, Nil);
+Obj x140246338351623 = makeCons(x140246338351335, x140246338351591);
+Obj x140246338351655 = makeCons(cc, x140246338351623);
+Obj x140246338351687 = makeCons(symlet, x140246338351655);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246338351687;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label44:
 {
-Obj v0x7f41124eba00 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124eb720= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 45, clofun3, 2, v0x7f41124eba00, v0x7f41124eb720);
+Obj rules = __arg1;
+Obj cc = __arg2;
+Obj x140246338553959 = PRIM_CDR(rules);
+Obj x140246338553991 = PRIM_CAR(x140246338553959);
+Obj action = x140246338553991;
+pushCont(co, 45, clofun3, 2, cc, action);
 __nargs = 2;
-__arg0 = globalRef(symcadddr);
-__arg1 = exp;
+__arg0 = globalRef(sympair_63);
+__arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6108,29 +6723,79 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f41124ebb80 = __arg1;
-Obj v0x7f41124eba00= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124eb720= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124ebbc0 = makeCons(v0x7f41124ebb80, Nil);
-Obj v0x7f41124ebbe0 = makeCons(v0x7f41124eba00, v0x7f41124ebbc0);
-Obj v0x7f41124ebc00 = makeCons(symlambda, v0x7f41124ebbe0);
-Obj v0x7f41124ebc40 = makeCons(v0x7f41124ebc00, Nil);
-Obj v0x7f41124ebc60 = makeCons(v0x7f41124eb720, v0x7f41124ebc40);
-Obj v0x7f41124ebc80 = makeCons(symdef, v0x7f41124ebc60);
+Obj x140246338554311 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140246338554311) {
+Obj x140246338554727 = PRIM_CAR(action);
+Obj x140246338554791 = PRIM_EQ(x140246338554727, symwhere);
+if (True == x140246338554791) {
+if (True == True) {
+pushCont(co, 0, clofun4, 2, action, cc);
 __nargs = 2;
-__arg1 = v0x7f41124ebc80;
+__arg0 = globalRef(symcadr);
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
+} else {
+if (True == False) {
+pushCont(co, 48, clofun3, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+} else {
+if (True == False) {
+pushCont(co, 46, clofun3, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+}
 
 label46:
 {
-Obj exp = __arg1;
-Obj v0x7f41124eb3a0 = PRIM_CDR(exp);
+Obj x140246338496903 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 47, clofun3, 2, cc, x140246338496903);
 __nargs = 2;
-__arg0 = globalRef(symrcons);
-__arg1 = v0x7f41124eb3a0;
+__arg0 = globalRef(symcaddr);
+__arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6140,28 +6805,30 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj exp = __arg1;
-pushCont(co, 48, clofun3, 1, exp);
+Obj x140246338497287 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338496903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338497703 = makeCons(cc, Nil);
+Obj x140246338497767 = makeCons(x140246338497703, Nil);
+Obj x140246338497799 = makeCons(x140246338497287, x140246338497767);
+Obj x140246338497831 = makeCons(x140246338496903, x140246338497799);
+Obj x140246338497863 = makeCons(symif, x140246338497831);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246338497863;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label48:
 {
-Obj v0x7f4112512ae0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512b20 = makeCons(v0x7f4112512ae0, Nil);
-Obj v0x7f4112512b40 = makeCons(symquote, v0x7f4112512b20);
-pushCont(co, 49, clofun3, 2, exp, v0x7f4112512b40);
+Obj x140246338495399 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 49, clofun3, 2, cc, x140246338495399);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
-__arg1 = exp;
+__arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6171,18 +6838,19 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f4112512e20 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512b40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 0, clofun4, 2, v0x7f4112512e20, v0x7f4112512b40);
+Obj x140246338495783 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338495399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338496199 = makeCons(cc, Nil);
+Obj x140246338496263 = makeCons(x140246338496199, Nil);
+Obj x140246338496295 = makeCons(x140246338495783, x140246338496263);
+Obj x140246338496327 = makeCons(x140246338495399, x140246338496295);
+Obj x140246338496359 = makeCons(symif, x140246338496327);
 __nargs = 2;
-__arg0 = globalRef(symcdddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140246338496359;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:
@@ -6201,92 +6869,54 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43, &&label44, &&label45, &&label46, &&label47, &&label48, &&label49};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f4112512f00 = __arg1;
-Obj v0x7f4112512e20= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112512b40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112512f20 = makeCons(v0x7f4112512e20, v0x7f4112512f00);
-Obj v0x7f4112512f40 = makeCons(symlambda, v0x7f4112512f20);
-Obj v0x7f4112512f80 = makeCons(v0x7f4112512f40, Nil);
-Obj v0x7f4112512fa0 = makeCons(v0x7f4112512b40, v0x7f4112512f80);
-Obj v0x7f4112512fc0 = makeCons(symcora_47init_35add_45to_45_42macros_42, v0x7f4112512fa0);
+Obj x140246338555335 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 1, clofun4, 2, cc, x140246338555335);
 __nargs = 2;
-__arg1 = v0x7f4112512fc0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcaddr);
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj exp = __arg1;
-Obj v0x7f4112529140 = PRIM_ISCONS(exp);
-if (True == v0x7f4112529140) {
-Obj v0x7f4112529300 = PRIM_CAR(exp);
-Obj v0x7f4112529380 = PRIM_EQ(v0x7f4112529300, globalRef(sym_42protect_45symbol_42));
-if (True == v0x7f4112529380) {
-Obj v0x7f4112529440 = PRIM_CDR(exp);
+Obj x140246338555719 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338555335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338494695 = makeCons(cc, Nil);
+Obj x140246338494759 = makeCons(x140246338494695, Nil);
+Obj x140246338494791 = makeCons(x140246338555719, x140246338494759);
+Obj x140246338494823 = makeCons(x140246338555335, x140246338494791);
+Obj x140246338494855 = makeCons(symif, x140246338494823);
 __nargs = 2;
-__arg1 = v0x7f4112529440;
+__arg1 = x140246338494855;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj v0x7f4112529640 = PRIM_CAR(exp);
-Obj v0x7f4112529680 = PRIM_EQ(v0x7f4112529640, symlambda);
-if (True == v0x7f4112529680) {
-pushCont(co, 4, clofun4, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj v0x7f4112512040 = PRIM_CAR(exp);
-Obj v0x7f4112512080 = PRIM_EQ(v0x7f4112512040, symquote);
-if (True == v0x7f4112512080) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 2, clofun4, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand1);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
 }
 
 label2:
 {
-Obj v0x7f41125124e0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj pat = __arg1;
+Obj expr = __arg2;
+Obj body = __arg3;
+Obj cc = co->args[4];
+Obj literal_63 = makeNative(6, clofun4, 1, 0);
+pushCont(co, 3, clofun4, 4, expr, body, cc, pat);
 __nargs = 2;
-__arg0 = makeNative(3, clofun4, 1, 1, exp);
-__arg1 = v0x7f41125124e0;
+__arg0 = literal_63;
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6296,13 +6926,94 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj exp1 = __arg1;
-Obj v0x7f4112512260 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == v0x7f4112512260) {
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg2 = exp1;
+Obj x140246338703047 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x140246338703047) {
+Obj x140246338703335 = PRIM_EQ(pat, expr);
+if (True == x140246338703335) {
+__nargs = 2;
+__arg1 = body;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338626567 = makeCons(expr, Nil);
+Obj x140246338626599 = makeCons(pat, x140246338626567);
+Obj x140246338626631 = makeCons(sym_61, x140246338626599);
+Obj x140246338627303 = makeCons(cc, Nil);
+Obj x140246338627367 = makeCons(x140246338627303, Nil);
+Obj x140246338627399 = makeCons(body, x140246338627367);
+Obj x140246338627431 = makeCons(x140246338626631, x140246338627399);
+Obj x140246338627463 = makeCons(symif, x140246338627431);
+__nargs = 2;
+__arg1 = x140246338627463;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+Obj x140246338627943 = primIsSymbol(pat);
+if (True == x140246338627943) {
+Obj x140246338628839 = makeCons(body, Nil);
+Obj x140246338628871 = makeCons(expr, x140246338628839);
+Obj x140246338628903 = makeCons(pat, x140246338628871);
+Obj x140246338628935 = makeCons(symlet, x140246338628903);
+__nargs = 2;
+__arg1 = x140246338628935;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 4, clofun4, 4, expr, body, cc, pat);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label4:
+{
+Obj x140246338629191 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x140246338629191) {
+Obj x140246338600967 = PRIM_CAR(pat);
+Obj x140246338601031 = PRIM_EQ(x140246338600967, symquote);
+if (True == x140246338601031) {
+Obj x140246338602055 = makeCons(expr, Nil);
+Obj x140246338602183 = makeCons(pat, x140246338602055);
+Obj x140246338602343 = makeCons(sym_61, x140246338602183);
+Obj x140246338602983 = makeCons(cc, Nil);
+Obj x140246338603047 = makeCons(x140246338602983, Nil);
+Obj x140246338603079 = makeCons(body, x140246338603047);
+Obj x140246338603111 = makeCons(x140246338602343, x140246338603079);
+Obj x140246338603143 = makeCons(symif, x140246338603111);
+__nargs = 2;
+__arg1 = x140246338603143;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338603623 = PRIM_CAR(pat);
+Obj x140246338603687 = PRIM_EQ(x140246338603623, symcons);
+if (True == x140246338603687) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match_45cons_45expander);
+__arg1 = pat;
+__arg2 = expr;
+__arg3 = body;
+co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6310,8 +7021,8 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = exp1;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6319,30 +7030,26 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
-
-label4:
-{
-Obj v0x7f41125298e0 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 5, clofun4, 1, v0x7f41125298e0);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = exp;
+} else {
+PUSH_CONT_0(co, 5, clofun4);
+__nargs = 3;
+__arg0 = globalRef(symstr);
+__arg1 = makeCString("match fail ");
+__arg2 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label5:
 {
-Obj v0x7f4112529b20 = __arg1;
-Obj v0x7f41125298e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 6, clofun4, 1, v0x7f41125298e0);
+Obj x140246338552103 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = v0x7f4112529b20;
+__arg0 = globalRef(symerror);
+__arg1 = x140246338552103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6352,19 +7059,1266 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f4112529b40 = __arg1;
-Obj v0x7f41125298e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112529b80 = makeCons(v0x7f4112529b40, Nil);
-Obj v0x7f4112529ba0 = makeCons(v0x7f41125298e0, v0x7f4112529b80);
-Obj v0x7f4112529bc0 = makeCons(symlambda, v0x7f4112529ba0);
+Obj x = __arg1;
+pushCont(co, 7, clofun4, 1, x);
 __nargs = 2;
-__arg1 = v0x7f4112529bc0;
+__arg0 = globalRef(symatom_63);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj x140246338702247 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140246338702247) {
+Obj x140246338702663 = primIsSymbol(x);
+Obj x140246338702759 = primNot(x140246338702663);
+if (True == x140246338702759) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label8:
+{
+Obj pat = __arg1;
+Obj expr = __arg2;
+Obj body = __arg3;
+Obj cc = co->args[4];
+pushCont(co, 9, clofun4, 4, pat, expr, body, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj x140246339318951 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x = x140246339318951;
+pushCont(co, 10, clofun4, 4, expr, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
+{
+Obj x140246339319207 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj y = x140246339319207;
+Obj x140246339319719 = PRIM_ISCONS(expr);
+if (True == x140246339319719) {
+Obj x140246339320199 = PRIM_CAR(expr);
+Obj x140246339320263 = PRIM_EQ(x140246339320199, symcons);
+if (True == x140246339320263) {
+if (True == True) {
+pushCont(co, 23, clofun4, 5, expr, y, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338970503 = makeCons(expr, Nil);
+Obj x140246338970567 = makeCons(symcons_63, x140246338970503);
+Obj x140246338971751 = makeCons(expr, Nil);
+Obj x140246338971847 = makeCons(symcar, x140246338971751);
+Obj x140246338972679 = makeCons(expr, Nil);
+Obj x140246338972711 = makeCons(symcdr, x140246338972679);
+pushCont(co, 21, clofun4, 4, x, x140246338971847, cc, x140246338970567);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = x140246338972711;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+pushCont(co, 18, clofun4, 5, expr, y, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338951879 = makeCons(expr, Nil);
+Obj x140246338951911 = makeCons(symcons_63, x140246338951879);
+Obj x140246338953031 = makeCons(expr, Nil);
+Obj x140246338953063 = makeCons(symcar, x140246338953031);
+Obj x140246338822759 = makeCons(expr, Nil);
+Obj x140246338822791 = makeCons(symcdr, x140246338822759);
+pushCont(co, 16, clofun4, 4, x, x140246338953063, cc, x140246338951911);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = x140246338822791;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+pushCont(co, 13, clofun4, 5, expr, y, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338825703 = makeCons(expr, Nil);
+Obj x140246338825735 = makeCons(symcons_63, x140246338825703);
+Obj x140246338699687 = makeCons(expr, Nil);
+Obj x140246338699719 = makeCons(symcar, x140246338699687);
+Obj x140246338700487 = makeCons(expr, Nil);
+Obj x140246338700519 = makeCons(symcdr, x140246338700487);
+pushCont(co, 11, clofun4, 4, x, x140246338699719, cc, x140246338825735);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = x140246338700519;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label11:
+{
+Obj x140246338700615 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338699719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140246338825735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 12, clofun4, 2, cc, x140246338825735);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = x140246338699719;
+__arg3 = x140246338700615;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj x140246338700679 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338825735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338701255 = makeCons(cc, Nil);
+Obj x140246338701319 = makeCons(x140246338701255, Nil);
+Obj x140246338701351 = makeCons(x140246338700679, x140246338701319);
+Obj x140246338701383 = makeCons(x140246338825735, x140246338701351);
+Obj x140246338701415 = makeCons(symif, x140246338701383);
+__nargs = 2;
+__arg1 = x140246338701415;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
+label13:
+{
+Obj x140246338823911 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e1 = x140246338823911;
+pushCont(co, 14, clofun4, 5, y, body, x, e1, cc);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj x140246338824167 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e2 = x140246338824167;
+pushCont(co, 15, clofun4, 3, x, e1, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = e2;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj x140246338824807 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = e1;
+__arg3 = x140246338824807;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj x140246338822887 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338953063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140246338951911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 17, clofun4, 2, cc, x140246338951911);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = x140246338953063;
+__arg3 = x140246338822887;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj x140246338822951 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338951911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338823399 = makeCons(cc, Nil);
+Obj x140246338823527 = makeCons(x140246338823399, Nil);
+Obj x140246338823559 = makeCons(x140246338822951, x140246338823527);
+Obj x140246338823591 = makeCons(x140246338951911, x140246338823559);
+Obj x140246338823623 = makeCons(symif, x140246338823591);
+__nargs = 2;
+__arg1 = x140246338823623;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label18:
+{
+Obj x140246338949767 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e1 = x140246338949767;
+pushCont(co, 19, clofun4, 5, y, body, x, e1, cc);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj x140246338950119 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e2 = x140246338950119;
+pushCont(co, 20, clofun4, 3, x, e1, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = e2;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj x140246338950919 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = e1;
+__arg3 = x140246338950919;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label21:
+{
+Obj x140246338972839 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338971847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140246338970567= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 22, clofun4, 2, cc, x140246338970567);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = x140246338971847;
+__arg3 = x140246338972839;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label22:
+{
+Obj x140246338972935 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338970567= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338973511 = makeCons(cc, Nil);
+Obj x140246338973575 = makeCons(x140246338973511, Nil);
+Obj x140246338973607 = makeCons(x140246338972935, x140246338973575);
+Obj x140246338973639 = makeCons(x140246338970567, x140246338973607);
+Obj x140246338949287 = makeCons(symif, x140246338973639);
+__nargs = 2;
+__arg1 = x140246338949287;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label23:
+{
+Obj x140246339320519 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e1 = x140246339320519;
+pushCont(co, 24, clofun4, 5, y, body, x, e1, cc);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label24:
+{
+Obj x140246339320807 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj e2 = x140246339320807;
+pushCont(co, 25, clofun4, 3, x, e1, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = y;
+__arg2 = e2;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label25:
+{
+Obj x140246339321447 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x;
+__arg2 = e1;
+__arg3 = x140246339321447;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label26:
+{
+Obj exp = __arg1;
+Obj x140246339318311 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rcons1);
+__arg1 = x140246339318311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label27:
+{
+Obj pat = __arg1;
+Obj x140246339373159 = PRIM_CDR(pat);
+pushCont(co, 28, clofun4, 1, pat);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x140246339373159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label28:
+{
+Obj x140246339373191 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140246339373191) {
+Obj x140246339373383 = PRIM_CAR(pat);
+__nargs = 2;
+__arg1 = x140246339373383;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339374087 = PRIM_CAR(pat);
+Obj x140246339374631 = PRIM_CDR(pat);
+pushCont(co, 29, clofun4, 1, x140246339374087);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rcons1);
+__arg1 = x140246339374631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label29:
+{
+Obj x140246339374663 = __arg1;
+Obj x140246339374087= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339374727 = makeCons(x140246339374663, Nil);
+Obj x140246339374759 = makeCons(x140246339374087, x140246339374727);
+Obj x140246339374791 = makeCons(symcons, x140246339374759);
+__nargs = 2;
+__arg1 = x140246339374791;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label30:
+{
+Obj x = __arg1;
+Obj x140246339371879 = PRIM_EQ(x, True);
+if (True == x140246339371879) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339372263 = PRIM_EQ(x, False);
+if (True == x140246339372263) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+}
+
+label31:
+{
+Obj exp = __arg1;
+Obj x140246339371143 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45and);
+__arg1 = x140246339371143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label32:
+{
+Obj l = __arg1;
+Obj x140246339621831 = PRIM_EQ(Nil, l);
+if (True == x140246339621831) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339622247 = PRIM_CAR(l);
+Obj x140246339622311 = PRIM_EQ(x140246339622247, False);
+if (True == x140246339622311) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339622727 = PRIM_CDR(l);
+pushCont(co, 33, clofun4, 1, l);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45and);
+__arg1 = x140246339622727;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label33:
+{
+Obj x140246339622759 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj more = x140246339622759;
+Obj x140246339623111 = PRIM_EQ(more, False);
+if (True == x140246339623111) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339623751 = PRIM_CAR(l);
+Obj x140246339624199 = makeCons(False, Nil);
+Obj x140246339624231 = makeCons(more, x140246339624199);
+Obj x140246339624263 = makeCons(x140246339623751, x140246339624231);
+Obj x140246339624295 = makeCons(symif, x140246339624263);
+__nargs = 2;
+__arg1 = x140246339624295;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label34:
+{
+Obj exp = __arg1;
+Obj x140246339621191 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45or);
+__arg1 = x140246339621191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj l = __arg1;
+Obj x140246339712391 = PRIM_EQ(l, Nil);
+if (True == x140246339712391) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339712807 = PRIM_CAR(l);
+Obj x140246339712871 = PRIM_EQ(x140246339712807, True);
+if (True == x140246339712871) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339713287 = PRIM_CDR(l);
+pushCont(co, 36, clofun4, 1, l);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45or);
+__arg1 = x140246339713287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label36:
+{
+Obj x140246339713319 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj more = x140246339713319;
+Obj x140246339713607 = PRIM_EQ(more, True);
+if (True == x140246339713607) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246339714151 = PRIM_CAR(l);
+Obj x140246339714599 = makeCons(more, Nil);
+Obj x140246339714631 = makeCons(True, x140246339714599);
+Obj x140246339714663 = makeCons(x140246339714151, x140246339714631);
+Obj x140246339714695 = makeCons(symif, x140246339714663);
+__nargs = 2;
+__arg1 = x140246339714695;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label37:
+{
+Obj exp = __arg1;
+Obj x140246339750279 = PRIM_CDR(exp);
+Obj x140246339750311 = PRIM_EQ(Nil, x140246339750279);
+if (True == x140246339750311) {
+Obj x140246339750727 = makeCons(makeCString("no cond match"), Nil);
+Obj x140246339750759 = makeCons(symerror, x140246339750727);
+__nargs = 2;
+__arg1 = x140246339750759;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 38, clofun4, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label38:
+{
+Obj x140246339751015 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj curr = x140246339751015;
+Obj x140246339751559 = PRIM_CAR(curr);
+pushCont(co, 39, clofun4, 2, exp, x140246339751559);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = curr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+Obj x140246339710983 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339751559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 40, clofun4, 2, x140246339710983, x140246339751559);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x140246339711559 = __arg1;
+Obj x140246339710983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339751559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339711591 = makeCons(symcond, x140246339711559);
+Obj x140246339711655 = makeCons(x140246339711591, Nil);
+Obj x140246339711687 = makeCons(x140246339710983, x140246339711655);
+Obj x140246339711719 = makeCons(x140246339751559, x140246339711687);
+Obj x140246339711751 = makeCons(symif, x140246339711719);
+__nargs = 2;
+__arg1 = x140246339711751;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label41:
+{
+Obj exp = __arg1;
+Obj x140246339749479 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45let);
+__arg1 = x140246339749479;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj exp = __arg1;
+Obj x140246338552903 = PRIM_CDR(exp);
+pushCont(co, 43, clofun4, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x140246338552903;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x140246338552935 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140246338552935) {
+Obj x140246338553127 = PRIM_CAR(exp);
+__nargs = 2;
+__arg1 = x140246338553127;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338553671 = PRIM_CAR(exp);
+pushCont(co, 44, clofun4, 2, exp, x140246338553671);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label44:
+{
+Obj x140246339748039 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun4, 2, x140246339748039, x140246338553671);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x140246339748583 = __arg1;
+Obj x140246339748039= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun4, 2, x140246339748039, x140246338553671);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45let);
+__arg1 = x140246339748583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x140246339748615 = __arg1;
+Obj x140246339748039= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338553671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246339748679 = makeCons(x140246339748615, Nil);
+Obj x140246339748711 = makeCons(x140246339748039, x140246339748679);
+Obj x140246339748743 = makeCons(x140246338553671, x140246339748711);
+Obj x140246339748775 = makeCons(symlet, x140246339748743);
+__nargs = 2;
+__arg1 = x140246339748775;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label47:
+{
+Obj x = __arg1;
+Obj x140246338551911 = PRIM_ISCONS(x);
+Obj x140246338551943 = primNot(x140246338551911);
+__nargs = 2;
+__arg1 = x140246338551943;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label48:
+{
+Obj x = __arg1;
+Obj l = __arg2;
+Obj x140246338602887 = PRIM_ISCONS(l);
+if (True == x140246338602887) {
+Obj x140246338603303 = PRIM_CAR(l);
+Obj x140246338603367 = PRIM_EQ(x140246338603303, x);
+if (True == x140246338603367) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338603751 = PRIM_CDR(l);
+__nargs = 3;
+__arg0 = globalRef(symelem_63);
+__arg1 = x;
+__arg2 = x140246338603751;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label49:
+{
+Obj exp = __arg1;
+pushCont(co, 0, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+static void clofun5(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj x140246338629575 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 1, clofun5, 2, exp, x140246338629575);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj x140246338601639 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338629575= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun5, 2, x140246338601639, x140246338629575);
+__nargs = 2;
+__arg0 = globalRef(symcadddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj x140246338602023 = __arg1;
+Obj x140246338601639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338629575= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338602087 = makeCons(x140246338602023, Nil);
+Obj x140246338602119 = makeCons(x140246338601639, x140246338602087);
+Obj x140246338602151 = makeCons(symlambda, x140246338602119);
+Obj x140246338602215 = makeCons(x140246338602151, Nil);
+Obj x140246338602247 = makeCons(x140246338629575, x140246338602215);
+Obj x140246338602279 = makeCons(symdef, x140246338602247);
+__nargs = 2;
+__arg1 = x140246338602279;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj exp = __arg1;
+Obj x140246338628679 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symrcons);
+__arg1 = x140246338628679;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj exp = __arg1;
+pushCont(co, 5, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj x140246338626407 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338626471 = makeCons(x140246338626407, Nil);
+Obj x140246338626503 = makeCons(symquote, x140246338626471);
+pushCont(co, 6, clofun5, 2, exp, x140246338626503);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj x140246338627271 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338626503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 7, clofun5, 2, x140246338627271, x140246338626503);
+__nargs = 2;
+__arg0 = globalRef(symcdddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label7:
+{
+Obj x140246338627495 = __arg1;
+Obj x140246338627271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338626503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140246338627527 = makeCons(x140246338627271, x140246338627495);
+Obj x140246338627559 = makeCons(symlambda, x140246338627527);
+Obj x140246338627623 = makeCons(x140246338627559, Nil);
+Obj x140246338627655 = makeCons(x140246338626503, x140246338627623);
+Obj x140246338627687 = makeCons(symcora_47init_35add_45to_45_42macros_42, x140246338627655);
+__nargs = 2;
+__arg1 = x140246338627687;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label8:
+{
+Obj exp = __arg1;
+Obj x140246338825671 = PRIM_ISCONS(exp);
+if (True == x140246338825671) {
+Obj x140246338826087 = PRIM_CAR(exp);
+Obj x140246338826151 = PRIM_EQ(x140246338826087, globalRef(sym_42protect_45symbol_42));
+if (True == x140246338826151) {
+Obj x140246338699367 = PRIM_CDR(exp);
+__nargs = 2;
+__arg1 = x140246338699367;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140246338699815 = PRIM_CAR(exp);
+Obj x140246338699879 = PRIM_EQ(x140246338699815, symlambda);
+if (True == x140246338699879) {
+pushCont(co, 11, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140246338701575 = PRIM_CAR(exp);
+Obj x140246338701639 = PRIM_EQ(x140246338701575, symquote);
+if (True == x140246338701639) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 9, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand1);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label9:
+{
+Obj x140246338702695 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = makeNative(10, clofun5, 1, 1, exp);
+__arg1 = x140246338702695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
+{
+Obj exp1 = __arg1;
+Obj x140246338702119 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == x140246338702119) {
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg2 = exp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg1 = exp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label11:
+{
+Obj x140246338700455 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 12, clofun5, 1, x140246338700455);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj x140246338700999 = __arg1;
+Obj x140246338700455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 13, clofun5, 1, x140246338700455);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg1 = x140246338700999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj x140246338701031 = __arg1;
+Obj x140246338700455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246338701095 = makeCons(x140246338701031, Nil);
+Obj x140246338701127 = makeCons(x140246338700455, x140246338701095);
+Obj x140246338701159 = makeCons(symlambda, x140246338701127);
+__nargs = 2;
+__arg1 = x140246338701159;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label14:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -6374,130 +8328,130 @@ __arg2 = globalRef(sym_42macros_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label15:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj v0x7f4112563a00 = PRIM_EQ(Nil, macros);
-if (True == v0x7f4112563a00) {
+Obj x140246338951623 = PRIM_EQ(Nil, macros);
+if (True == x140246338951623) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f411252cb40 = PRIM_CAR(macros);
+Obj x140246338824487 = PRIM_CAR(macros);
 __nargs = 2;
-__arg0 = makeNative(9, clofun4, 1, 2, exp, macros);
-__arg1 = v0x7f411252cb40;
+__arg0 = makeNative(16, clofun5, 1, 2, exp, macros);
+__arg1 = x140246338824487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label16:
 {
 Obj item = __arg1;
-Obj v0x7f4112563c00 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112563c00) {
-Obj v0x7f4112563da0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112563e80 = PRIM_CAR(item);
-Obj v0x7f4112563ea0 = PRIM_EQ(v0x7f4112563da0, v0x7f4112563e80);
-if (True == v0x7f4112563ea0) {
+Obj x140246338952135 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140246338952135) {
+Obj x140246338952711 = PRIM_CAR(closureRef(co, 0));
+Obj x140246338952967 = PRIM_CAR(item);
+Obj x140246338952999 = PRIM_EQ(x140246338952711, x140246338952967);
+if (True == x140246338952999) {
 if (True == True) {
-Obj v0x7f4112563fe0 = PRIM_CDR(item);
+Obj x140246338822311 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = v0x7f4112563fe0;
+__arg0 = x140246338822311;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f411252c280 = PRIM_CDR(closureRef(co, 1));
+Obj x140246338822727 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = v0x7f411252c280;
+__arg2 = x140246338822727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj v0x7f411252c460 = PRIM_CDR(item);
+Obj x140246338823047 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = v0x7f411252c460;
+__arg0 = x140246338823047;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f411252c680 = PRIM_CDR(closureRef(co, 1));
+Obj x140246338823495 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = v0x7f411252c680;
+__arg2 = x140246338823495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
 if (True == False) {
-Obj v0x7f411252c7e0 = PRIM_CDR(item);
+Obj x140246338823815 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = v0x7f411252c7e0;
+__arg0 = x140246338823815;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f411252ca40 = PRIM_CDR(closureRef(co, 1));
+Obj x140246338824263 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = v0x7f411252ca40;
+__arg2 = x140246338824263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label10:
+label17:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj v0x7f4112563720 = makeCons(n, v);
-Obj v0x7f4112563760 = makeCons(v0x7f4112563720, globalRef(sym_42macros_42));
-Obj v0x7f4112563780 = primSet(co, sym_42macros_42, v0x7f4112563760);
+Obj x140246338950727 = makeCons(n, v);
+Obj x140246338950791 = makeCons(x140246338950727, globalRef(sym_42macros_42));
+Obj x140246338950823 = primSet(co, sym_42macros_42, x140246338950791);
 __nargs = 2;
-__arg1 = v0x7f4112563780;
+__arg1 = x140246338950823;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label11:
+label18:
 {
 Obj f = __arg1;
 Obj l = __arg2;
@@ -6509,26 +8463,26 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label19:
 {
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj v0x7f41125709c0 = PRIM_ISCONS(l);
-if (True == v0x7f41125709c0) {
-Obj v0x7f4112570c60 = PRIM_CAR(l);
-pushCont(co, 13, clofun4, 3, res, l, f);
+Obj x140246338970727 = PRIM_ISCONS(l);
+if (True == x140246338970727) {
+Obj x140246338971559 = PRIM_CAR(l);
+pushCont(co, 20, clofun5, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = v0x7f4112570c60;
+__arg1 = x140246338971559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -6537,204 +8491,204 @@ __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label13:
+label20:
 {
-Obj v0x7f4112570c80 = __arg1;
+Obj x140246338971623 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112570cc0 = makeCons(v0x7f4112570c80, res);
-Obj v0x7f4112570dc0 = PRIM_CDR(l);
+Obj x140246338971719 = makeCons(x140246338971623, res);
+Obj x140246338972103 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symmap_45h);
-__arg1 = v0x7f4112570cc0;
+__arg1 = x140246338971719;
 __arg2 = f;
-__arg3 = v0x7f4112570dc0;
+__arg3 = x140246338972103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label21:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj v0x7f4112570260 = PRIM_ISCONS(l);
-if (True == v0x7f4112570260) {
-Obj v0x7f4112570460 = PRIM_CAR(l);
-Obj v0x7f41125704a0 = makeCons(v0x7f4112570460, res);
-Obj v0x7f4112570580 = PRIM_CDR(l);
+Obj x140246339320583 = PRIM_ISCONS(l);
+if (True == x140246339320583) {
+Obj x140246339321095 = PRIM_CAR(l);
+Obj x140246339321159 = makeCons(x140246339321095, res);
+Obj x140246339321383 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = v0x7f41125704a0;
-__arg2 = v0x7f4112570580;
+__arg1 = x140246339321159;
+__arg2 = x140246339321383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
-}
-
-label15:
-{
-Obj x = __arg1;
-Obj v0x7f4112570000 = PRIM_ISCONS(x);
-__nargs = 2;
-__arg1 = v0x7f4112570000;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj exp = __arg1;
-Obj v0x7f41124cb8a0 = PRIM_ISCONS(exp);
-if (True == v0x7f41124cb8a0) {
-Obj v0x7f41124cbac0 = PRIM_CAR(exp);
-Obj v0x7f41124cbce0 = PRIM_CDR(exp);
-pushCont(co, 17, clofun4, 1, v0x7f41124cbac0);
-__nargs = 2;
-__arg0 = globalRef(symrcons);
-__arg1 = v0x7f41124cbce0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label17:
-{
-Obj v0x7f41124cbd00 = __arg1;
-Obj v0x7f41124cbac0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41124cbd40 = makeCons(v0x7f41124cbd00, Nil);
-Obj v0x7f41124cbd60 = makeCons(v0x7f41124cbac0, v0x7f41124cbd40);
-Obj v0x7f41124cbd80 = makeCons(symcons, v0x7f41124cbd60);
-__nargs = 2;
-__arg1 = v0x7f41124cbd80;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label18:
-{
-Obj x = __arg1;
-Obj v0x7f41124cb600 = PRIM_CDR(x);
-Obj v0x7f41124cb620 = PRIM_CDR(v0x7f41124cb600);
-Obj v0x7f41124cb640 = PRIM_CDR(v0x7f41124cb620);
-__nargs = 2;
-__arg1 = v0x7f41124cb640;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj x = __arg1;
-Obj v0x7f41124cb240 = PRIM_CDR(x);
-Obj v0x7f41124cb260 = PRIM_CDR(v0x7f41124cb240);
-Obj v0x7f41124cb280 = PRIM_CDR(v0x7f41124cb260);
-Obj v0x7f41124cb2a0 = PRIM_CAR(v0x7f41124cb280);
-__nargs = 2;
-__arg1 = v0x7f41124cb2a0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj x = __arg1;
-Obj v0x7f41124d9e00 = PRIM_CDR(x);
-Obj v0x7f41124d9e20 = PRIM_CDR(v0x7f41124d9e00);
-Obj v0x7f41124d9e40 = PRIM_CAR(v0x7f41124d9e20);
-__nargs = 2;
-__arg1 = v0x7f41124d9e40;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label21:
-{
-Obj x = __arg1;
-Obj v0x7f41124d9a80 = PRIM_CDR(x);
-Obj v0x7f41124d9aa0 = PRIM_CDR(v0x7f41124d9a80);
-__nargs = 2;
-__arg1 = v0x7f41124d9aa0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 }
 
 label22:
 {
 Obj x = __arg1;
-Obj v0x7f41124d97a0 = PRIM_CAR(x);
-Obj v0x7f41124d97c0 = PRIM_CDR(v0x7f41124d97a0);
+Obj x140246339319975 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = v0x7f41124d97c0;
+__arg1 = x140246339319975;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label23:
 {
-Obj x = __arg1;
-Obj v0x7f41124d94c0 = PRIM_CAR(x);
-Obj v0x7f41124d94e0 = PRIM_CAR(v0x7f41124d94c0);
+Obj exp = __arg1;
+Obj x140246339318183 = PRIM_ISCONS(exp);
+if (True == x140246339318183) {
+Obj x140246339318727 = PRIM_CAR(exp);
+Obj x140246339319271 = PRIM_CDR(exp);
+pushCont(co, 24, clofun5, 1, x140246339318727);
 __nargs = 2;
-__arg1 = v0x7f41124d94e0;
+__arg0 = globalRef(symrcons);
+__arg1 = x140246339319271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label24:
 {
-Obj x = __arg1;
-Obj v0x7f41124d91e0 = PRIM_CDR(x);
-Obj v0x7f41124d9200 = PRIM_CAR(v0x7f41124d91e0);
+Obj x140246339319303 = __arg1;
+Obj x140246339318727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140246339319367 = makeCons(x140246339319303, Nil);
+Obj x140246339319399 = makeCons(x140246339318727, x140246339319367);
+Obj x140246339319431 = makeCons(symcons, x140246339319399);
 __nargs = 2;
-__arg1 = v0x7f41124d9200;
+__arg1 = x140246339319431;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label25:
 {
 Obj x = __arg1;
-Obj v0x7f41124ebf20 = PRIM_EQ(x, Nil);
+Obj x140246339374855 = PRIM_CDR(x);
+Obj x140246339374887 = PRIM_CDR(x140246339374855);
+Obj x140246339374919 = PRIM_CDR(x140246339374887);
 __nargs = 2;
-__arg1 = v0x7f41124ebf20;
+__arg1 = x140246339374919;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label26:
+{
+Obj x = __arg1;
+Obj x140246339373895 = PRIM_CDR(x);
+Obj x140246339373927 = PRIM_CDR(x140246339373895);
+Obj x140246339373959 = PRIM_CDR(x140246339373927);
+Obj x140246339373991 = PRIM_CAR(x140246339373959);
+__nargs = 2;
+__arg1 = x140246339373991;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label27:
+{
+Obj x = __arg1;
+Obj x140246339372807 = PRIM_CDR(x);
+Obj x140246339372839 = PRIM_CDR(x140246339372807);
+Obj x140246339372871 = PRIM_CAR(x140246339372839);
+__nargs = 2;
+__arg1 = x140246339372871;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label28:
+{
+Obj x = __arg1;
+Obj x140246339371911 = PRIM_CDR(x);
+Obj x140246339371943 = PRIM_CDR(x140246339371911);
+__nargs = 2;
+__arg1 = x140246339371943;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label29:
+{
+Obj x = __arg1;
+Obj x140246339371175 = PRIM_CAR(x);
+Obj x140246339371207 = PRIM_CDR(x140246339371175);
+__nargs = 2;
+__arg1 = x140246339371207;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label30:
+{
+Obj x = __arg1;
+Obj x140246339624391 = PRIM_CAR(x);
+Obj x140246339624423 = PRIM_CAR(x140246339624391);
+__nargs = 2;
+__arg1 = x140246339624423;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label31:
+{
+Obj x = __arg1;
+Obj x140246339623655 = PRIM_CDR(x);
+Obj x140246339623687 = PRIM_CAR(x140246339623655);
+__nargs = 2;
+__arg1 = x140246339623687;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label32:
+{
+Obj x = __arg1;
+Obj x140246339622951 = PRIM_EQ(x, Nil);
+__nargs = 2;
+__arg1 = x140246339622951;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 

--- a/init.c
+++ b/init.c
@@ -343,17 +343,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140166664293415 = primSet(co, symnull_63, makeNative(32, clofun5, 1, 0));
-Obj x140166664294375 = primSet(co, symcadr, makeNative(31, clofun5, 1, 0));
-Obj x140166664131559 = primSet(co, symcaar, makeNative(30, clofun5, 1, 0));
-Obj x140166664132551 = primSet(co, symcdar, makeNative(29, clofun5, 1, 0));
-Obj x140166664133383 = primSet(co, symcddr, makeNative(28, clofun5, 1, 0));
-Obj x140166664134535 = primSet(co, symcaddr, makeNative(27, clofun5, 1, 0));
-Obj x140166664115271 = primSet(co, symcadddr, makeNative(26, clofun5, 1, 0));
-Obj x140166664116231 = primSet(co, symcdddr, makeNative(25, clofun5, 1, 0));
-Obj x140166664118151 = primSet(co, symrcons, makeNative(23, clofun5, 1, 0));
-Obj x140166664085959 = primSet(co, sympair_63, makeNative(22, clofun5, 1, 0));
-Obj x140166664087399 = primSet(co, symcora_47init_35reverse_45h, makeNative(21, clofun5, 2, 0));
+Obj x139731067801927 = primSet(co, symnull_63, makeNative(32, clofun5, 1, 0));
+Obj x139731067802663 = primSet(co, symcadr, makeNative(31, clofun5, 1, 0));
+Obj x139731067803399 = primSet(co, symcaar, makeNative(30, clofun5, 1, 0));
+Obj x139731067804135 = primSet(co, symcdar, makeNative(29, clofun5, 1, 0));
+Obj x139731067804871 = primSet(co, symcddr, makeNative(28, clofun5, 1, 0));
+Obj x139731067727975 = primSet(co, symcaddr, makeNative(27, clofun5, 1, 0));
+Obj x139731067729095 = primSet(co, symcadddr, makeNative(26, clofun5, 1, 0));
+Obj x139731067730023 = primSet(co, symcdddr, makeNative(25, clofun5, 1, 0));
+Obj x139731067731879 = primSet(co, symrcons, makeNative(23, clofun5, 1, 0));
+Obj x139731067613831 = primSet(co, sympair_63, makeNative(22, clofun5, 1, 0));
+Obj x139731067615719 = primSet(co, symcora_47init_35reverse_45h, makeNative(21, clofun5, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
@@ -367,19 +367,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140166664087847 = __arg1;
-Obj x140166664087879 = primSet(co, symreverse, x140166664087847);
-Obj x140166664081479 = primSet(co, symmap_45h, makeNative(19, clofun5, 3, 0));
-Obj x140166664082055 = primSet(co, symmap, makeNative(18, clofun5, 2, 0));
-Obj x140166664082343 = primSet(co, sym_42macros_42, Nil);
-Obj x140166664082759 = primGenSym();
-Obj x140166664082791 = primSet(co, sym_42protect_45symbol_42, x140166664082759);
-Obj x140166664083815 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(17, clofun5, 2, 0));
-Obj x140166664075783 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(15, clofun5, 2, 0));
-Obj x140166664076327 = primSet(co, symcora_47init_35macroexpand1, makeNative(14, clofun5, 1, 0));
-Obj x140166665232103 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(8, clofun5, 1, 0));
-Obj x140166665162759 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj x140166665165255 = primSet(co, symdefmacro_45macro, makeNative(4, clofun5, 1, 0));
+Obj x139731067616327 = __arg1;
+Obj x139731067616359 = primSet(co, symreverse, x139731067616327);
+Obj x139731067594055 = primSet(co, symmap_45h, makeNative(19, clofun5, 3, 0));
+Obj x139731067594759 = primSet(co, symmap, makeNative(18, clofun5, 2, 0));
+Obj x139731067595079 = primSet(co, sym_42macros_42, Nil);
+Obj x139731067595527 = primGenSym();
+Obj x139731067595559 = primSet(co, sym_42protect_45symbol_42, x139731067595527);
+Obj x139731067596775 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(17, clofun5, 2, 0));
+Obj x139731067469991 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(15, clofun5, 2, 0));
+Obj x139731067470631 = primSet(co, symcora_47init_35macroexpand1, makeNative(14, clofun5, 1, 0));
+Obj x139731067422343 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(8, clofun5, 1, 0));
+Obj x139731067422631 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
+Obj x139731067371879 = primSet(co, symdefmacro_45macro, makeNative(4, clofun5, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -394,7 +394,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140166665165543 = __arg1;
+Obj x139731067372167 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -409,7 +409,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140166665166247 = __arg1;
+Obj x139731067372871 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -424,10 +424,10 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140166665045639 = __arg1;
-Obj x140166665047111 = primSet(co, symelem_63, makeNative(48, clofun4, 2, 0));
-Obj x140166665047879 = primSet(co, symatom_63, makeNative(47, clofun4, 1, 0));
-Obj x140166664833447 = primSet(co, symcora_47init_35rewrite_45let, makeNative(42, clofun4, 1, 0));
+Obj x139731067954087 = __arg1;
+Obj x139731067955559 = primSet(co, symelem_63, makeNative(48, clofun4, 2, 0));
+Obj x139731067956295 = primSet(co, symatom_63, makeNative(47, clofun4, 1, 0));
+Obj x139731067934375 = primSet(co, symcora_47init_35rewrite_45let, makeNative(42, clofun4, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -442,7 +442,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140166664834151 = __arg1;
+Obj x139731067935079 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -457,8 +457,8 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140166664694023 = __arg1;
-Obj x140166664471687 = primSet(co, symcora_47init_35rewrite_45or, makeNative(35, clofun4, 1, 0));
+Obj x139731067930119 = __arg1;
+Obj x139731067904391 = primSet(co, symcora_47init_35rewrite_45or, makeNative(35, clofun4, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -473,8 +473,8 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140166664472391 = __arg1;
-Obj x140166664291463 = primSet(co, symcora_47init_35rewrite_45and, makeNative(32, clofun4, 1, 0));
+Obj x139731067905095 = __arg1;
+Obj x139731067908071 = primSet(co, symcora_47init_35rewrite_45and, makeNative(32, clofun4, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -489,9 +489,9 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140166664292455 = __arg1;
-Obj x140166664293607 = primSet(co, symboolean_63, makeNative(30, clofun4, 1, 0));
-Obj x140166664133159 = primSet(co, symcora_47init_35rcons1, makeNative(27, clofun4, 1, 0));
+Obj x139731067859623 = __arg1;
+Obj x139731067860551 = primSet(co, symboolean_63, makeNative(30, clofun4, 1, 0));
+Obj x139731067862791 = primSet(co, symcora_47init_35rcons1, makeNative(27, clofun4, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -506,12 +506,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140166664134183 = __arg1;
-Obj x140166663950887 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(8, clofun4, 4, 0));
-Obj x140166663758855 = primSet(co, symcora_47init_35match1, makeNative(2, clofun4, 4, 0));
-Obj x140166665228583 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(44, clofun3, 2, 0));
-Obj x140166664833895 = primSet(co, symcora_47init_35match_45helper, makeNative(28, clofun3, 2, 0));
-Obj x140166664472871 = primSet(co, symcora_47init_35rewrite_45match, makeNative(21, clofun3, 1, 0));
+Obj x139731067834823 = __arg1;
+Obj x139731067593287 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(8, clofun4, 4, 0));
+Obj x139731067472711 = primSet(co, symcora_47init_35match1, makeNative(2, clofun4, 4, 0));
+Obj x139731067302183 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(44, clofun3, 2, 0));
+Obj x139731067930215 = primSet(co, symcora_47init_35match_45helper, makeNative(28, clofun3, 2, 0));
+Obj x139731067859975 = primSet(co, symcora_47init_35rewrite_45match, makeNative(21, clofun3, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -526,17 +526,17 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140166664473447 = __arg1;
-Obj x140166664084871 = primSet(co, symcora_47init_35extract_45rules1, makeNative(13, clofun3, 3, 0));
-Obj x140166664073255 = primSet(co, symcora_47init_35extract_45rules, makeNative(12, clofun3, 1, 0));
-Obj x140166664075175 = primSet(co, symcora_47init_35rules_45patterns, makeNative(9, clofun3, 2, 0));
-Obj x140166664076743 = primSet(co, symcora_47init_35length_45h, makeNative(8, clofun3, 2, 0));
-Obj x140166663951367 = primSet(co, symlength, makeNative(7, clofun3, 1, 0));
-Obj x140166663954087 = primSet(co, symcora_47init_35filter_45h, makeNative(5, clofun3, 3, 0));
-Obj x140166663926183 = primSet(co, symfilter, makeNative(4, clofun3, 2, 0));
-Obj x140166663927879 = primSet(co, symappend, makeNative(2, clofun3, 2, 0));
-Obj x140166663759463 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(45, clofun2, 1, 0));
-Obj x140166663761095 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(43, clofun2, 1, 0));
+Obj x139731067860583 = __arg1;
+Obj x139731067593351 = primSet(co, symcora_47init_35extract_45rules1, makeNative(13, clofun3, 3, 0));
+Obj x139731067594279 = primSet(co, symcora_47init_35extract_45rules, makeNative(12, clofun3, 1, 0));
+Obj x139731067596519 = primSet(co, symcora_47init_35rules_45patterns, makeNative(9, clofun3, 2, 0));
+Obj x139731067581863 = primSet(co, symcora_47init_35length_45h, makeNative(8, clofun3, 2, 0));
+Obj x139731067582535 = primSet(co, symlength, makeNative(7, clofun3, 1, 0));
+Obj x139731067471239 = primSet(co, symcora_47init_35filter_45h, makeNative(5, clofun3, 3, 0));
+Obj x139731067472071 = primSet(co, symfilter, makeNative(4, clofun3, 2, 0));
+Obj x139731067420935 = primSet(co, symappend, makeNative(2, clofun3, 2, 0));
+Obj x139731067371751 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(45, clofun2, 1, 0));
+Obj x139731067373415 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(43, clofun2, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -551,12 +551,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166663577287 = __arg1;
-Obj x140166665230343 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(25, clofun2, 1, 0));
-Obj x140166663558887 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(2, clofun2, 1, 0));
-Obj x140166663559623 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(1, clofun2, 1, 0));
-Obj x140166663560679 = primSet(co, symmacroexpand, makeNative(48, clofun1, 1, 0));
-Obj x140166663366343 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(43, clofun1, 1, 0));
+Obj x139731067303303 = __arg1;
+Obj x139731067929351 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(25, clofun2, 1, 0));
+Obj x139731066959047 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(2, clofun2, 1, 0));
+Obj x139731066959655 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(1, clofun2, 1, 0));
+Obj x139731066960551 = primSet(co, symmacroexpand, makeNative(48, clofun1, 1, 0));
+Obj x139731066844711 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(43, clofun1, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -571,8 +571,8 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140166663367047 = __arg1;
-Obj x140166665093575 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(36, clofun1, 1, 0));
+Obj x139731067954375 = __arg1;
+Obj x139731067932295 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(36, clofun1, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -587,9 +587,9 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140166665273735 = __arg1;
-Obj x140166665096071 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(29, clofun1, 4, 0));
-Obj x140166665096679 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(28, clofun1, 2, 0));
+Obj x139731067904839 = __arg1;
+Obj x139731067729159 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(29, clofun1, 4, 0));
+Obj x139731067730535 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(28, clofun1, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -604,159 +604,159 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140166664834247 = __arg1;
-Obj x140166664693639 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(15, clofun1, 2, 0));
-Obj x140166664292807 = primSet(co, symcora_47init_35lookup_45var, makeNative(5, clofun1, 3, 0));
-Obj x140166664131431 = makeCons(makeCString("primSet"), Nil);
-Obj x140166664131463 = makeCons(MAKE_NUMBER(2), x140166664131431);
-Obj x140166664131591 = makeCons(symset, x140166664131463);
-Obj x140166664133543 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x140166664133575 = makeCons(MAKE_NUMBER(1), x140166664133543);
-Obj x140166664133639 = makeCons(symcar, x140166664133575);
-Obj x140166664114823 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x140166664114855 = makeCons(MAKE_NUMBER(1), x140166664114823);
-Obj x140166664114919 = makeCons(symcdr, x140166664114855);
-Obj x140166664116647 = makeCons(makeCString("makeCons"), Nil);
-Obj x140166664116679 = makeCons(MAKE_NUMBER(2), x140166664116647);
-Obj x140166664116711 = makeCons(symcons, x140166664116679);
-Obj x140166664117927 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x140166664118215 = makeCons(MAKE_NUMBER(1), x140166664117927);
-Obj x140166664118247 = makeCons(symcons_63, x140166664118215);
-Obj x140166664087111 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x140166664087207 = makeCons(MAKE_NUMBER(2), x140166664087111);
-Obj x140166664087239 = makeCons(sym_43, x140166664087207);
-Obj x140166664088999 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x140166664089031 = makeCons(MAKE_NUMBER(2), x140166664088999);
-Obj x140166664089063 = makeCons(sym_45, x140166664089031);
-Obj x140166664082151 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x140166664082183 = makeCons(MAKE_NUMBER(2), x140166664082151);
-Obj x140166664082215 = makeCons(sym_42, x140166664082183);
-Obj x140166664083943 = makeCons(makeCString("primDiv"), Nil);
-Obj x140166664083975 = makeCons(MAKE_NUMBER(2), x140166664083943);
-Obj x140166664084007 = makeCons(sym_47, x140166664083975);
-Obj x140166664085383 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x140166664085415 = makeCons(MAKE_NUMBER(2), x140166664085383);
-Obj x140166664085447 = makeCons(sym_61, x140166664085415);
-Obj x140166664074567 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x140166664074599 = makeCons(MAKE_NUMBER(2), x140166664074567);
-Obj x140166664074631 = makeCons(sym_62, x140166664074599);
-Obj x140166664076167 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x140166664076359 = makeCons(MAKE_NUMBER(2), x140166664076167);
-Obj x140166664076519 = makeCons(sym_60, x140166664076359);
-Obj x140166663951655 = makeCons(makeCString("primGenSym"), Nil);
-Obj x140166663951687 = makeCons(MAKE_NUMBER(0), x140166663951655);
-Obj x140166663951719 = makeCons(symgensym, x140166663951687);
-Obj x140166663952999 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x140166663953031 = makeCons(MAKE_NUMBER(1), x140166663952999);
-Obj x140166663953095 = makeCons(symsymbol_63, x140166663953031);
-Obj x140166663954375 = makeCons(makeCString("primNot"), Nil);
-Obj x140166663925767 = makeCons(MAKE_NUMBER(1), x140166663954375);
-Obj x140166663925927 = makeCons(symnot, x140166663925767);
-Obj x140166663927239 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x140166663927335 = makeCons(MAKE_NUMBER(1), x140166663927239);
-Obj x140166663927367 = makeCons(syminteger_63, x140166663927335);
-Obj x140166663928903 = makeCons(makeCString("primIsString"), Nil);
-Obj x140166663928935 = makeCons(MAKE_NUMBER(1), x140166663928903);
-Obj x140166663928967 = makeCons(symstring_63, x140166663928935);
-Obj x140166663929127 = makeCons(x140166663928967, Nil);
-Obj x140166663929159 = makeCons(x140166663927367, x140166663929127);
-Obj x140166663929191 = makeCons(x140166663925927, x140166663929159);
-Obj x140166663929223 = makeCons(x140166663953095, x140166663929191);
-Obj x140166663929255 = makeCons(x140166663951719, x140166663929223);
-Obj x140166663929287 = makeCons(x140166664076519, x140166663929255);
-Obj x140166663929319 = makeCons(x140166664074631, x140166663929287);
-Obj x140166663929383 = makeCons(x140166664085447, x140166663929319);
-Obj x140166663929447 = makeCons(x140166664084007, x140166663929383);
-Obj x140166663929607 = makeCons(x140166664082215, x140166663929447);
-Obj x140166663929639 = makeCons(x140166664089063, x140166663929607);
-Obj x140166663929671 = makeCons(x140166664087239, x140166663929639);
-Obj x140166663929703 = makeCons(x140166664118247, x140166663929671);
-Obj x140166663929735 = makeCons(x140166664116711, x140166663929703);
-Obj x140166663929799 = makeCons(x140166664114919, x140166663929735);
-Obj x140166663929831 = makeCons(x140166664133639, x140166663929799);
-Obj x140166663757831 = makeCons(x140166664131591, x140166663929831);
-Obj x140166663757863 = primSet(co, symcora_47init_35_42builtin_45prims_42, x140166663757831);
-Obj x140166663561735 = primSet(co, symassq, makeNative(1, clofun1, 2, 0));
-Obj x140166663562983 = primSet(co, symcora_47init_35builtin_63, makeNative(48, clofun0, 1, 0));
-Obj x140166664834631 = primSet(co, symcora_47init_35parse, makeNative(15, clofun0, 4, 0));
-Obj x140166664473607 = makeCons(symappend, Nil);
-Obj x140166664473639 = makeCons(symfilter, x140166664473607);
-Obj x140166664473671 = makeCons(symlength, x140166664473639);
-Obj x140166664473703 = makeCons(symelem_63, x140166664473671);
-Obj x140166664473735 = makeCons(symmacroexpand, x140166664473703);
-Obj x140166664473767 = makeCons(symmap, x140166664473735);
-Obj x140166664473831 = makeCons(symreverse, x140166664473767);
-Obj x140166664473863 = makeCons(symthrow, x140166664473831);
-Obj x140166664473959 = makeCons(symtry, x140166664473863);
-Obj x140166664473991 = makeCons(symload, x140166664473959);
-Obj x140166664474023 = makeCons(symimport, x140166664473991);
-Obj x140166664474055 = makeCons(symload_45so, x140166664474023);
-Obj x140166664474087 = makeCons(symapply, x140166664474055);
-Obj x140166664474151 = makeCons(symvalue_45or, x140166664474087);
-Obj x140166664474183 = makeCons(symvalue, x140166664474151);
-Obj x140166664474247 = makeCons(symread_45file_45as_45sexp, x140166664474183);
-Obj x140166664474279 = makeCons(symbytes_45length, x140166664474247);
-Obj x140166664474599 = makeCons(symbytes, x140166664474279);
-Obj x140166664290343 = makeCons(symvector_45length, x140166664474599);
-Obj x140166664290407 = makeCons(symvector_45ref, x140166664290343);
-Obj x140166664290471 = makeCons(symvector_45set_33, x140166664290407);
-Obj x140166664290503 = makeCons(symvector, x140166664290471);
-Obj x140166664290631 = makeCons(symsymbol_45_62string, x140166664290503);
-Obj x140166664290663 = makeCons(symintern, x140166664290631);
-Obj x140166664290791 = makeCons(symstring_45append, x140166664290663);
-Obj x140166664290887 = makeCons(symnull_63, x140166664290791);
-Obj x140166664290919 = makeCons(symnumber_63, x140166664290887);
-Obj x140166664290951 = makeCons(symboolean_63, x140166664290919);
-Obj x140166664290983 = makeCons(symatom_63, x140166664290951);
-Obj x140166664291047 = makeCons(sympair_63, x140166664290983);
-Obj x140166664291111 = makeCons(symcdddr, x140166664291047);
-Obj x140166664291207 = makeCons(symcadddr, x140166664291111);
-Obj x140166664291239 = makeCons(symcaddr, x140166664291207);
-Obj x140166664291527 = makeCons(symcddr, x140166664291239);
-Obj x140166664291559 = makeCons(symcdar, x140166664291527);
-Obj x140166664291591 = makeCons(symcaar, x140166664291559);
-Obj x140166664291655 = makeCons(symcadr, x140166664291591);
-Obj x140166664291687 = primSet(co, symcora_47init_35_42ns_45export_42, x140166664291655);
-Obj x140166664292679 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj x140166664293095 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj x140166664293703 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj x140166664130887 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj x140166664131847 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj x140166664132391 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj x140166664133255 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj x140166664133959 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj x140166664134631 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj x140166664114727 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj x140166664115495 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj x140166664116039 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj x140166664116775 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj x140166664117223 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj x140166664117703 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj x140166664085799 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj x140166664086311 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj x140166664086983 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj x140166664087623 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj x140166664088423 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj x140166664089191 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj x140166664081607 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj x140166664081959 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj x140166664082695 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj x140166664083143 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj x140166664083879 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj x140166664084583 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj x140166664085031 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj x140166664073223 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj x140166664073799 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj x140166664074279 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj x140166664074951 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj x140166664075431 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj x140166664076103 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj x140166663950599 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj x140166663951047 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj x140166663951815 = primSet(co, symcora_47init_35append, globalRef(symappend));
-Obj x140166663952167 = primSet(co, symcora_47init_35assq, globalRef(symassq));
+Obj x139731067581255 = __arg1;
+Obj x139731067584359 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(15, clofun1, 2, 0));
+Obj x139731067372199 = primSet(co, symcora_47init_35lookup_45var, makeNative(5, clofun1, 3, 0));
+Obj x139731067373991 = makeCons(makeCString("primSet"), Nil);
+Obj x139731067374023 = makeCons(MAKE_NUMBER(2), x139731067373991);
+Obj x139731067374055 = makeCons(symset, x139731067374023);
+Obj x139731067375399 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x139731067375431 = makeCons(MAKE_NUMBER(1), x139731067375399);
+Obj x139731067375463 = makeCons(symcar, x139731067375431);
+Obj x139731067303367 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x139731067303399 = makeCons(MAKE_NUMBER(1), x139731067303367);
+Obj x139731067303431 = makeCons(symcdr, x139731067303399);
+Obj x139731067304647 = makeCons(makeCString("makeCons"), Nil);
+Obj x139731067304679 = makeCons(MAKE_NUMBER(2), x139731067304647);
+Obj x139731067304711 = makeCons(symcons, x139731067304679);
+Obj x139731067257575 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x139731067257607 = makeCons(MAKE_NUMBER(1), x139731067257575);
+Obj x139731067257639 = makeCons(symcons_63, x139731067257607);
+Obj x139731067258887 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x139731067258919 = makeCons(MAKE_NUMBER(2), x139731067258887);
+Obj x139731067258951 = makeCons(sym_43, x139731067258919);
+Obj x139731067259975 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x139731067260007 = makeCons(MAKE_NUMBER(2), x139731067259975);
+Obj x139731067260039 = makeCons(sym_45, x139731067260007);
+Obj x139731067187335 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x139731067187367 = makeCons(MAKE_NUMBER(2), x139731067187335);
+Obj x139731067187399 = makeCons(sym_42, x139731067187367);
+Obj x139731067188423 = makeCons(makeCString("primDiv"), Nil);
+Obj x139731067188551 = makeCons(MAKE_NUMBER(2), x139731067188423);
+Obj x139731067188583 = makeCons(sym_47, x139731067188551);
+Obj x139731067189575 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x139731067189607 = makeCons(MAKE_NUMBER(2), x139731067189575);
+Obj x139731067189639 = makeCons(sym_61, x139731067189607);
+Obj x139731067190727 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x139731067190759 = makeCons(MAKE_NUMBER(2), x139731067190727);
+Obj x139731067190791 = makeCons(sym_62, x139731067190759);
+Obj x139731066978855 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x139731066978887 = makeCons(MAKE_NUMBER(2), x139731066978855);
+Obj x139731066978919 = makeCons(sym_60, x139731066978887);
+Obj x139731066980039 = makeCons(makeCString("primGenSym"), Nil);
+Obj x139731066980071 = makeCons(MAKE_NUMBER(0), x139731066980039);
+Obj x139731066980135 = makeCons(symgensym, x139731066980071);
+Obj x139731066981159 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x139731066981191 = makeCons(MAKE_NUMBER(1), x139731066981159);
+Obj x139731066981223 = makeCons(symsymbol_63, x139731066981191);
+Obj x139731066982247 = makeCons(makeCString("primNot"), Nil);
+Obj x139731066982343 = makeCons(MAKE_NUMBER(1), x139731066982247);
+Obj x139731066982375 = makeCons(symnot, x139731066982343);
+Obj x139731066971111 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x139731066971143 = makeCons(MAKE_NUMBER(1), x139731066971111);
+Obj x139731066971175 = makeCons(syminteger_63, x139731066971143);
+Obj x139731066972167 = makeCons(makeCString("primIsString"), Nil);
+Obj x139731066972263 = makeCons(MAKE_NUMBER(1), x139731066972167);
+Obj x139731066972295 = makeCons(symstring_63, x139731066972263);
+Obj x139731066972359 = makeCons(x139731066972295, Nil);
+Obj x139731066972391 = makeCons(x139731066971175, x139731066972359);
+Obj x139731066972423 = makeCons(x139731066982375, x139731066972391);
+Obj x139731066972455 = makeCons(x139731066981223, x139731066972423);
+Obj x139731066972487 = makeCons(x139731066980135, x139731066972455);
+Obj x139731066972583 = makeCons(x139731066978919, x139731066972487);
+Obj x139731066972615 = makeCons(x139731067190791, x139731066972583);
+Obj x139731066972647 = makeCons(x139731067189639, x139731066972615);
+Obj x139731066972679 = makeCons(x139731067188583, x139731066972647);
+Obj x139731066972711 = makeCons(x139731067187399, x139731066972679);
+Obj x139731066972743 = makeCons(x139731067260039, x139731066972711);
+Obj x139731066972775 = makeCons(x139731067258951, x139731066972743);
+Obj x139731066972807 = makeCons(x139731067257639, x139731066972775);
+Obj x139731066972839 = makeCons(x139731067304711, x139731066972807);
+Obj x139731066972871 = makeCons(x139731067303431, x139731066972839);
+Obj x139731066972903 = makeCons(x139731067375463, x139731066972871);
+Obj x139731066972935 = makeCons(x139731067374055, x139731066972903);
+Obj x139731066972967 = primSet(co, symcora_47init_35_42builtin_45prims_42, x139731066972935);
+Obj x139731066917479 = primSet(co, symassq, makeNative(1, clofun1, 2, 0));
+Obj x139731066918599 = primSet(co, symcora_47init_35builtin_63, makeNative(48, clofun0, 1, 0));
+Obj x139731067423719 = primSet(co, symcora_47init_35parse, makeNative(15, clofun0, 4, 0));
+Obj x139731067187623 = makeCons(symappend, Nil);
+Obj x139731067187655 = makeCons(symfilter, x139731067187623);
+Obj x139731067187751 = makeCons(symlength, x139731067187655);
+Obj x139731067187783 = makeCons(symelem_63, x139731067187751);
+Obj x139731067187815 = makeCons(symmacroexpand, x139731067187783);
+Obj x139731067187847 = makeCons(symmap, x139731067187815);
+Obj x139731067187943 = makeCons(symreverse, x139731067187847);
+Obj x139731067187975 = makeCons(symthrow, x139731067187943);
+Obj x139731067188007 = makeCons(symtry, x139731067187975);
+Obj x139731067188039 = makeCons(symload, x139731067188007);
+Obj x139731067188071 = makeCons(symimport, x139731067188039);
+Obj x139731067188103 = makeCons(symload_45so, x139731067188071);
+Obj x139731067188135 = makeCons(symapply, x139731067188103);
+Obj x139731067188167 = makeCons(symvalue_45or, x139731067188135);
+Obj x139731067188199 = makeCons(symvalue, x139731067188167);
+Obj x139731067188231 = makeCons(symread_45file_45as_45sexp, x139731067188199);
+Obj x139731067188263 = makeCons(symbytes_45length, x139731067188231);
+Obj x139731067188295 = makeCons(symbytes, x139731067188263);
+Obj x139731067188391 = makeCons(symvector_45length, x139731067188295);
+Obj x139731067188615 = makeCons(symvector_45ref, x139731067188391);
+Obj x139731067188647 = makeCons(symvector_45set_33, x139731067188615);
+Obj x139731067188679 = makeCons(symvector, x139731067188647);
+Obj x139731067188711 = makeCons(symsymbol_45_62string, x139731067188679);
+Obj x139731067188743 = makeCons(symintern, x139731067188711);
+Obj x139731067188807 = makeCons(symstring_45append, x139731067188743);
+Obj x139731067188839 = makeCons(symnull_63, x139731067188807);
+Obj x139731067188871 = makeCons(symnumber_63, x139731067188839);
+Obj x139731067188903 = makeCons(symboolean_63, x139731067188871);
+Obj x139731067189031 = makeCons(symatom_63, x139731067188903);
+Obj x139731067189063 = makeCons(sympair_63, x139731067189031);
+Obj x139731067189095 = makeCons(symcdddr, x139731067189063);
+Obj x139731067189127 = makeCons(symcadddr, x139731067189095);
+Obj x139731067189159 = makeCons(symcaddr, x139731067189127);
+Obj x139731067189191 = makeCons(symcddr, x139731067189159);
+Obj x139731067189223 = makeCons(symcdar, x139731067189191);
+Obj x139731067189255 = makeCons(symcaar, x139731067189223);
+Obj x139731067189287 = makeCons(symcadr, x139731067189255);
+Obj x139731067189319 = primSet(co, symcora_47init_35_42ns_45export_42, x139731067189287);
+Obj x139731067189895 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
+Obj x139731067190183 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
+Obj x139731067190503 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
+Obj x139731067191079 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
+Obj x139731066978375 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
+Obj x139731066978951 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
+Obj x139731066979303 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
+Obj x139731066979751 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
+Obj x139731066980263 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
+Obj x139731066980711 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
+Obj x139731066981063 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
+Obj x139731066981447 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
+Obj x139731066981959 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
+Obj x139731066970119 = primSet(co, symcora_47init_35intern, globalRef(symintern));
+Obj x139731066970503 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
+Obj x139731066970855 = primSet(co, symcora_47init_35vector, globalRef(symvector));
+Obj x139731066971303 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
+Obj x139731066971591 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
+Obj x139731066972007 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
+Obj x139731066973255 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
+Obj x139731066973543 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
+Obj x139731066973831 = primSet(co, symcora_47init_35value, globalRef(symvalue));
+Obj x139731066957863 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
+Obj x139731066958183 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
+Obj x139731066958663 = primSet(co, symcora_47init_35apply, globalRef(symapply));
+Obj x139731066958951 = primSet(co, symcora_47init_35load, globalRef(symload));
+Obj x139731066959271 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
+Obj x139731066959591 = primSet(co, symcora_47init_35import, globalRef(symimport));
+Obj x139731066959975 = primSet(co, symcora_47init_35try, globalRef(symtry));
+Obj x139731066960327 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
+Obj x139731066960711 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
+Obj x139731066961095 = primSet(co, symcora_47init_35map, globalRef(symmap));
+Obj x139731066961415 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
+Obj x139731066961767 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
+Obj x139731066917031 = primSet(co, symcora_47init_35length, globalRef(symlength));
+Obj x139731066917383 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
+Obj x139731066917703 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj x139731066918055 = primSet(co, symcora_47init_35assq, globalRef(symassq));
 __nargs = 2;
-__arg1 = x140166663952167;
+__arg1 = x139731066918055;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -764,16 +764,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj x140166664130727 = __arg1;
-Obj x140166664130759 = __arg2;
-Obj x140166664130791 = __arg3;
-Obj x140166664130823 = co->args[4];
-Obj x140166664131175 = makeNative(19, clofun0, 0, 4, x140166664130727, x140166664130759, x140166664130791, x140166664130823);
-Obj __ = x140166664130727;
-__ = x140166664130759;
-__ = x140166664130791;
-Obj x = x140166664130823;
-pushCont(co, 16, clofun0, 2, x, x140166664131175);
+Obj x139731067593735 = __arg1;
+Obj x139731067593767 = __arg2;
+Obj x139731067593927 = __arg3;
+Obj x139731067593959 = co->args[4];
+Obj x139731067594727 = makeNative(19, clofun0, 0, 4, x139731067593735, x139731067593767, x139731067593927, x139731067593959);
+Obj __ = x139731067593735;
+__ = x139731067593767;
+__ = x139731067593927;
+Obj x = x139731067593959;
+pushCont(co, 16, clofun0, 2, x, x139731067594727);
 __nargs = 2;
 __arg0 = globalRef(symnumber_63);
 __arg1 = x;
@@ -786,10 +786,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140166664831623 = __arg1;
+Obj x139731067473735 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166664831623) {
+Obj x139731067594727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731067473735) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -798,7 +798,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131175;
+__arg0 = x139731067594727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -806,8 +806,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140166664832135 = primIsString(x);
-if (True == x140166664832135) {
+Obj x139731067421639 = primIsString(x);
+if (True == x139731067421639) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -816,7 +816,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131175;
+__arg0 = x139731067594727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -824,7 +824,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 17, clofun0, 2, x, x140166664131175);
+pushCont(co, 17, clofun0, 2, x, x139731067594727);
 __nargs = 2;
 __arg0 = globalRef(symboolean_63);
 __arg1 = x;
@@ -839,10 +839,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140166664832807 = __arg1;
+Obj x139731067422215 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166664832807) {
+Obj x139731067594727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731067422215) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -851,7 +851,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131175;
+__arg0 = x139731067594727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -859,7 +859,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 18, clofun0, 2, x, x140166664131175);
+pushCont(co, 18, clofun0, 2, x, x139731067594727);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
 __arg1 = x;
@@ -873,10 +873,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140166664833991 = __arg1;
+Obj x139731067422919 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664131175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166664833991) {
+Obj x139731067594727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731067422919) {
 if (True == True) {
 __nargs = 2;
 __arg1 = x;
@@ -885,7 +885,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131175;
+__arg0 = x139731067594727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -901,7 +901,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131175;
+__arg0 = x139731067594727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -913,35 +913,35 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140166664131911 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067595783 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj x140166665091847 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166665091847) {
-Obj x140166665092423 = PRIM_CAR(closureRef(co, 3));
-Obj x140166665092455 = PRIM_EQ(symquote, x140166665092423);
-if (True == x140166665092455) {
-Obj x140166665092871 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665092903 = PRIM_ISCONS(x140166665092871);
-if (True == x140166665092903) {
-Obj x140166665044391 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665044423 = PRIM_CAR(x140166665044391);
-Obj x = x140166665044423;
-Obj x140166665045511 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665045671 = PRIM_CDR(x140166665045511);
-Obj x140166665045703 = PRIM_EQ(Nil, x140166665045671);
-if (True == x140166665045703) {
-Obj x140166665046663 = makeCons(x, Nil);
-Obj x140166665046727 = makeCons(symquote, x140166665046663);
+Obj x139731067596615 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731067596615) {
+Obj x139731067582023 = PRIM_CAR(closureRef(co, 3));
+Obj x139731067582055 = PRIM_EQ(symquote, x139731067582023);
+if (True == x139731067582055) {
+Obj x139731067582631 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067582791 = PRIM_ISCONS(x139731067582631);
+if (True == x139731067582791) {
+Obj x139731067583431 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067583463 = PRIM_CAR(x139731067583431);
+Obj x = x139731067583463;
+Obj x139731067470279 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067470343 = PRIM_CDR(x139731067470279);
+Obj x139731067470599 = PRIM_EQ(Nil, x139731067470343);
+if (True == x139731067470599) {
+Obj x139731067471367 = makeCons(x, Nil);
+Obj x139731067471399 = makeCons(symquote, x139731067471367);
 __nargs = 2;
-__arg1 = x140166665046727;
+__arg1 = x139731067471399;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131911;
+__arg0 = x139731067595783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -950,7 +950,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131911;
+__arg0 = x139731067595783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -959,7 +959,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131911;
+__arg0 = x139731067595783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -968,7 +968,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131911;
+__arg0 = x139731067595783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -979,13 +979,13 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140166664132903 = makeNative(22, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067470407 = makeNative(22, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj x = closureRef(co, 3);
-Obj x140166665090663 = primIsSymbol(x);
-if (True == x140166665090663) {
+Obj x139731067594183 = primIsSymbol(x);
+if (True == x139731067594183) {
 pushCont(co, 21, clofun0, 3, x, ns, import);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
@@ -998,7 +998,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664132903;
+__arg0 = x139731067470407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1009,11 +1009,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140166665090951 = __arg1;
+Obj x139731067594919 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140166665090951) {
+if (True == x139731067594919) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1035,34 +1035,34 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140166664133607 = makeNative(25, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067471495 = makeNative(25, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140166665165735 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166665165735) {
-Obj x140166665166631 = PRIM_CAR(closureRef(co, 3));
-Obj x140166665166663 = PRIM_EQ(symlambda, x140166665166631);
-if (True == x140166665166663) {
-Obj x140166665093447 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665093479 = PRIM_ISCONS(x140166665093447);
-if (True == x140166665093479) {
-Obj x140166665093927 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665093959 = PRIM_CAR(x140166665093927);
-Obj args = x140166665093959;
-Obj x140166665094663 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665094695 = PRIM_CDR(x140166665094663);
-Obj x140166665094759 = PRIM_ISCONS(x140166665094695);
-if (True == x140166665094759) {
-Obj x140166665095367 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665095399 = PRIM_CDR(x140166665095367);
-Obj x140166665095431 = PRIM_CAR(x140166665095399);
-Obj body = x140166665095431;
-Obj x140166665096231 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665096263 = PRIM_CDR(x140166665096231);
-Obj x140166665096295 = PRIM_CDR(x140166665096263);
-Obj x140166665096327 = PRIM_EQ(Nil, x140166665096295);
-if (True == x140166665096327) {
+Obj x139731067838343 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731067838343) {
+Obj x139731067802471 = PRIM_CAR(closureRef(co, 3));
+Obj x139731067802503 = PRIM_EQ(symlambda, x139731067802471);
+if (True == x139731067802503) {
+Obj x139731067803719 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067803751 = PRIM_ISCONS(x139731067803719);
+if (True == x139731067803751) {
+Obj x139731067804903 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067804935 = PRIM_CAR(x139731067804903);
+Obj args = x139731067804935;
+Obj x139731067728263 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067728487 = PRIM_CDR(x139731067728263);
+Obj x139731067728519 = PRIM_ISCONS(x139731067728487);
+if (True == x139731067728519) {
+Obj x139731067729479 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067729511 = PRIM_CDR(x139731067729479);
+Obj x139731067729543 = PRIM_CAR(x139731067729511);
+Obj body = x139731067729543;
+Obj x139731067731751 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067731943 = PRIM_CDR(x139731067731751);
+Obj x139731067613287 = PRIM_CDR(x139731067731943);
+Obj x139731067613447 = PRIM_EQ(Nil, x139731067613287);
+if (True == x139731067613447) {
 pushCont(co, 23, clofun0, 4, ns, import, body, args);
 __nargs = 3;
 __arg0 = globalRef(symappend);
@@ -1075,7 +1075,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664133607;
+__arg0 = x139731067471495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1084,7 +1084,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133607;
+__arg0 = x139731067471495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1093,7 +1093,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133607;
+__arg0 = x139731067471495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1102,7 +1102,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133607;
+__arg0 = x139731067471495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1111,7 +1111,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133607;
+__arg0 = x139731067471495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1122,7 +1122,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140166665089095 = __arg1;
+Obj x139731067615783 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1130,7 +1130,7 @@ Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 24, clofun0, 1, args);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140166665089095;
+__arg1 = x139731067615783;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = body;
@@ -1143,13 +1143,13 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140166665089223 = __arg1;
+Obj x139731067616071 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665089287 = makeCons(x140166665089223, Nil);
-Obj x140166665089319 = makeCons(args, x140166665089287);
-Obj x140166665089351 = makeCons(symlambda, x140166665089319);
+Obj x139731067616135 = makeCons(x139731067616071, Nil);
+Obj x139731067616199 = makeCons(args, x139731067616135);
+Obj x139731067616263 = makeCons(symlambda, x139731067616199);
 __nargs = 2;
-__arg1 = x140166665089351;
+__arg1 = x139731067616263;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1157,67 +1157,67 @@ goto *jumpTable[co->ctx.pc.label];
 
 label25:
 {
-Obj x140166664114311 = makeNative(28, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067473383 = makeNative(28, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140166665354471 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166665354471) {
-Obj x140166665354919 = PRIM_CAR(closureRef(co, 3));
-Obj x140166665354951 = PRIM_EQ(symdo, x140166665354919);
-if (True == x140166665354951) {
-Obj x140166665334919 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665334951 = PRIM_ISCONS(x140166665334919);
-if (True == x140166665334951) {
-Obj x140166665335719 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665335751 = PRIM_CAR(x140166665335719);
-Obj x140166665335783 = PRIM_ISCONS(x140166665335751);
-if (True == x140166665335783) {
-Obj x140166665336551 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665336583 = PRIM_CAR(x140166665336551);
-Obj x140166665336615 = PRIM_CAR(x140166665336583);
-Obj x140166665336647 = PRIM_EQ(symimport, x140166665336615);
-if (True == x140166665336647) {
-Obj x140166665337479 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665337511 = PRIM_CAR(x140166665337479);
-Obj x140166665337543 = PRIM_CDR(x140166665337511);
-Obj x140166665337575 = PRIM_ISCONS(x140166665337543);
-if (True == x140166665337575) {
-Obj x140166665273415 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665273447 = PRIM_CAR(x140166665273415);
-Obj x140166665273479 = PRIM_CDR(x140166665273447);
-Obj x140166665273511 = PRIM_CAR(x140166665273479);
-Obj pkg = x140166665273511;
-Obj x140166665274631 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665274663 = PRIM_CAR(x140166665274631);
-Obj x140166665274695 = PRIM_CDR(x140166665274663);
-Obj x140166665274727 = PRIM_CDR(x140166665274695);
-Obj x140166665274759 = PRIM_EQ(Nil, x140166665274727);
-if (True == x140166665274759) {
-Obj x140166665275495 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665275527 = PRIM_CDR(x140166665275495);
-Obj x140166665275559 = PRIM_ISCONS(x140166665275527);
-if (True == x140166665275559) {
-Obj x140166665276231 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665276327 = PRIM_CDR(x140166665276231);
-Obj x140166665276359 = PRIM_CAR(x140166665276327);
-Obj y = x140166665276359;
-Obj x140166665277223 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665277255 = PRIM_CDR(x140166665277223);
-Obj x140166665277319 = PRIM_CDR(x140166665277255);
-Obj x140166665277351 = PRIM_EQ(Nil, x140166665277319);
-if (True == x140166665277351) {
-Obj x140166665228839 = primIsString(pkg);
-if (True == x140166665228839) {
-Obj x140166665230631 = makeCons(pkg, Nil);
-Obj x140166665230727 = makeCons(symimport, x140166665230631);
+Obj x139731067957095 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731067957095) {
+Obj x139731067933511 = PRIM_CAR(closureRef(co, 3));
+Obj x139731067933543 = PRIM_EQ(symdo, x139731067933511);
+if (True == x139731067933543) {
+Obj x139731067934471 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067934503 = PRIM_ISCONS(x139731067934471);
+if (True == x139731067934503) {
+Obj x139731067935495 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067935559 = PRIM_CAR(x139731067935495);
+Obj x139731067935655 = PRIM_ISCONS(x139731067935559);
+if (True == x139731067935655) {
+Obj x139731067928871 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067928903 = PRIM_CAR(x139731067928871);
+Obj x139731067929031 = PRIM_CAR(x139731067928903);
+Obj x139731067929063 = PRIM_EQ(symimport, x139731067929031);
+if (True == x139731067929063) {
+Obj x139731067930535 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067930663 = PRIM_CAR(x139731067930535);
+Obj x139731067930695 = PRIM_CDR(x139731067930663);
+Obj x139731067930759 = PRIM_ISCONS(x139731067930695);
+if (True == x139731067930759) {
+Obj x139731067931911 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067931975 = PRIM_CAR(x139731067931911);
+Obj x139731067932007 = PRIM_CDR(x139731067931975);
+Obj x139731067932039 = PRIM_CAR(x139731067932007);
+Obj pkg = x139731067932039;
+Obj x139731067904999 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067905031 = PRIM_CAR(x139731067904999);
+Obj x139731067905127 = PRIM_CDR(x139731067905031);
+Obj x139731067905159 = PRIM_CDR(x139731067905127);
+Obj x139731067905223 = PRIM_EQ(Nil, x139731067905159);
+if (True == x139731067905223) {
+Obj x139731067906279 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067906343 = PRIM_CDR(x139731067906279);
+Obj x139731067906375 = PRIM_ISCONS(x139731067906343);
+if (True == x139731067906375) {
+Obj x139731067907335 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067907367 = PRIM_CDR(x139731067907335);
+Obj x139731067907399 = PRIM_CAR(x139731067907367);
+Obj y = x139731067907399;
+Obj x139731067859815 = PRIM_CDR(closureRef(co, 3));
+Obj x139731067859847 = PRIM_CDR(x139731067859815);
+Obj x139731067859879 = PRIM_CDR(x139731067859847);
+Obj x139731067859911 = PRIM_EQ(Nil, x139731067859879);
+if (True == x139731067859911) {
+Obj x139731067860423 = primIsString(pkg);
+if (True == x139731067860423) {
+Obj x139731067862279 = makeCons(pkg, Nil);
+Obj x139731067862311 = makeCons(symimport, x139731067862279);
 pushCont(co, 26, clofun0, 5, pkg, import, env, ns, y);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
-co->args[4] = x140166665230727;
+co->args[4] = x139731067862311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1225,16 +1225,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1243,7 +1234,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1252,7 +1243,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1261,7 +1252,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1270,7 +1261,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1279,7 +1270,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1288,7 +1279,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1297,7 +1288,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1306,7 +1297,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664114311;
+__arg0 = x139731067473383;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731067473383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1317,19 +1317,19 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140166665230759 = __arg1;
+Obj x139731067862343 = __arg1;
 Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140166665231687 = makeCons(pkg, import);
-pushCont(co, 27, clofun0, 1, x140166665230759);
+Obj x139731067834951 = makeCons(pkg, import);
+pushCont(co, 27, clofun0, 1, x139731067862343);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
 __arg2 = ns;
-__arg3 = x140166665231687;
+__arg3 = x139731067834951;
 co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1340,13 +1340,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x140166665231847 = __arg1;
-Obj x140166665230759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665231911 = makeCons(x140166665231847, Nil);
-Obj x140166665231943 = makeCons(x140166665230759, x140166665231911);
-Obj x140166665232007 = makeCons(symdo, x140166665231943);
+Obj x139731067835015 = __arg1;
+Obj x139731067862343= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067835079 = makeCons(x139731067835015, Nil);
+Obj x139731067835111 = makeCons(x139731067862343, x139731067835079);
+Obj x139731067835239 = makeCons(symdo, x139731067835111);
 __nargs = 2;
-__arg1 = x140166665232007;
+__arg1 = x139731067835239;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1354,17 +1354,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label28:
 {
-Obj x140166664115527 = makeNative(38, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067422279 = makeNative(38, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140166665336871 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166665336871) {
-Obj x140166665337127 = PRIM_CAR(closureRef(co, 3));
-Obj op = x140166665337127;
-Obj x140166665337383 = PRIM_CDR(closureRef(co, 3));
-Obj args = x140166665337383;
-pushCont(co, 29, clofun0, 6, env, ns, import, args, op, x140166664115527);
+Obj x139731068685959 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731068685959) {
+Obj x139731068686215 = PRIM_CAR(closureRef(co, 3));
+Obj op = x139731068686215;
+Obj x139731068551303 = PRIM_CDR(closureRef(co, 3));
+Obj args = x139731068551303;
+pushCont(co, 29, clofun0, 6, env, ns, import, args, op, x139731067422279);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35builtin_63);
 __arg1 = op;
@@ -1375,7 +1375,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664115527;
+__arg0 = x139731067422279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1386,14 +1386,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140166665337703 = __arg1;
+Obj x139731068551623 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140166664115527= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-if (True == x140166665337703) {
+Obj x139731067422279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+if (True == x139731068551623) {
 if (True == True) {
 pushCont(co, 36, clofun0, 2, args, op);
 __nargs = 4;
@@ -1408,7 +1408,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664115527;
+__arg0 = x139731067422279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1416,8 +1416,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140166665338823 = PRIM_EQ(op, symif);
-if (True == x140166665338823) {
+Obj x139731068553927 = PRIM_EQ(op, symif);
+if (True == x139731068553927) {
 if (True == True) {
 pushCont(co, 34, clofun0, 2, args, op);
 __nargs = 4;
@@ -1432,7 +1432,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664115527;
+__arg0 = x139731067422279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1440,8 +1440,8 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x140166665352231 = PRIM_EQ(op, symdo);
-if (True == x140166665352231) {
+Obj x139731068555047 = PRIM_EQ(op, symdo);
+if (True == x139731068555047) {
 if (True == True) {
 pushCont(co, 32, clofun0, 2, args, op);
 __nargs = 4;
@@ -1456,7 +1456,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664115527;
+__arg0 = x139731067422279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1478,7 +1478,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664115527;
+__arg0 = x139731067422279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1492,13 +1492,13 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140166665353671 = __arg1;
+Obj x139731067955655 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 31, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140166665353671;
+__arg1 = x139731067955655;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1509,11 +1509,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140166665353735 = __arg1;
+Obj x139731067955751 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665353767 = makeCons(op, x140166665353735);
+Obj x139731067955783 = makeCons(op, x139731067955751);
 __nargs = 2;
-__arg1 = x140166665353767;
+__arg1 = x139731067955783;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1521,13 +1521,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label32:
 {
-Obj x140166665352839 = __arg1;
+Obj x139731067953767 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 33, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140166665352839;
+__arg1 = x139731067953767;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1538,11 +1538,11 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140166665352903 = __arg1;
+Obj x139731067953959 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665352935 = makeCons(op, x140166665352903);
+Obj x139731067954247 = makeCons(op, x139731067953959);
 __nargs = 2;
-__arg1 = x140166665352935;
+__arg1 = x139731067954247;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1550,13 +1550,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj x140166665351719 = __arg1;
+Obj x139731068554535 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 35, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140166665351719;
+__arg1 = x139731068554535;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1567,11 +1567,11 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140166665351783 = __arg1;
+Obj x139731068554599 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665351815 = makeCons(op, x140166665351783);
+Obj x139731068554631 = makeCons(op, x139731068554599);
 __nargs = 2;
-__arg1 = x140166665351815;
+__arg1 = x139731068554631;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1579,13 +1579,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label36:
 {
-Obj x140166665338311 = __arg1;
+Obj x139731068553415 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 37, clofun0, 1, op);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140166665338311;
+__arg1 = x139731068553415;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1596,11 +1596,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140166665338375 = __arg1;
+Obj x139731068553479 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665338407 = makeCons(op, x140166665338375);
+Obj x139731068553511 = makeCons(op, x139731068553479);
 __nargs = 2;
-__arg1 = x140166665338407;
+__arg1 = x139731068553511;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1608,45 +1608,45 @@ goto *jumpTable[co->ctx.pc.label];
 
 label38:
 {
-Obj x140166664116263 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067614311 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140166665091015 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166665091015) {
-Obj x140166665091463 = PRIM_CAR(closureRef(co, 3));
-Obj x140166665091495 = PRIM_EQ(symlet, x140166665091463);
-if (True == x140166665091495) {
-Obj x140166665091911 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665091943 = PRIM_ISCONS(x140166665091911);
-if (True == x140166665091943) {
-Obj x140166665092359 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665092391 = PRIM_CAR(x140166665092359);
-Obj a = x140166665092391;
-Obj x140166665092967 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665092999 = PRIM_CDR(x140166665092967);
-Obj x140166665093031 = PRIM_ISCONS(x140166665092999);
-if (True == x140166665093031) {
-Obj x140166664655335 = PRIM_CDR(closureRef(co, 3));
-Obj x140166664655367 = PRIM_CDR(x140166664655335);
-Obj x140166664655399 = PRIM_CAR(x140166664655367);
-Obj b = x140166664655399;
-Obj x140166664656135 = PRIM_CDR(closureRef(co, 3));
-Obj x140166664656167 = PRIM_CDR(x140166664656135);
-Obj x140166664656199 = PRIM_CDR(x140166664656167);
-Obj x140166664656231 = PRIM_ISCONS(x140166664656199);
-if (True == x140166664656231) {
-Obj x140166664656967 = PRIM_CDR(closureRef(co, 3));
-Obj x140166664656999 = PRIM_CDR(x140166664656967);
-Obj x140166664657031 = PRIM_CDR(x140166664656999);
-Obj x140166664657063 = PRIM_CAR(x140166664657031);
-Obj c = x140166664657063;
-Obj x140166664657991 = PRIM_CDR(closureRef(co, 3));
-Obj x140166664658023 = PRIM_CDR(x140166664657991);
-Obj x140166664658055 = PRIM_CDR(x140166664658023);
-Obj x140166664658087 = PRIM_CDR(x140166664658055);
-Obj x140166664658119 = PRIM_EQ(Nil, x140166664658087);
-if (True == x140166664658119) {
+Obj x139731068551911 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731068551911) {
+Obj x139731068552359 = PRIM_CAR(closureRef(co, 3));
+Obj x139731068552391 = PRIM_EQ(symlet, x139731068552359);
+if (True == x139731068552391) {
+Obj x139731068552807 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068552839 = PRIM_ISCONS(x139731068552807);
+if (True == x139731068552839) {
+Obj x139731068553255 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068553287 = PRIM_CAR(x139731068553255);
+Obj a = x139731068553287;
+Obj x139731068686855 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068686887 = PRIM_CDR(x139731068686855);
+Obj x139731068686919 = PRIM_ISCONS(x139731068686887);
+if (True == x139731068686919) {
+Obj x139731068687623 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068687655 = PRIM_CDR(x139731068687623);
+Obj x139731068687687 = PRIM_CAR(x139731068687655);
+Obj b = x139731068687687;
+Obj x139731068688455 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068688487 = PRIM_CDR(x139731068688455);
+Obj x139731068688519 = PRIM_CDR(x139731068688487);
+Obj x139731068688551 = PRIM_ISCONS(x139731068688519);
+if (True == x139731068688551) {
+Obj x139731068689415 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068689447 = PRIM_CDR(x139731068689415);
+Obj x139731068689479 = PRIM_CDR(x139731068689447);
+Obj x139731068689511 = PRIM_CAR(x139731068689479);
+Obj c = x139731068689511;
+Obj x139731068682407 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068682439 = PRIM_CDR(x139731068682407);
+Obj x139731068682471 = PRIM_CDR(x139731068682439);
+Obj x139731068682503 = PRIM_CDR(x139731068682471);
+Obj x139731068682535 = PRIM_EQ(Nil, x139731068682503);
+if (True == x139731068682535) {
 pushCont(co, 39, clofun0, 5, env, ns, import, c, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
@@ -1661,7 +1661,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1670,7 +1670,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1679,7 +1679,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1688,7 +1688,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1697,7 +1697,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1706,7 +1706,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664116263;
+__arg0 = x139731067614311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1717,17 +1717,17 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140166665334791 = __arg1;
+Obj x139731068683463 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140166665335367 = makeCons(a, env);
-pushCont(co, 40, clofun0, 2, x140166665334791, a);
+Obj x139731068684167 = makeCons(a, env);
+pushCont(co, 40, clofun0, 2, x139731068683463, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140166665335367;
+__arg1 = x139731068684167;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = c;
@@ -1740,15 +1740,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140166665335495 = __arg1;
-Obj x140166665334791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068684295 = __arg1;
+Obj x139731068683463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166665335559 = makeCons(x140166665335495, Nil);
-Obj x140166665335591 = makeCons(x140166665334791, x140166665335559);
-Obj x140166665335623 = makeCons(a, x140166665335591);
-Obj x140166665335655 = makeCons(symlet, x140166665335623);
+Obj x139731068684359 = makeCons(x139731068684295, Nil);
+Obj x139731068684391 = makeCons(x139731068683463, x139731068684359);
+Obj x139731068684423 = makeCons(a, x139731068684391);
+Obj x139731068684583 = makeCons(symlet, x139731068684423);
 __nargs = 2;
-__arg1 = x140166665335655;
+__arg1 = x139731068684583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1756,45 +1756,45 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj x140166664117351 = makeNative(42, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067616583 = makeNative(42, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj x140166663472711 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166663472711) {
-Obj x140166663473159 = PRIM_CAR(closureRef(co, 3));
-Obj x140166663473191 = PRIM_EQ(symns, x140166663473159);
-if (True == x140166663473191) {
-Obj x140166663473831 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663473863 = PRIM_ISCONS(x140166663473831);
-if (True == x140166663473863) {
-Obj x140166663474279 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663474311 = PRIM_CAR(x140166663474279);
-Obj path = x140166663474311;
-Obj x140166663475079 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663475111 = PRIM_CDR(x140166663475079);
-Obj x140166663475143 = PRIM_ISCONS(x140166663475111);
-if (True == x140166663475143) {
-Obj x140166663366471 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663366503 = PRIM_CDR(x140166663366471);
-Obj x140166663366535 = PRIM_CAR(x140166663366503);
-Obj import = x140166663366535;
-Obj x140166663367335 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663367367 = PRIM_CDR(x140166663367335);
-Obj x140166663367399 = PRIM_CDR(x140166663367367);
-Obj x140166663367431 = PRIM_ISCONS(x140166663367399);
-if (True == x140166663367431) {
-Obj x140166663368167 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663368199 = PRIM_CDR(x140166663368167);
-Obj x140166663368231 = PRIM_CDR(x140166663368199);
-Obj x140166663368263 = PRIM_CAR(x140166663368231);
-Obj body = x140166663368263;
-Obj x140166665089415 = PRIM_CDR(closureRef(co, 3));
-Obj x140166665089447 = PRIM_CDR(x140166665089415);
-Obj x140166665089479 = PRIM_CDR(x140166665089447);
-Obj x140166665089511 = PRIM_CDR(x140166665089479);
-Obj x140166665089543 = PRIM_EQ(Nil, x140166665089511);
-if (True == x140166665089543) {
+Obj x139731068688423 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731068688423) {
+Obj x139731068688871 = PRIM_CAR(closureRef(co, 3));
+Obj x139731068688903 = PRIM_EQ(symns, x139731068688871);
+if (True == x139731068688903) {
+Obj x139731068689319 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068689351 = PRIM_ISCONS(x139731068689319);
+if (True == x139731068689351) {
+Obj x139731068689767 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068689799 = PRIM_CAR(x139731068689767);
+Obj path = x139731068689799;
+Obj x139731068690375 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068690407 = PRIM_CDR(x139731068690375);
+Obj x139731068682247 = PRIM_ISCONS(x139731068690407);
+if (True == x139731068682247) {
+Obj x139731068682823 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068682855 = PRIM_CDR(x139731068682823);
+Obj x139731068682887 = PRIM_CAR(x139731068682855);
+Obj import = x139731068682887;
+Obj x139731068683623 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068683655 = PRIM_CDR(x139731068683623);
+Obj x139731068683687 = PRIM_CDR(x139731068683655);
+Obj x139731068683719 = PRIM_ISCONS(x139731068683687);
+if (True == x139731068683719) {
+Obj x139731068684455 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068684487 = PRIM_CDR(x139731068684455);
+Obj x139731068684519 = PRIM_CDR(x139731068684487);
+Obj x139731068684551 = PRIM_CAR(x139731068684519);
+Obj body = x139731068684551;
+Obj x139731068685479 = PRIM_CDR(closureRef(co, 3));
+Obj x139731068685511 = PRIM_CDR(x139731068685479);
+Obj x139731068685543 = PRIM_CDR(x139731068685511);
+Obj x139731068685575 = PRIM_CDR(x139731068685543);
+Obj x139731068685607 = PRIM_EQ(Nil, x139731068685575);
+if (True == x139731068685607) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
@@ -1808,7 +1808,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1817,7 +1817,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1826,7 +1826,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1835,7 +1835,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1844,7 +1844,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1853,7 +1853,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664117351;
+__arg0 = x139731067616583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1864,34 +1864,34 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140166664085671 = makeNative(45, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067594375 = makeNative(45, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj x140166663558759 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140166663558759) {
-Obj x140166663559239 = PRIM_CAR(closureRef(co, 3));
-Obj x140166663559271 = PRIM_EQ(symdef, x140166663559239);
-if (True == x140166663559271) {
-Obj x140166663559847 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663559879 = PRIM_ISCONS(x140166663559847);
-if (True == x140166663559879) {
-Obj x140166663560295 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663560327 = PRIM_CAR(x140166663560295);
-Obj var = x140166663560327;
-Obj x140166663561159 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663561191 = PRIM_CDR(x140166663561159);
-Obj x140166663532551 = PRIM_ISCONS(x140166663561191);
-if (True == x140166663532551) {
-Obj x140166663533191 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663533223 = PRIM_CDR(x140166663533191);
-Obj x140166663533255 = PRIM_CAR(x140166663533223);
-Obj val = x140166663533255;
-Obj x140166663534215 = PRIM_CDR(closureRef(co, 3));
-Obj x140166663534247 = PRIM_CDR(x140166663534215);
-Obj x140166663534279 = PRIM_CDR(x140166663534247);
-Obj x140166663534311 = PRIM_EQ(Nil, x140166663534279);
-if (True == x140166663534311) {
+Obj x139731066846087 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731066846087) {
+Obj x139731066846535 = PRIM_CAR(closureRef(co, 3));
+Obj x139731066846567 = PRIM_EQ(symdef, x139731066846535);
+if (True == x139731066846567) {
+Obj x139731066846983 = PRIM_CDR(closureRef(co, 3));
+Obj x139731066847015 = PRIM_ISCONS(x139731066846983);
+if (True == x139731066847015) {
+Obj x139731066770791 = PRIM_CDR(closureRef(co, 3));
+Obj x139731066770823 = PRIM_CAR(x139731066770791);
+Obj var = x139731066770823;
+Obj x139731066771399 = PRIM_CDR(closureRef(co, 3));
+Obj x139731066771431 = PRIM_CDR(x139731066771399);
+Obj x139731066771463 = PRIM_ISCONS(x139731066771431);
+if (True == x139731066771463) {
+Obj x139731066772039 = PRIM_CDR(closureRef(co, 3));
+Obj x139731066772071 = PRIM_CDR(x139731066772039);
+Obj x139731066772103 = PRIM_CAR(x139731066772071);
+Obj val = x139731066772103;
+Obj x139731066772871 = PRIM_CDR(closureRef(co, 3));
+Obj x139731066772903 = PRIM_CDR(x139731066772871);
+Obj x139731066772935 = PRIM_CDR(x139731066772903);
+Obj x139731066772967 = PRIM_EQ(Nil, x139731066772935);
+if (True == x139731066772967) {
 pushCont(co, 43, clofun0, 4, env, ns, import, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35var_45with_45ns);
@@ -1904,7 +1904,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664085671;
+__arg0 = x139731067594375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1913,7 +1913,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664085671;
+__arg0 = x139731067594375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1922,7 +1922,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664085671;
+__arg0 = x139731067594375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1931,7 +1931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664085671;
+__arg0 = x139731067594375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1940,7 +1940,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664085671;
+__arg0 = x139731067594375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1951,15 +1951,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140166663534823 = __arg1;
+Obj x139731066773255 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj var1 = x140166663534823;
-Obj x140166663535783 = makeCons(var1, Nil);
-Obj x140166663535815 = makeCons(symquote, x140166663535783);
-pushCont(co, 44, clofun0, 1, x140166663535815);
+Obj var1 = x139731066773255;
+Obj x139731068686695 = makeCons(var1, Nil);
+Obj x139731068686727 = makeCons(symquote, x139731068686695);
+pushCont(co, 44, clofun0, 1, x139731068686727);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
 __arg1 = env;
@@ -1975,13 +1975,13 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140166663536487 = __arg1;
-Obj x140166663535815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663536615 = makeCons(x140166663536487, Nil);
-Obj x140166663471111 = makeCons(x140166663535815, x140166663536615);
-Obj x140166663471143 = makeCons(symset, x140166663471111);
+Obj x139731068687207 = __arg1;
+Obj x139731068686727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068687271 = makeCons(x139731068687207, Nil);
+Obj x139731068687303 = makeCons(x139731068686727, x139731068687271);
+Obj x139731068687335 = makeCons(symset, x139731068687303);
 __nargs = 2;
-__arg1 = x140166663471143;
+__arg1 = x139731068687335;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1989,7 +1989,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label45:
 {
-Obj x140166664086631 = makeNative(47, clofun0, 0, 0);
+Obj x139731067596231 = makeNative(47, clofun0, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -2009,11 +2009,11 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140166663558087 = __arg1;
+Obj x139731066845607 = __arg1;
 Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = x140166663558087;
+__arg1 = x139731066845607;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2051,11 +2051,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140166663562887 = __arg1;
+Obj x139731066918503 = __arg1;
 PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140166663562887;
+__arg1 = x139731066918503;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2085,10 +2085,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140166663562919 = __arg1;
-Obj x140166663562951 = primNot(x140166663562919);
+Obj x139731066918535 = __arg1;
+Obj x139731066918567 = primNot(x139731066918535);
 __nargs = 2;
-__arg1 = x140166663562951;
+__arg1 = x139731066918567;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2096,12 +2096,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label1:
 {
-Obj x140166664290727 = __arg1;
-Obj x140166664290759 = __arg2;
-Obj x140166664291015 = makeNative(2, clofun1, 0, 2, x140166664290727, x140166664290759);
-Obj var = x140166664290727;
-Obj x140166663561575 = PRIM_EQ(Nil, x140166664290759);
-if (True == x140166663561575) {
+Obj x139731067613575 = __arg1;
+Obj x139731067613607 = __arg2;
+Obj x139731067614055 = makeNative(2, clofun1, 0, 2, x139731067613575, x139731067613607);
+Obj var = x139731067613575;
+Obj x139731066917319 = PRIM_EQ(Nil, x139731067613607);
+if (True == x139731066917319) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2109,7 +2109,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291015;
+__arg0 = x139731067614055;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2120,32 +2120,32 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140166664291495 = makeNative(3, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731067614759 = makeNative(3, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj x140166663761703 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140166663761703) {
-Obj x140166663574023 = PRIM_CAR(closureRef(co, 1));
-Obj x140166663574087 = PRIM_ISCONS(x140166663574023);
-if (True == x140166663574087) {
-Obj x140166663574695 = PRIM_CAR(closureRef(co, 1));
-Obj x140166663574727 = PRIM_CAR(x140166663574695);
-Obj x = x140166663574727;
-Obj x140166663575495 = PRIM_CAR(closureRef(co, 1));
-Obj x140166663575527 = PRIM_CDR(x140166663575495);
-Obj y = x140166663575527;
-Obj x140166663575879 = PRIM_CDR(closureRef(co, 1));
-Obj __ = x140166663575879;
-Obj x140166663576263 = PRIM_EQ(var, x);
-if (True == x140166663576263) {
-Obj x140166663576647 = makeCons(x, y);
+Obj x139731066959303 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731066959303) {
+Obj x139731066959751 = PRIM_CAR(closureRef(co, 1));
+Obj x139731066959783 = PRIM_ISCONS(x139731066959751);
+if (True == x139731066959783) {
+Obj x139731066960199 = PRIM_CAR(closureRef(co, 1));
+Obj x139731066960231 = PRIM_CAR(x139731066960199);
+Obj x = x139731066960231;
+Obj x139731066960743 = PRIM_CAR(closureRef(co, 1));
+Obj x139731066960775 = PRIM_CDR(x139731066960743);
+Obj y = x139731066960775;
+Obj x139731066961031 = PRIM_CDR(closureRef(co, 1));
+Obj __ = x139731066961031;
+Obj x139731066961319 = PRIM_EQ(var, x);
+if (True == x139731066961319) {
+Obj x139731066961543 = makeCons(x, y);
 __nargs = 2;
-__arg1 = x140166663576647;
+__arg1 = x139731066961543;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291495;
+__arg0 = x139731067614759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2154,7 +2154,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291495;
+__arg0 = x139731067614759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2163,7 +2163,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291495;
+__arg0 = x139731067614759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2174,14 +2174,14 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140166664292295 = makeNative(4, clofun1, 0, 0);
+Obj x139731067615975 = makeNative(4, clofun1, 0, 0);
 Obj var = closureRef(co, 0);
-Obj x140166663759719 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140166663759719) {
-Obj x140166663760135 = PRIM_CAR(closureRef(co, 1));
-Obj __ = x140166663760135;
-Obj x140166663760487 = PRIM_CDR(closureRef(co, 1));
-Obj y = x140166663760487;
+Obj x139731066957991 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731066957991) {
+Obj x139731066958247 = PRIM_CAR(closureRef(co, 1));
+Obj __ = x139731066958247;
+Obj x139731066958631 = PRIM_CDR(closureRef(co, 1));
+Obj y = x139731066958631;
 __nargs = 3;
 __arg0 = globalRef(symassq);
 __arg1 = var;
@@ -2193,7 +2193,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292295;
+__arg0 = x139731067615975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2216,14 +2216,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140166664133767 = __arg1;
-Obj x140166664133799 = __arg2;
-Obj x140166664133831 = __arg3;
-Obj x140166664134087 = makeNative(6, clofun1, 0, 3, x140166664133767, x140166664133799, x140166664133831);
-Obj s = x140166664133767;
-Obj ns = x140166664133799;
-Obj x140166664292039 = PRIM_EQ(Nil, x140166664133831);
-if (True == x140166664292039) {
+Obj x139731067472359 = __arg1;
+Obj x139731067472391 = __arg2;
+Obj x139731067472423 = __arg3;
+Obj x139731067472967 = makeNative(6, clofun1, 0, 3, x139731067472359, x139731067472391, x139731067472423);
+Obj s = x139731067472359;
+Obj ns = x139731067472391;
+Obj x139731067424551 = PRIM_EQ(Nil, x139731067472423);
+if (True == x139731067424551) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35var_45with_45ns);
 __arg1 = s;
@@ -2235,7 +2235,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664134087;
+__arg0 = x139731067472967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2246,15 +2246,15 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140166664134599 = makeNative(14, clofun1, 0, 0);
+Obj x139731067473767 = makeNative(14, clofun1, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
-Obj x140166664695591 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x140166664695591) {
-Obj x140166664470887 = PRIM_CAR(closureRef(co, 2));
-Obj import = x140166664470887;
-Obj x140166664471335 = PRIM_CDR(closureRef(co, 2));
-Obj more = x140166664471335;
+Obj x139731067472167 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731067472167) {
+Obj x139731067472615 = PRIM_CAR(closureRef(co, 2));
+Obj import = x139731067472615;
+Obj x139731067473159 = PRIM_CDR(closureRef(co, 2));
+Obj more = x139731067473159;
 pushCont(co, 7, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
@@ -2267,7 +2267,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664134599;
+__arg0 = x139731067473767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2278,7 +2278,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140166664472423 = __arg1;
+Obj x139731067421319 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2286,7 +2286,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 8, clofun1, 4, import, s, ns, more);
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140166664472423;
+__arg1 = x139731067421319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2296,7 +2296,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140166664472455 = __arg1;
+Obj x139731067421351 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2304,7 +2304,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 9, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symvalue_45or);
-__arg1 = x140166664472455;
+__arg1 = x139731067421351;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2315,12 +2315,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140166664472679 = __arg1;
+Obj x139731067421479 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = x140166664472679;
+Obj export = x139731067421479;
 pushCont(co, 10, clofun1, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
@@ -2335,12 +2335,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140166664473031 = __arg1;
+Obj x139731067421863 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140166664473031) {
+if (True == x139731067421863) {
 pushCont(co, 11, clofun1, 1, import);
 __nargs = 2;
 __arg0 = globalRef(symsymbol_45_62string);
@@ -2366,13 +2366,13 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166664474471 = __arg1;
+Obj x139731067423207 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 12, clofun1, 1, import);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = makeCString("#");
-__arg2 = x140166664474471;
+__arg2 = x139731067423207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2382,13 +2382,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140166664474503 = __arg1;
+Obj x139731067423239 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 13, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = import;
-__arg2 = x140166664474503;
+__arg2 = x139731067423239;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2398,10 +2398,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140166664474535 = __arg1;
+Obj x139731067423271 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140166664474535;
+__arg1 = x139731067423271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2425,8 +2425,8 @@ label15:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj x140166664691815 = PRIM_EQ(ns, makeCString(""));
-if (True == x140166664691815) {
+Obj x139731067582439 = PRIM_EQ(ns, makeCString(""));
+if (True == x139731067582439) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2447,10 +2447,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140166664692359 = __arg1;
+Obj x139731067582983 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166664692359) {
+if (True == x139731067582983) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2471,13 +2471,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140166664693383 = __arg1;
+Obj x139731067584199 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun1, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = makeCString("#");
-__arg2 = x140166664693383;
+__arg2 = x139731067584199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2487,13 +2487,13 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140166664693511 = __arg1;
+Obj x139731067584231 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 19, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = ns;
-__arg2 = x140166664693511;
+__arg2 = x139731067584231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2503,10 +2503,10 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140166664693543 = __arg1;
+Obj x139731067584327 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140166664693543;
+__arg1 = x139731067584327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2530,9 +2530,9 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140166665044071 = __arg1;
+Obj x139731067613223 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = x140166665044071;
+Obj path = x139731067613223;
 pushCont(co, 22, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -2546,12 +2546,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140166665044743 = __arg1;
+Obj x139731067614183 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 23, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library);
-__arg1 = x140166665044743;
+__arg1 = x139731067614183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2561,10 +2561,10 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140166665044775 = __arg1;
+Obj x139731067614215 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = x140166665044775;
+__arg0 = x139731067614215;
 __arg1 = makeNative(24, clofun1, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2578,8 +2578,8 @@ label24:
 Obj import = __arg1;
 Obj export = __arg2;
 Obj body = __arg3;
-Obj x140166665046311 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 25, clofun1, 3, export, body, x140166665046311);
+Obj x139731067616391 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 25, clofun1, 3, export, body, x139731067616391);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = makeNative(27, clofun1, 1, 0);
@@ -2593,21 +2593,21 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140166664831495 = __arg1;
+Obj x139731067594471 = __arg1;
 Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166665046311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664833287 = makeCons(export, Nil);
-Obj x140166664833479 = makeCons(symbackquote, x140166664833287);
-Obj x140166664833735 = makeCons(x140166664833479, Nil);
-Obj x140166664833767 = makeCons(sym_42ns_45export_42, x140166664833735);
-Obj x140166664833799 = makeCons(symdef, x140166664833767);
-Obj x140166664833863 = makeCons(x140166664833799, body);
-pushCont(co, 26, clofun1, 1, x140166665046311);
+Obj x139731067616391= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139731067580487 = makeCons(export, Nil);
+Obj x139731067580711 = makeCons(symbackquote, x139731067580487);
+Obj x139731067580807 = makeCons(x139731067580711, Nil);
+Obj x139731067580839 = makeCons(sym_42ns_45export_42, x139731067580807);
+Obj x139731067580871 = makeCons(symdef, x139731067580839);
+Obj x139731067580935 = makeCons(x139731067580871, body);
+pushCont(co, 26, clofun1, 1, x139731067616391);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = x140166664831495;
-__arg2 = x140166664833863;
+__arg1 = x139731067594471;
+__arg2 = x139731067580935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2617,15 +2617,15 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140166664833927 = __arg1;
-Obj x140166665046311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664833959 = makeCons(symbegin, x140166664833927);
-Obj x140166664834023 = makeCons(x140166664833959, Nil);
-Obj x140166664834087 = makeCons(x140166665046311, x140166664834023);
-Obj x140166664834183 = makeCons(closureRef(co, 0), x140166664834087);
-Obj x140166664834215 = makeCons(symns, x140166664834183);
+Obj x139731067581031 = __arg1;
+Obj x139731067616391= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067581063 = makeCons(symbegin, x139731067581031);
+Obj x139731067581127 = makeCons(x139731067581063, Nil);
+Obj x139731067581159 = makeCons(x139731067616391, x139731067581127);
+Obj x139731067581191 = makeCons(closureRef(co, 0), x139731067581159);
+Obj x139731067581223 = makeCons(symns, x139731067581191);
 __nargs = 2;
-__arg1 = x140166664834215;
+__arg1 = x139731067581223;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2634,10 +2634,10 @@ goto *jumpTable[co->ctx.pc.label];
 label27:
 {
 Obj imp = __arg1;
-Obj x140166664831271 = makeCons(imp, Nil);
-Obj x140166664831431 = makeCons(symimport, x140166664831271);
+Obj x139731067594247 = makeCons(imp, Nil);
+Obj x139731067594311 = makeCons(symimport, x139731067594247);
 __nargs = 2;
-__arg1 = x140166664831431;
+__arg1 = x139731067594311;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2662,43 +2662,43 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140166664294023 = __arg1;
-Obj x140166664294055 = __arg2;
-Obj x140166664294087 = __arg3;
-Obj x140166664294151 = co->args[4];
-Obj x140166664130631 = makeNative(30, clofun1, 0, 4, x140166664294023, x140166664294055, x140166664294087, x140166664294151);
-Obj x140166665232039 = PRIM_ISCONS(x140166664294023);
-if (True == x140166665232039) {
-Obj x140166665163047 = PRIM_CAR(x140166664294023);
-Obj x140166665163079 = PRIM_ISCONS(x140166665163047);
-if (True == x140166665163079) {
-Obj x140166665163783 = PRIM_CAR(x140166664294023);
-Obj x140166665163943 = PRIM_CAR(x140166665163783);
-Obj x140166665164007 = PRIM_EQ(symimport, x140166665163943);
-if (True == x140166665164007) {
-Obj x140166665165351 = PRIM_CAR(x140166664294023);
-Obj x140166665165383 = PRIM_CDR(x140166665165351);
-Obj x140166665165415 = PRIM_ISCONS(x140166665165383);
-if (True == x140166665165415) {
-Obj x140166665166183 = PRIM_CAR(x140166664294023);
-Obj x140166665166279 = PRIM_CDR(x140166665166183);
-Obj x140166665166311 = PRIM_CAR(x140166665166279);
-Obj lib = x140166665166311;
-Obj x140166665094375 = PRIM_CAR(x140166664294023);
-Obj x140166665094407 = PRIM_CDR(x140166665094375);
-Obj x140166665094439 = PRIM_CDR(x140166665094407);
-Obj x140166665094471 = PRIM_EQ(Nil, x140166665094439);
-if (True == x140166665094471) {
-Obj x140166665094727 = PRIM_CDR(x140166664294023);
-Obj rest = x140166665094727;
-Obj imports = x140166664294055;
-Obj exports = x140166664294087;
-Obj k = x140166664294151;
-Obj x140166665095335 = makeCons(lib, imports);
+Obj x139731067593799 = __arg1;
+Obj x139731067593831 = __arg2;
+Obj x139731067593863 = __arg3;
+Obj x139731067593895 = co->args[4];
+Obj x139731067594631 = makeNative(30, clofun1, 0, 4, x139731067593799, x139731067593831, x139731067593863, x139731067593895);
+Obj x139731067834919 = PRIM_ISCONS(x139731067593799);
+if (True == x139731067834919) {
+Obj x139731067835527 = PRIM_CAR(x139731067593799);
+Obj x139731067835559 = PRIM_ISCONS(x139731067835527);
+if (True == x139731067835559) {
+Obj x139731067836551 = PRIM_CAR(x139731067593799);
+Obj x139731067836583 = PRIM_CAR(x139731067836551);
+Obj x139731067836615 = PRIM_EQ(symimport, x139731067836583);
+if (True == x139731067836615) {
+Obj x139731067837575 = PRIM_CAR(x139731067593799);
+Obj x139731067837607 = PRIM_CDR(x139731067837575);
+Obj x139731067837639 = PRIM_ISCONS(x139731067837607);
+if (True == x139731067837639) {
+Obj x139731067801671 = PRIM_CAR(x139731067593799);
+Obj x139731067801703 = PRIM_CDR(x139731067801671);
+Obj x139731067801735 = PRIM_CAR(x139731067801703);
+Obj lib = x139731067801735;
+Obj x139731067803431 = PRIM_CAR(x139731067593799);
+Obj x139731067803463 = PRIM_CDR(x139731067803431);
+Obj x139731067803495 = PRIM_CDR(x139731067803463);
+Obj x139731067803527 = PRIM_EQ(Nil, x139731067803495);
+if (True == x139731067803527) {
+Obj x139731067804231 = PRIM_CDR(x139731067593799);
+Obj rest = x139731067804231;
+Obj imports = x139731067593831;
+Obj exports = x139731067593863;
+Obj k = x139731067593895;
+Obj x139731067805383 = makeCons(lib, imports);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
 __arg1 = rest;
-__arg2 = x140166665095335;
+__arg2 = x139731067805383;
 __arg3 = exports;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -2708,7 +2708,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664130631;
+__arg0 = x139731067594631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2717,7 +2717,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130631;
+__arg0 = x139731067594631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2726,7 +2726,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130631;
+__arg0 = x139731067594631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2735,7 +2735,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130631;
+__arg0 = x139731067594631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2744,7 +2744,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130631;
+__arg0 = x139731067594631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2755,21 +2755,21 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140166664131751 = makeNative(31, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x140166665275847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665275847) {
-Obj x140166665276263 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665276295 = PRIM_ISCONS(x140166665276263);
-if (True == x140166665276295) {
-Obj x140166665229159 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665229191 = PRIM_CAR(x140166665229159);
-Obj x140166665229319 = PRIM_EQ(symexport, x140166665229191);
-if (True == x140166665229319) {
-Obj x140166665229895 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665229927 = PRIM_CDR(x140166665229895);
-Obj more = x140166665229927;
-Obj x140166665230279 = PRIM_CDR(closureRef(co, 0));
-Obj rest = x140166665230279;
+Obj x139731067596391 = makeNative(31, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067907815 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067907815) {
+Obj x139731067859367 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067859399 = PRIM_ISCONS(x139731067859367);
+if (True == x139731067859399) {
+Obj x139731067860487 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067860615 = PRIM_CAR(x139731067860487);
+Obj x139731067860647 = PRIM_EQ(symexport, x139731067860615);
+if (True == x139731067860647) {
+Obj x139731067861255 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067861351 = PRIM_CDR(x139731067861255);
+Obj more = x139731067861351;
+Obj x139731067861639 = PRIM_CDR(closureRef(co, 0));
+Obj rest = x139731067861639;
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
 Obj k = closureRef(co, 3);
@@ -2786,7 +2786,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131751;
+__arg0 = x139731067596391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2795,7 +2795,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131751;
+__arg0 = x139731067596391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2804,7 +2804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131751;
+__arg0 = x139731067596391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2815,7 +2815,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140166664132839 = makeNative(33, clofun1, 0, 0);
+Obj x139731067471047 = makeNative(33, clofun1, 0, 0);
 Obj body = closureRef(co, 0);
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
@@ -2833,13 +2833,13 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140166665275463 = __arg1;
+Obj x139731067907303 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 __nargs = 4;
 __arg0 = k;
-__arg1 = x140166665275463;
+__arg1 = x139731067907303;
 __arg2 = exports;
 __arg3 = body;
 co->ctx.frees = __arg0;
@@ -2877,10 +2877,10 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140166665273703 = __arg1;
+Obj x139731067904807 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = x140166665273703;
+__arg1 = x139731067904807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2890,21 +2890,21 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140166664291975 = __arg1;
-Obj x140166664292199 = makeNative(37, clofun1, 0, 1, x140166664291975);
-Obj x = x140166664291975;
-Obj x140166665277287 = primIsSymbol(x);
-if (True == x140166665277287) {
-Obj x140166665093383 = makeCons(x, Nil);
-Obj x140166665093415 = makeCons(symquote, x140166665093383);
+Obj x139731067615623 = __arg1;
+Obj x139731067615847 = makeNative(37, clofun1, 0, 1, x139731067615623);
+Obj x = x139731067615623;
+Obj x139731067931431 = primIsSymbol(x);
+if (True == x139731067931431) {
+Obj x139731067932103 = makeCons(x, Nil);
+Obj x139731067932135 = makeCons(symquote, x139731067932103);
 __nargs = 2;
-__arg1 = x140166665093415;
+__arg1 = x139731067932135;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292199;
+__arg0 = x139731067615847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2915,22 +2915,22 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140166664292423 = makeNative(38, clofun1, 0, 1, closureRef(co, 0));
-Obj x140166665274407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665274407) {
-Obj x140166665274855 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665274887 = PRIM_EQ(symunquote, x140166665274855);
-if (True == x140166665274887) {
-Obj x140166665275303 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665275335 = PRIM_ISCONS(x140166665275303);
-if (True == x140166665275335) {
-Obj x140166665275751 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665275783 = PRIM_CAR(x140166665275751);
-Obj x = x140166665275783;
-Obj x140166665276391 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665276423 = PRIM_CDR(x140166665276391);
-Obj x140166665276455 = PRIM_EQ(Nil, x140166665276423);
-if (True == x140166665276455) {
+Obj x139731067616231 = makeNative(38, clofun1, 0, 1, closureRef(co, 0));
+Obj x139731067935143 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067935143) {
+Obj x139731067935719 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067935751 = PRIM_EQ(symunquote, x139731067935719);
+if (True == x139731067935751) {
+Obj x139731067936551 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067936615 = PRIM_ISCONS(x139731067936551);
+if (True == x139731067936615) {
+Obj x139731067928967 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067928999 = PRIM_CAR(x139731067928967);
+Obj x = x139731067928999;
+Obj x139731067930247 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067930279 = PRIM_CDR(x139731067930247);
+Obj x139731067930311 = PRIM_EQ(Nil, x139731067930279);
+if (True == x139731067930311) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2938,7 +2938,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292423;
+__arg0 = x139731067616231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2947,7 +2947,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292423;
+__arg0 = x139731067616231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2956,7 +2956,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292423;
+__arg0 = x139731067616231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2965,7 +2965,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292423;
+__arg0 = x139731067616231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2976,19 +2976,19 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140166664292903 = makeNative(40, clofun1, 0, 1, closureRef(co, 0));
-Obj x140166663368359 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663368359) {
-Obj x140166663368615 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140166663368615;
-Obj x140166665273351 = PRIM_CDR(closureRef(co, 0));
-Obj more = x140166665273351;
-Obj x140166665273959 = makeCons(x, more);
+Obj x139731067616999 = makeNative(40, clofun1, 0, 1, closureRef(co, 0));
+Obj x139731067956839 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067956839) {
+Obj x139731067957159 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731067957159;
+Obj x139731067933031 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139731067933031;
+Obj x139731067934087 = makeCons(x, more);
 PUSH_CONT_0(co, 39, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = x140166665273959;
+__arg2 = x139731067934087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2996,7 +2996,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292903;
+__arg0 = x139731067616999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3007,10 +3007,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140166665273991 = __arg1;
-Obj x140166665274023 = makeCons(symlist, x140166665273991);
+Obj x139731067934119 = __arg1;
+Obj x139731067934215 = makeCons(symlist, x139731067934119);
 __nargs = 2;
-__arg1 = x140166665274023;
+__arg1 = x139731067934215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3018,7 +3018,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x140166664293319 = makeNative(41, clofun1, 0, 0);
+Obj x139731067593031 = makeNative(41, clofun1, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -3042,10 +3042,10 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj exp = __arg1;
-Obj x140166663367015 = PRIM_CDR(exp);
+Obj x139731067954343 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = x140166663367015;
+__arg1 = x139731067954343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3055,15 +3055,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140166664132359 = __arg1;
-Obj x140166664132487 = makeNative(44, clofun1, 0, 1, x140166664132359);
-Obj x140166663473287 = PRIM_ISCONS(x140166664132359);
-if (True == x140166663473287) {
-Obj x140166663473703 = PRIM_CAR(x140166664132359);
-Obj x = x140166663473703;
-Obj x140166663366023 = PRIM_CDR(x140166664132359);
-Obj x140166663366055 = PRIM_EQ(Nil, x140166663366023);
-if (True == x140166663366055) {
+Obj x139731067469927 = __arg1;
+Obj x139731067470151 = makeNative(44, clofun1, 0, 1, x139731067469927);
+Obj x139731066843687 = PRIM_ISCONS(x139731067469927);
+if (True == x139731066843687) {
+Obj x139731066843943 = PRIM_CAR(x139731067469927);
+Obj x = x139731066843943;
+Obj x139731066844391 = PRIM_CDR(x139731067469927);
+Obj x139731066844423 = PRIM_EQ(Nil, x139731066844391);
+if (True == x139731066844423) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3071,7 +3071,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664132487;
+__arg0 = x139731067470151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3080,7 +3080,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132487;
+__arg0 = x139731067470151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3091,32 +3091,32 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140166664290823 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
-Obj x140166663535143 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663535143) {
-Obj x140166663535527 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140166663535527;
-Obj x140166663535943 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663535975 = PRIM_ISCONS(x140166663535943);
-if (True == x140166663535975) {
-Obj x140166663536519 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663536551 = PRIM_CAR(x140166663536519);
-Obj y = x140166663536551;
-Obj x140166663471751 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663471783 = PRIM_CDR(x140166663471751);
-Obj x140166663471815 = PRIM_EQ(Nil, x140166663471783);
-if (True == x140166663471815) {
-Obj x140166663472583 = makeCons(y, Nil);
-Obj x140166663472615 = makeCons(x, x140166663472583);
-Obj x140166663472647 = makeCons(symdo, x140166663472615);
+Obj x139731067613863 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
+Obj x139731066918375 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731066918375) {
+Obj x139731066918631 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731066918631;
+Obj x139731066919047 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066919079 = PRIM_ISCONS(x139731066919047);
+if (True == x139731066919079) {
+Obj x139731066919495 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066919527 = PRIM_CAR(x139731066919495);
+Obj y = x139731066919527;
+Obj x139731066920135 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066920167 = PRIM_CDR(x139731066920135);
+Obj x139731066920199 = PRIM_EQ(Nil, x139731066920167);
+if (True == x139731066920199) {
+Obj x139731066920807 = makeCons(y, Nil);
+Obj x139731066920839 = makeCons(x, x139731066920807);
+Obj x139731066920871 = makeCons(symdo, x139731066920839);
 __nargs = 2;
-__arg1 = x140166663472647;
+__arg1 = x139731066920871;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664290823;
+__arg0 = x139731067613863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3125,7 +3125,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290823;
+__arg0 = x139731067613863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3134,7 +3134,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290823;
+__arg0 = x139731067613863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3145,13 +3145,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140166664291431 = makeNative(47, clofun1, 0, 0);
-Obj x140166663533159 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663533159) {
-Obj x140166663533479 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140166663533479;
-Obj x140166663533735 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140166663533735;
+Obj x139731067614823 = makeNative(47, clofun1, 0, 0);
+Obj x139731066961671 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731066961671) {
+Obj x139731066916871 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731066916871;
+Obj x139731066917127 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731066917127;
 pushCont(co, 46, clofun1, 1, x);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
@@ -3163,7 +3163,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291431;
+__arg0 = x139731067614823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3174,13 +3174,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140166663534631 = __arg1;
+Obj x139731066917863 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663534695 = makeCons(x140166663534631, Nil);
-Obj x140166663534727 = makeCons(x, x140166663534695);
-Obj x140166663534759 = makeCons(symdo, x140166663534727);
+Obj x139731066917927 = makeCons(x139731066917863, Nil);
+Obj x139731066917959 = makeCons(x, x139731066917927);
+Obj x139731066917991 = makeCons(symdo, x139731066917959);
 __nargs = 2;
-__arg1 = x140166663534759;
+__arg1 = x139731066917991;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3214,11 +3214,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140166663560615 = __arg1;
+Obj x139731066960487 = __arg1;
 PUSH_CONT_0(co, 0, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45namespace);
-__arg1 = x140166663560615;
+__arg1 = x139731066960487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3248,10 +3248,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140166663560647 = __arg1;
+Obj x139731066960519 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x140166663560647;
+__arg1 = x139731066960519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3277,33 +3277,33 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140166664290855 = __arg1;
-Obj x140166664290567 = makeNative(3, clofun2, 0, 1, x140166664290855);
-Obj x140166663563495 = PRIM_ISCONS(x140166664290855);
-if (True == x140166663563495) {
-Obj x140166663564071 = PRIM_CAR(x140166664290855);
-Obj x140166663564103 = PRIM_EQ(symquote, x140166663564071);
-if (True == x140166663564103) {
-Obj x140166663564519 = PRIM_CDR(x140166664290855);
-Obj x140166663564551 = PRIM_ISCONS(x140166663564519);
-if (True == x140166663564551) {
-Obj x140166663565063 = PRIM_CDR(x140166664290855);
-Obj x140166663565095 = PRIM_CAR(x140166663565063);
-Obj x = x140166663565095;
-Obj x140166663557607 = PRIM_CDR(x140166664290855);
-Obj x140166663557639 = PRIM_CDR(x140166663557607);
-Obj x140166663557671 = PRIM_EQ(Nil, x140166663557639);
-if (True == x140166663557671) {
-Obj x140166663558183 = makeCons(x, Nil);
-Obj x140166663558215 = makeCons(symquote, x140166663558183);
+Obj x139731067614087 = __arg1;
+Obj x139731067614375 = makeNative(3, clofun2, 0, 1, x139731067614087);
+Obj x139731066981639 = PRIM_ISCONS(x139731067614087);
+if (True == x139731066981639) {
+Obj x139731066982279 = PRIM_CAR(x139731067614087);
+Obj x139731066982311 = PRIM_EQ(symquote, x139731066982279);
+if (True == x139731066982311) {
+Obj x139731066970535 = PRIM_CDR(x139731067614087);
+Obj x139731066970567 = PRIM_ISCONS(x139731066970535);
+if (True == x139731066970567) {
+Obj x139731066970983 = PRIM_CDR(x139731067614087);
+Obj x139731066971015 = PRIM_CAR(x139731066970983);
+Obj x = x139731066971015;
+Obj x139731066971655 = PRIM_CDR(x139731067614087);
+Obj x139731066971687 = PRIM_CDR(x139731066971655);
+Obj x139731066971719 = PRIM_EQ(Nil, x139731066971687);
+if (True == x139731066971719) {
+Obj x139731066972199 = makeCons(x, Nil);
+Obj x139731066972231 = makeCons(symquote, x139731066972199);
 __nargs = 2;
-__arg1 = x140166663558215;
+__arg1 = x139731066972231;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664290567;
+__arg0 = x139731067614375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3312,7 +3312,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290567;
+__arg0 = x139731067614375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3321,7 +3321,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290567;
+__arg0 = x139731067614375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3330,7 +3330,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290567;
+__arg0 = x139731067614375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3341,22 +3341,22 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140166664291143 = makeNative(5, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166663575111 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663575111) {
-Obj x140166663575719 = PRIM_CAR(closureRef(co, 0));
-Obj x140166663575751 = PRIM_EQ(symcons_63, x140166663575719);
-if (True == x140166663575751) {
-Obj x140166663576199 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663576231 = PRIM_ISCONS(x140166663576199);
-if (True == x140166663576231) {
-Obj x140166663576807 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663576839 = PRIM_CAR(x140166663576807);
-Obj x = x140166663576839;
-Obj x140166663561479 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663561511 = PRIM_CDR(x140166663561479);
-Obj x140166663561543 = PRIM_EQ(Nil, x140166663561511);
-if (True == x140166663561543) {
+Obj x139731067615143 = makeNative(5, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067190375 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067190375) {
+Obj x139731067190951 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067190983 = PRIM_EQ(symcons_63, x139731067190951);
+if (True == x139731067190983) {
+Obj x139731066978407 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066978567 = PRIM_ISCONS(x139731066978407);
+if (True == x139731066978567) {
+Obj x139731066978983 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066979015 = PRIM_CAR(x139731066978983);
+Obj x = x139731066979015;
+Obj x139731066979783 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066979815 = PRIM_CDR(x139731066979783);
+Obj x139731066979847 = PRIM_EQ(Nil, x139731066979815);
+if (True == x139731066979847) {
 PUSH_CONT_0(co, 4, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3368,7 +3368,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291143;
+__arg0 = x139731067615143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3377,7 +3377,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291143;
+__arg0 = x139731067615143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3386,7 +3386,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291143;
+__arg0 = x139731067615143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3395,7 +3395,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291143;
+__arg0 = x139731067615143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3406,13 +3406,13 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140166663561799 = __arg1;
-Obj x1 = x140166663561799;
-Obj x140166663562375 = makeCons(x1, Nil);
-Obj x140166663562407 = makeCons(symcons_63, x140166663562375);
+Obj x139731066980103 = __arg1;
+Obj x1 = x139731066980103;
+Obj x139731066980839 = makeCons(x1, Nil);
+Obj x139731066980871 = makeCons(symcons_63, x139731066980839);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166663562407;
+__arg1 = x139731066980871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3422,22 +3422,22 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140166664291623 = makeNative(7, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166663758087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663758087) {
-Obj x140166663758631 = PRIM_CAR(closureRef(co, 0));
-Obj x140166663758663 = PRIM_EQ(symcar, x140166663758631);
-if (True == x140166663758663) {
-Obj x140166663759335 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663759367 = PRIM_ISCONS(x140166663759335);
-if (True == x140166663759367) {
-Obj x140166663759975 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663760007 = PRIM_CAR(x140166663759975);
-Obj x = x140166663760007;
-Obj x140166663760839 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663760871 = PRIM_CDR(x140166663760839);
-Obj x140166663760903 = PRIM_EQ(Nil, x140166663760871);
-if (True == x140166663760903) {
+Obj x139731067615879 = makeNative(7, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067259943 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067259943) {
+Obj x139731067260487 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067260519 = PRIM_EQ(symcar, x139731067260487);
+if (True == x139731067260519) {
+Obj x139731067187207 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067187239 = PRIM_ISCONS(x139731067187207);
+if (True == x139731067187239) {
+Obj x139731067187687 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067187719 = PRIM_CAR(x139731067187687);
+Obj x = x139731067187719;
+Obj x139731067188455 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067188487 = PRIM_CDR(x139731067188455);
+Obj x139731067188519 = PRIM_EQ(Nil, x139731067188487);
+if (True == x139731067188519) {
 PUSH_CONT_0(co, 6, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3449,7 +3449,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291623;
+__arg0 = x139731067615879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3458,7 +3458,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291623;
+__arg0 = x139731067615879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3467,7 +3467,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291623;
+__arg0 = x139731067615879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3476,7 +3476,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291623;
+__arg0 = x139731067615879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3487,13 +3487,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140166663761319 = __arg1;
-Obj x1 = x140166663761319;
-Obj x140166663573863 = makeCons(x1, Nil);
-Obj x140166663573927 = makeCons(symcar, x140166663573863);
+Obj x139731067188775 = __arg1;
+Obj x1 = x139731067188775;
+Obj x139731067189447 = makeCons(x1, Nil);
+Obj x139731067189479 = makeCons(symcar, x139731067189447);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166663573927;
+__arg1 = x139731067189479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3503,22 +3503,22 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140166664292103 = makeNative(9, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166663953223 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663953223) {
-Obj x140166663953991 = PRIM_CAR(closureRef(co, 0));
-Obj x140166663954023 = PRIM_EQ(symcdr, x140166663953991);
-if (True == x140166663954023) {
-Obj x140166663925959 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663925991 = PRIM_ISCONS(x140166663925959);
-if (True == x140166663925991) {
-Obj x140166663926631 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663926663 = PRIM_CAR(x140166663926631);
-Obj x = x140166663926663;
-Obj x140166663927495 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663927527 = PRIM_CDR(x140166663927495);
-Obj x140166663927559 = PRIM_EQ(Nil, x140166663927527);
-if (True == x140166663927559) {
+Obj x139731067614119 = makeNative(9, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067303591 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067303591) {
+Obj x139731067304295 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067304327 = PRIM_EQ(symcdr, x139731067304295);
+if (True == x139731067304327) {
+Obj x139731067304807 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067304839 = PRIM_ISCONS(x139731067304807);
+if (True == x139731067304839) {
+Obj x139731067305319 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067305543 = PRIM_CAR(x139731067305319);
+Obj x = x139731067305543;
+Obj x139731067257895 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067257927 = PRIM_CDR(x139731067257895);
+Obj x139731067257959 = PRIM_EQ(Nil, x139731067257927);
+if (True == x139731067257959) {
 PUSH_CONT_0(co, 8, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3530,7 +3530,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292103;
+__arg0 = x139731067614119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3539,7 +3539,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292103;
+__arg0 = x139731067614119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3548,7 +3548,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292103;
+__arg0 = x139731067614119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3557,7 +3557,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292103;
+__arg0 = x139731067614119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3568,13 +3568,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140166663928199 = __arg1;
-Obj x1 = x140166663928199;
-Obj x140166663928999 = makeCons(x1, Nil);
-Obj x140166663929031 = makeCons(symcdr, x140166663928999);
+Obj x139731067258215 = __arg1;
+Obj x1 = x139731067258215;
+Obj x139731067259015 = makeCons(x1, Nil);
+Obj x139731067259047 = makeCons(symcdr, x139731067259015);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166663929031;
+__arg1 = x139731067259047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3584,31 +3584,31 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140166664292583 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664082823 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664082823) {
-Obj x140166664083399 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664083431 = PRIM_EQ(symand, x140166664083399);
-if (True == x140166664083431) {
-Obj x140166664084327 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664084359 = PRIM_ISCONS(x140166664084327);
-if (True == x140166664084359) {
-Obj x140166664084967 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664084999 = PRIM_CAR(x140166664084967);
-Obj x = x140166664084999;
-Obj x140166664073479 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664073511 = PRIM_CDR(x140166664073479);
-Obj x140166664073543 = PRIM_ISCONS(x140166664073511);
-if (True == x140166664073543) {
-Obj x140166664074439 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664074471 = PRIM_CDR(x140166664074439);
-Obj x140166664074503 = PRIM_CAR(x140166664074471);
-Obj y = x140166664074503;
-Obj x140166664075719 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664075847 = PRIM_CDR(x140166664075719);
-Obj x140166664075911 = PRIM_CDR(x140166664075847);
-Obj x140166664075943 = PRIM_EQ(Nil, x140166664075911);
-if (True == x140166664075943) {
+Obj x139731067614983 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067421575 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067421575) {
+Obj x139731067422119 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067422151 = PRIM_EQ(symand, x139731067422119);
+if (True == x139731067422151) {
+Obj x139731067422823 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067422855 = PRIM_ISCONS(x139731067422823);
+if (True == x139731067422855) {
+Obj x139731067423527 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067423559 = PRIM_CAR(x139731067423527);
+Obj x = x139731067423559;
+Obj x139731067424423 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067424455 = PRIM_CDR(x139731067424423);
+Obj x139731067424487 = PRIM_ISCONS(x139731067424455);
+if (True == x139731067424487) {
+Obj x139731067372359 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067372391 = PRIM_CDR(x139731067372359);
+Obj x139731067372423 = PRIM_CAR(x139731067372391);
+Obj y = x139731067372423;
+Obj x139731067373575 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067373607 = PRIM_CDR(x139731067373575);
+Obj x139731067373639 = PRIM_CDR(x139731067373607);
+Obj x139731067373671 = PRIM_EQ(Nil, x139731067373639);
+if (True == x139731067373671) {
 pushCont(co, 10, clofun2, 1, y);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3620,7 +3620,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292583;
+__arg0 = x139731067614983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3629,7 +3629,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292583;
+__arg0 = x139731067614983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3638,7 +3638,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292583;
+__arg0 = x139731067614983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3647,7 +3647,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292583;
+__arg0 = x139731067614983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3656,7 +3656,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292583;
+__arg0 = x139731067614983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3667,9 +3667,9 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140166664076423 = __arg1;
+Obj x139731067374087 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1 = x140166664076423;
+Obj x1 = x139731067374087;
 pushCont(co, 11, clofun2, 1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3683,15 +3683,15 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166664076807 = __arg1;
+Obj x139731067374567 = __arg1;
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y1 = x140166664076807;
-Obj x140166663951847 = makeCons(y1, Nil);
-Obj x140166663951879 = makeCons(x1, x140166663951847);
-Obj x140166663951911 = makeCons(symand, x140166663951879);
+Obj y1 = x139731067374567;
+Obj x139731067301895 = makeCons(y1, Nil);
+Obj x139731067301927 = makeCons(x1, x139731067301895);
+Obj x139731067301959 = makeCons(symand, x139731067301927);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166663951911;
+__arg1 = x139731067301959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3701,22 +3701,22 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140166664293191 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664117447 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664117447) {
-Obj x140166664118023 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664118183 = PRIM_EQ(symnull_63, x140166664118023);
-if (True == x140166664118183) {
-Obj x140166664086087 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664086119 = PRIM_ISCONS(x140166664086087);
-if (True == x140166664086119) {
-Obj x140166664086855 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664086887 = PRIM_CAR(x140166664086855);
-Obj x = x140166664086887;
-Obj x140166664088199 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664088231 = PRIM_CDR(x140166664088199);
-Obj x140166664088263 = PRIM_EQ(Nil, x140166664088231);
-if (True == x140166664088263) {
+Obj x139731067616743 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067582887 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067582887) {
+Obj x139731067583623 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067583687 = PRIM_EQ(symnull_63, x139731067583623);
+if (True == x139731067583687) {
+Obj x139731067584263 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067584295 = PRIM_ISCONS(x139731067584263);
+if (True == x139731067584295) {
+Obj x139731067470375 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067470471 = PRIM_CAR(x139731067470375);
+Obj x = x139731067470471;
+Obj x139731067471751 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067471815 = PRIM_CDR(x139731067471751);
+Obj x139731067471847 = PRIM_EQ(Nil, x139731067471815);
+if (True == x139731067471847) {
 PUSH_CONT_0(co, 13, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3728,7 +3728,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664293191;
+__arg0 = x139731067616743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3737,7 +3737,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293191;
+__arg0 = x139731067616743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3746,7 +3746,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293191;
+__arg0 = x139731067616743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3755,7 +3755,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293191;
+__arg0 = x139731067616743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3766,13 +3766,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140166664088679 = __arg1;
-Obj x1 = x140166664088679;
-Obj x140166664081543 = makeCons(x1, Nil);
-Obj x140166664081575 = makeCons(symnull_63, x140166664081543);
+Obj x139731067472199 = __arg1;
+Obj x1 = x139731067472199;
+Obj x139731067473255 = makeCons(x1, Nil);
+Obj x139731067473287 = makeCons(symnull_63, x139731067473255);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166664081575;
+__arg1 = x139731067473287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3782,22 +3782,22 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140166664293639 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664130951 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664130951) {
-Obj x140166664131975 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664132039 = PRIM_EQ(symnot, x140166664131975);
-if (True == x140166664132039) {
-Obj x140166664132743 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664132871 = PRIM_ISCONS(x140166664132743);
-if (True == x140166664132871) {
-Obj x140166664133703 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664133735 = PRIM_CAR(x140166664133703);
-Obj x = x140166664133735;
-Obj x140166664114407 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664114439 = PRIM_CDR(x140166664114407);
-Obj x140166664114471 = PRIM_EQ(Nil, x140166664114439);
-if (True == x140166664114471) {
+Obj x139731067592903 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067592711 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067592711) {
+Obj x139731067593607 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067593639 = PRIM_EQ(symnot, x139731067593607);
+if (True == x139731067593639) {
+Obj x139731067594535 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067594567 = PRIM_ISCONS(x139731067594535);
+if (True == x139731067594567) {
+Obj x139731067595367 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067595399 = PRIM_CAR(x139731067595367);
+Obj x = x139731067595399;
+Obj x139731067596359 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067596423 = PRIM_CDR(x139731067596359);
+Obj x139731067596551 = PRIM_EQ(Nil, x139731067596423);
+if (True == x139731067596551) {
 PUSH_CONT_0(co, 15, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3809,7 +3809,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664293639;
+__arg0 = x139731067592903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3818,7 +3818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293639;
+__arg0 = x139731067592903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3827,7 +3827,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293639;
+__arg0 = x139731067592903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3836,7 +3836,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293639;
+__arg0 = x139731067592903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3847,13 +3847,13 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140166664114887 = __arg1;
-Obj x1 = x140166664114887;
-Obj x140166664115943 = makeCons(x1, Nil);
-Obj x140166664115975 = makeCons(symnot, x140166664115943);
+Obj x139731067580743 = __arg1;
+Obj x1 = x139731067580743;
+Obj x139731067581703 = makeCons(x1, Nil);
+Obj x139731067581767 = makeCons(symnot, x139731067581703);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166664115975;
+__arg1 = x139731067581767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3863,42 +3863,42 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140166664294119 = makeNative(20, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664834055 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664834055) {
-Obj x140166664834663 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664834759 = PRIM_EQ(symif, x140166664834663);
-if (True == x140166664834759) {
-Obj x140166664692103 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664692135 = PRIM_ISCONS(x140166664692103);
-if (True == x140166664692135) {
-Obj x140166664692583 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664692615 = PRIM_CAR(x140166664692583);
-Obj x = x140166664692615;
-Obj x140166664693415 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664693447 = PRIM_CDR(x140166664693415);
-Obj x140166664693479 = PRIM_ISCONS(x140166664693447);
-if (True == x140166664693479) {
-Obj x140166664694567 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664694599 = PRIM_CDR(x140166664694567);
-Obj x140166664694663 = PRIM_CAR(x140166664694599);
-Obj y = x140166664694663;
-Obj x140166664695655 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664695687 = PRIM_CDR(x140166664695655);
-Obj x140166664695719 = PRIM_CDR(x140166664695687);
-Obj x140166664695751 = PRIM_ISCONS(x140166664695719);
-if (True == x140166664695751) {
-Obj x140166664471751 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664471783 = PRIM_CDR(x140166664471751);
-Obj x140166664471815 = PRIM_CDR(x140166664471783);
-Obj x140166664471847 = PRIM_CAR(x140166664471815);
-Obj z = x140166664471847;
-Obj x140166664473319 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664473351 = PRIM_CDR(x140166664473319);
-Obj x140166664473383 = PRIM_CDR(x140166664473351);
-Obj x140166664473511 = PRIM_CDR(x140166664473383);
-Obj x140166664473543 = PRIM_EQ(Nil, x140166664473511);
-if (True == x140166664473543) {
+Obj x139731067593671 = makeNative(20, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067836007 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067836007) {
+Obj x139731067836679 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067836743 = PRIM_EQ(symif, x139731067836679);
+if (True == x139731067836743) {
+Obj x139731067837287 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067837319 = PRIM_ISCONS(x139731067837287);
+if (True == x139731067837319) {
+Obj x139731067837895 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067837927 = PRIM_CAR(x139731067837895);
+Obj x = x139731067837927;
+Obj x139731067801831 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067801959 = PRIM_CDR(x139731067801831);
+Obj x139731067801991 = PRIM_ISCONS(x139731067801959);
+if (True == x139731067801991) {
+Obj x139731067802919 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067802951 = PRIM_CDR(x139731067802919);
+Obj x139731067802983 = PRIM_CAR(x139731067802951);
+Obj y = x139731067802983;
+Obj x139731067804487 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067804519 = PRIM_CDR(x139731067804487);
+Obj x139731067804551 = PRIM_CDR(x139731067804519);
+Obj x139731067804615 = PRIM_ISCONS(x139731067804551);
+if (True == x139731067804615) {
+Obj x139731067728135 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067728167 = PRIM_CDR(x139731067728135);
+Obj x139731067728199 = PRIM_CDR(x139731067728167);
+Obj x139731067728231 = PRIM_CAR(x139731067728199);
+Obj z = x139731067728231;
+Obj x139731067729863 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067729895 = PRIM_CDR(x139731067729863);
+Obj x139731067730311 = PRIM_CDR(x139731067729895);
+Obj x139731067730343 = PRIM_CDR(x139731067730311);
+Obj x139731067730375 = PRIM_EQ(Nil, x139731067730343);
+if (True == x139731067730375) {
 pushCont(co, 17, clofun2, 2, y, z);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3910,7 +3910,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3919,7 +3919,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3928,7 +3928,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3937,7 +3937,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3946,7 +3946,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3955,7 +3955,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664294119;
+__arg0 = x139731067593671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3966,10 +3966,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140166664473799 = __arg1;
+Obj x139731067730663 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x1 = x140166664473799;
+Obj x1 = x139731067730663;
 pushCont(co, 18, clofun2, 2, z, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -3983,10 +3983,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140166664474119 = __arg1;
+Obj x139731067731079 = __arg1;
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y1 = x140166664474119;
+Obj y1 = x139731067731079;
 pushCont(co, 19, clofun2, 2, y1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -4000,17 +4000,17 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140166664474567 = __arg1;
+Obj x139731067731911 = __arg1;
 Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj z1 = x140166664474567;
-Obj x140166664292487 = makeCons(z1, Nil);
-Obj x140166664292519 = makeCons(y1, x140166664292487);
-Obj x140166664292551 = makeCons(x1, x140166664292519);
-Obj x140166664292615 = makeCons(symif, x140166664292551);
+Obj z1 = x139731067731911;
+Obj x139731067614919 = makeCons(z1, Nil);
+Obj x139731067614951 = makeCons(y1, x139731067614919);
+Obj x139731067615335 = makeCons(x1, x139731067614951);
+Obj x139731067615399 = makeCons(symif, x139731067615335);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140166664292615;
+__arg1 = x139731067615399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4020,31 +4020,31 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140166664131015 = makeNative(22, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166665166151 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665166151) {
-Obj x140166665044007 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665044039 = PRIM_EQ(symlambda, x140166665044007);
-if (True == x140166665044039) {
-Obj x140166665044583 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665044615 = PRIM_ISCONS(x140166665044583);
-if (True == x140166665044615) {
-Obj x140166665045095 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665045127 = PRIM_CAR(x140166665045095);
-Obj args = x140166665045127;
-Obj x140166665046119 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665046151 = PRIM_CDR(x140166665046119);
-Obj x140166665046183 = PRIM_ISCONS(x140166665046151);
-if (True == x140166665046183) {
-Obj x140166665047143 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665047175 = PRIM_CDR(x140166665047143);
-Obj x140166665047239 = PRIM_CAR(x140166665047175);
-Obj body = x140166665047239;
-Obj x140166664831303 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664831335 = PRIM_CDR(x140166664831303);
-Obj x140166664831367 = PRIM_CDR(x140166664831335);
-Obj x140166664831399 = PRIM_EQ(Nil, x140166664831367);
-if (True == x140166664831399) {
+Obj x139731067594887 = makeNative(22, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067906311 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067906311) {
+Obj x139731067906823 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067906855 = PRIM_EQ(symlambda, x139731067906823);
+if (True == x139731067906855) {
+Obj x139731067907527 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067907591 = PRIM_ISCONS(x139731067907527);
+if (True == x139731067907591) {
+Obj x139731067859143 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067859175 = PRIM_CAR(x139731067859143);
+Obj args = x139731067859175;
+Obj x139731067860103 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067860135 = PRIM_CDR(x139731067860103);
+Obj x139731067860167 = PRIM_ISCONS(x139731067860135);
+if (True == x139731067860167) {
+Obj x139731067860967 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067860999 = PRIM_CDR(x139731067860967);
+Obj x139731067861031 = PRIM_CAR(x139731067860999);
+Obj body = x139731067861031;
+Obj x139731067861959 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067861991 = PRIM_CDR(x139731067861959);
+Obj x139731067862023 = PRIM_CDR(x139731067861991);
+Obj x139731067862087 = PRIM_EQ(Nil, x139731067862023);
+if (True == x139731067862087) {
 pushCont(co, 21, clofun2, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -4056,7 +4056,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131015;
+__arg0 = x139731067594887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4065,7 +4065,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131015;
+__arg0 = x139731067594887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4074,7 +4074,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131015;
+__arg0 = x139731067594887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4083,7 +4083,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131015;
+__arg0 = x139731067594887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4092,7 +4092,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131015;
+__arg0 = x139731067594887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4103,13 +4103,13 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140166664832391 = __arg1;
+Obj x139731067834567 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664832455 = makeCons(x140166664832391, Nil);
-Obj x140166664832487 = makeCons(args, x140166664832455);
-Obj x140166664832519 = makeCons(symlambda, x140166664832487);
+Obj x139731067834631 = makeCons(x139731067834567, Nil);
+Obj x139731067834663 = makeCons(args, x139731067834631);
+Obj x139731067834695 = makeCons(symlambda, x139731067834663);
 __nargs = 2;
-__arg1 = x140166664832519;
+__arg1 = x139731067834695;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4117,18 +4117,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label22:
 {
-Obj x140166664131623 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166665164103 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665164103) {
-Obj x140166665164359 = PRIM_CAR(closureRef(co, 0));
-Obj f = x140166665164359;
-Obj x140166665164711 = PRIM_CDR(closureRef(co, 0));
-Obj args = x140166665164711;
-Obj x140166665165703 = makeCons(f, args);
+Obj x139731067595879 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067904455 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067904455) {
+Obj x139731067904711 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139731067904711;
+Obj x139731067904967 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139731067904967;
+Obj x139731067905831 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35propagate_45boolean);
-__arg2 = x140166665165703;
+__arg2 = x139731067905831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4136,7 +4136,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131623;
+__arg0 = x139731067595879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4147,7 +4147,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140166664132007 = makeNative(24, clofun2, 0, 0);
+Obj x139731067596455 = makeNative(24, clofun2, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -4170,58 +4170,58 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140166664292007 = __arg1;
-Obj x140166664292135 = makeNative(26, clofun2, 0, 1, x140166664292007);
-Obj x140166663532935 = PRIM_ISCONS(x140166664292007);
-if (True == x140166663532935) {
-Obj x140166663533383 = PRIM_CAR(x140166664292007);
-Obj x140166663533415 = PRIM_EQ(symcar, x140166663533383);
-if (True == x140166663533415) {
-Obj x140166663533831 = PRIM_CDR(x140166664292007);
-Obj x140166663533863 = PRIM_ISCONS(x140166663533831);
-if (True == x140166663533863) {
-Obj x140166663534439 = PRIM_CDR(x140166664292007);
-Obj x140166663534471 = PRIM_CAR(x140166663534439);
-Obj x140166663534503 = PRIM_ISCONS(x140166663534471);
-if (True == x140166663534503) {
-Obj x140166663535271 = PRIM_CDR(x140166664292007);
-Obj x140166663535303 = PRIM_CAR(x140166663535271);
-Obj x140166663535335 = PRIM_CAR(x140166663535303);
-Obj x140166663535367 = PRIM_EQ(symcons, x140166663535335);
-if (True == x140166663535367) {
-Obj x140166663536103 = PRIM_CDR(x140166664292007);
-Obj x140166663536135 = PRIM_CAR(x140166663536103);
-Obj x140166663536167 = PRIM_CDR(x140166663536135);
-Obj x140166663536199 = PRIM_ISCONS(x140166663536167);
-if (True == x140166663536199) {
-Obj x140166663471399 = PRIM_CDR(x140166664292007);
-Obj x140166663471431 = PRIM_CAR(x140166663471399);
-Obj x140166663471463 = PRIM_CDR(x140166663471431);
-Obj x140166663471495 = PRIM_CAR(x140166663471463);
-Obj x = x140166663471495;
-Obj x140166663472391 = PRIM_CDR(x140166664292007);
-Obj x140166663472423 = PRIM_CAR(x140166663472391);
-Obj x140166663472455 = PRIM_CDR(x140166663472423);
-Obj x140166663472487 = PRIM_CDR(x140166663472455);
-Obj x140166663472519 = PRIM_ISCONS(x140166663472487);
-if (True == x140166663472519) {
-Obj x140166663473415 = PRIM_CDR(x140166664292007);
-Obj x140166663473447 = PRIM_CAR(x140166663473415);
-Obj x140166663473479 = PRIM_CDR(x140166663473447);
-Obj x140166663473511 = PRIM_CDR(x140166663473479);
-Obj x140166663473543 = PRIM_CAR(x140166663473511);
-Obj __ = x140166663473543;
-Obj x140166663474631 = PRIM_CDR(x140166664292007);
-Obj x140166663474663 = PRIM_CAR(x140166663474631);
-Obj x140166663474695 = PRIM_CDR(x140166663474663);
-Obj x140166663474727 = PRIM_CDR(x140166663474695);
-Obj x140166663474759 = PRIM_CDR(x140166663474727);
-Obj x140166663474791 = PRIM_EQ(Nil, x140166663474759);
-if (True == x140166663474791) {
-Obj x140166665228679 = PRIM_CDR(x140166664292007);
-Obj x140166665228711 = PRIM_CDR(x140166665228679);
-Obj x140166665228743 = PRIM_EQ(Nil, x140166665228711);
-if (True == x140166665228743) {
+Obj x139731067614023 = __arg1;
+Obj x139731067614247 = makeNative(26, clofun2, 0, 1, x139731067614023);
+Obj x139731066971623 = PRIM_ISCONS(x139731067614023);
+if (True == x139731066971623) {
+Obj x139731066972071 = PRIM_CAR(x139731067614023);
+Obj x139731066972103 = PRIM_EQ(symcar, x139731066972071);
+if (True == x139731066972103) {
+Obj x139731066972519 = PRIM_CDR(x139731067614023);
+Obj x139731066972551 = PRIM_ISCONS(x139731066972519);
+if (True == x139731066972551) {
+Obj x139731066973127 = PRIM_CDR(x139731067614023);
+Obj x139731066973159 = PRIM_CAR(x139731066973127);
+Obj x139731066973191 = PRIM_ISCONS(x139731066973159);
+if (True == x139731066973191) {
+Obj x139731066973959 = PRIM_CDR(x139731067614023);
+Obj x139731066973991 = PRIM_CAR(x139731066973959);
+Obj x139731066974023 = PRIM_CAR(x139731066973991);
+Obj x139731066974055 = PRIM_EQ(symcons, x139731066974023);
+if (True == x139731066974055) {
+Obj x139731066958407 = PRIM_CDR(x139731067614023);
+Obj x139731066958439 = PRIM_CAR(x139731066958407);
+Obj x139731066958471 = PRIM_CDR(x139731066958439);
+Obj x139731066958503 = PRIM_ISCONS(x139731066958471);
+if (True == x139731066958503) {
+Obj x139731067954535 = PRIM_CDR(x139731067614023);
+Obj x139731067954567 = PRIM_CAR(x139731067954535);
+Obj x139731067954599 = PRIM_CDR(x139731067954567);
+Obj x139731067954695 = PRIM_CAR(x139731067954599);
+Obj x = x139731067954695;
+Obj x139731067955975 = PRIM_CDR(x139731067614023);
+Obj x139731067956007 = PRIM_CAR(x139731067955975);
+Obj x139731067956039 = PRIM_CDR(x139731067956007);
+Obj x139731067956071 = PRIM_CDR(x139731067956039);
+Obj x139731067956103 = PRIM_ISCONS(x139731067956071);
+if (True == x139731067956103) {
+Obj x139731067932839 = PRIM_CDR(x139731067614023);
+Obj x139731067932871 = PRIM_CAR(x139731067932839);
+Obj x139731067932903 = PRIM_CDR(x139731067932871);
+Obj x139731067932935 = PRIM_CDR(x139731067932903);
+Obj x139731067932967 = PRIM_CAR(x139731067932935);
+Obj __ = x139731067932967;
+Obj x139731067934791 = PRIM_CDR(x139731067614023);
+Obj x139731067934823 = PRIM_CAR(x139731067934791);
+Obj x139731067934855 = PRIM_CDR(x139731067934823);
+Obj x139731067934887 = PRIM_CDR(x139731067934855);
+Obj x139731067934951 = PRIM_CDR(x139731067934887);
+Obj x139731067934983 = PRIM_EQ(Nil, x139731067934951);
+if (True == x139731067934983) {
+Obj x139731067935815 = PRIM_CDR(x139731067614023);
+Obj x139731067935911 = PRIM_CDR(x139731067935815);
+Obj x139731067935943 = PRIM_EQ(Nil, x139731067935911);
+if (True == x139731067935943) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4229,7 +4229,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4238,7 +4238,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4247,7 +4247,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4256,7 +4256,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4265,7 +4265,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4274,7 +4274,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4283,7 +4283,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4292,7 +4292,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4301,7 +4301,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292135;
+__arg0 = x139731067614247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4312,57 +4312,57 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140166664292935 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166663758599 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663758599) {
-Obj x140166663759111 = PRIM_CAR(closureRef(co, 0));
-Obj x140166663759143 = PRIM_EQ(symcdr, x140166663759111);
-if (True == x140166663759143) {
-Obj x140166663759783 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663759815 = PRIM_ISCONS(x140166663759783);
-if (True == x140166663759815) {
-Obj x140166663760519 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663760583 = PRIM_CAR(x140166663760519);
-Obj x140166663760615 = PRIM_ISCONS(x140166663760583);
-if (True == x140166663760615) {
-Obj x140166663761575 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663761607 = PRIM_CAR(x140166663761575);
-Obj x140166663761639 = PRIM_CAR(x140166663761607);
-Obj x140166663761671 = PRIM_EQ(symcons, x140166663761639);
-if (True == x140166663761671) {
-Obj x140166663574311 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663574343 = PRIM_CAR(x140166663574311);
-Obj x140166663574375 = PRIM_CDR(x140166663574343);
-Obj x140166663574407 = PRIM_ISCONS(x140166663574375);
-if (True == x140166663574407) {
-Obj x140166663575367 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663575399 = PRIM_CAR(x140166663575367);
-Obj x140166663575431 = PRIM_CDR(x140166663575399);
-Obj x140166663575463 = PRIM_CAR(x140166663575431);
-Obj __ = x140166663575463;
-Obj x140166663576423 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663576455 = PRIM_CAR(x140166663576423);
-Obj x140166663576487 = PRIM_CDR(x140166663576455);
-Obj x140166663576519 = PRIM_CDR(x140166663576487);
-Obj x140166663576551 = PRIM_ISCONS(x140166663576519);
-if (True == x140166663576551) {
-Obj x140166663561319 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663561351 = PRIM_CAR(x140166663561319);
-Obj x140166663561383 = PRIM_CDR(x140166663561351);
-Obj x140166663561415 = PRIM_CDR(x140166663561383);
-Obj x140166663561447 = PRIM_CAR(x140166663561415);
-Obj x = x140166663561447;
-Obj x140166663562535 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663562567 = PRIM_CAR(x140166663562535);
-Obj x140166663562599 = PRIM_CDR(x140166663562567);
-Obj x140166663562631 = PRIM_CDR(x140166663562599);
-Obj x140166663562663 = PRIM_CDR(x140166663562631);
-Obj x140166663562695 = PRIM_EQ(Nil, x140166663562663);
-if (True == x140166663562695) {
-Obj x140166663563335 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663563367 = PRIM_CDR(x140166663563335);
-Obj x140166663563399 = PRIM_EQ(Nil, x140166663563367);
-if (True == x140166663563399) {
+Obj x139731067616167 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067187431 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067187431) {
+Obj x139731067187879 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067187911 = PRIM_EQ(symcdr, x139731067187879);
+if (True == x139731067187911) {
+Obj x139731067188327 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067188359 = PRIM_ISCONS(x139731067188327);
+if (True == x139731067188359) {
+Obj x139731067188935 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067188967 = PRIM_CAR(x139731067188935);
+Obj x139731067188999 = PRIM_ISCONS(x139731067188967);
+if (True == x139731067188999) {
+Obj x139731067189767 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067189799 = PRIM_CAR(x139731067189767);
+Obj x139731067189831 = PRIM_CAR(x139731067189799);
+Obj x139731067189863 = PRIM_EQ(symcons, x139731067189831);
+if (True == x139731067189863) {
+Obj x139731067190599 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067190631 = PRIM_CAR(x139731067190599);
+Obj x139731067190663 = PRIM_CDR(x139731067190631);
+Obj x139731067190695 = PRIM_ISCONS(x139731067190663);
+if (True == x139731067190695) {
+Obj x139731066978439 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066978471 = PRIM_CAR(x139731066978439);
+Obj x139731066978503 = PRIM_CDR(x139731066978471);
+Obj x139731066978535 = PRIM_CAR(x139731066978503);
+Obj __ = x139731066978535;
+Obj x139731066979431 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066979463 = PRIM_CAR(x139731066979431);
+Obj x139731066979495 = PRIM_CDR(x139731066979463);
+Obj x139731066979527 = PRIM_CDR(x139731066979495);
+Obj x139731066979559 = PRIM_ISCONS(x139731066979527);
+if (True == x139731066979559) {
+Obj x139731066980455 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066980487 = PRIM_CAR(x139731066980455);
+Obj x139731066980519 = PRIM_CDR(x139731066980487);
+Obj x139731066980551 = PRIM_CDR(x139731066980519);
+Obj x139731066980583 = PRIM_CAR(x139731066980551);
+Obj x = x139731066980583;
+Obj x139731066981671 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066981703 = PRIM_CAR(x139731066981671);
+Obj x139731066981735 = PRIM_CDR(x139731066981703);
+Obj x139731066981767 = PRIM_CDR(x139731066981735);
+Obj x139731066981799 = PRIM_CDR(x139731066981767);
+Obj x139731066981831 = PRIM_EQ(Nil, x139731066981799);
+if (True == x139731066981831) {
+Obj x139731066970151 = PRIM_CDR(closureRef(co, 0));
+Obj x139731066970183 = PRIM_CDR(x139731066970151);
+Obj x139731066970215 = PRIM_EQ(Nil, x139731066970183);
+if (True == x139731066970215) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4370,7 +4370,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4379,7 +4379,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4388,7 +4388,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4397,7 +4397,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4406,7 +4406,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4415,7 +4415,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4424,7 +4424,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4433,7 +4433,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4442,7 +4442,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664292935;
+__arg0 = x139731067616167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4453,57 +4453,57 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x140166664293735 = makeNative(28, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664085287 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664085287) {
-Obj x140166664073607 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664073671 = PRIM_EQ(symcons_63, x140166664073607);
-if (True == x140166664073671) {
-Obj x140166664074215 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664074247 = PRIM_ISCONS(x140166664074215);
-if (True == x140166664074247) {
-Obj x140166664075015 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664075047 = PRIM_CAR(x140166664075015);
-Obj x140166664075079 = PRIM_ISCONS(x140166664075047);
-if (True == x140166664075079) {
-Obj x140166664076199 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664076231 = PRIM_CAR(x140166664076199);
-Obj x140166664076263 = PRIM_CAR(x140166664076231);
-Obj x140166664076295 = PRIM_EQ(symcons, x140166664076263);
-if (True == x140166664076295) {
-Obj x140166663951111 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663951143 = PRIM_CAR(x140166663951111);
-Obj x140166663951399 = PRIM_CDR(x140166663951143);
-Obj x140166663951431 = PRIM_ISCONS(x140166663951399);
-if (True == x140166663951431) {
-Obj x140166663952295 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663952327 = PRIM_CAR(x140166663952295);
-Obj x140166663952359 = PRIM_CDR(x140166663952327);
-Obj x140166663952391 = PRIM_CAR(x140166663952359);
-Obj __ = x140166663952391;
-Obj x140166663953511 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663953543 = PRIM_CAR(x140166663953511);
-Obj x140166663953575 = PRIM_CDR(x140166663953543);
-Obj x140166663953607 = PRIM_CDR(x140166663953575);
-Obj x140166663953639 = PRIM_ISCONS(x140166663953607);
-if (True == x140166663953639) {
-Obj x140166663926247 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663926279 = PRIM_CAR(x140166663926247);
-Obj x140166663926311 = PRIM_CDR(x140166663926279);
-Obj x140166663926343 = PRIM_CDR(x140166663926311);
-Obj x140166663926375 = PRIM_CAR(x140166663926343);
-__ = x140166663926375;
-Obj x140166663927751 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663927911 = PRIM_CAR(x140166663927751);
-Obj x140166663927943 = PRIM_CDR(x140166663927911);
-Obj x140166663927975 = PRIM_CDR(x140166663927943);
-Obj x140166663928007 = PRIM_CDR(x140166663927975);
-Obj x140166663928039 = PRIM_EQ(Nil, x140166663928007);
-if (True == x140166663928039) {
-Obj x140166663928679 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663928711 = PRIM_CDR(x140166663928679);
-Obj x140166663928839 = PRIM_EQ(Nil, x140166663928711);
-if (True == x140166663928839) {
+Obj x139731067592967 = makeNative(28, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067422759 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067422759) {
+Obj x139731067423399 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067423431 = PRIM_EQ(symcons_63, x139731067423399);
+if (True == x139731067423431) {
+Obj x139731067424039 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067424071 = PRIM_ISCONS(x139731067424039);
+if (True == x139731067424071) {
+Obj x139731067371591 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067371623 = PRIM_CAR(x139731067371591);
+Obj x139731067371911 = PRIM_ISCONS(x139731067371623);
+if (True == x139731067371911) {
+Obj x139731067372743 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067372775 = PRIM_CAR(x139731067372743);
+Obj x139731067372807 = PRIM_CAR(x139731067372775);
+Obj x139731067372935 = PRIM_EQ(symcons, x139731067372807);
+if (True == x139731067372935) {
+Obj x139731067373831 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067373863 = PRIM_CAR(x139731067373831);
+Obj x139731067373895 = PRIM_CDR(x139731067373863);
+Obj x139731067373927 = PRIM_ISCONS(x139731067373895);
+if (True == x139731067373927) {
+Obj x139731067374983 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067375015 = PRIM_CAR(x139731067374983);
+Obj x139731067375047 = PRIM_CDR(x139731067375015);
+Obj x139731067375079 = PRIM_CAR(x139731067375047);
+Obj __ = x139731067375079;
+Obj x139731067302503 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067302535 = PRIM_CAR(x139731067302503);
+Obj x139731067302567 = PRIM_CDR(x139731067302535);
+Obj x139731067302599 = PRIM_CDR(x139731067302567);
+Obj x139731067302631 = PRIM_ISCONS(x139731067302599);
+if (True == x139731067302631) {
+Obj x139731067303911 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067304007 = PRIM_CAR(x139731067303911);
+Obj x139731067304039 = PRIM_CDR(x139731067304007);
+Obj x139731067304071 = PRIM_CDR(x139731067304039);
+Obj x139731067304103 = PRIM_CAR(x139731067304071);
+__ = x139731067304103;
+Obj x139731067305351 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067305383 = PRIM_CAR(x139731067305351);
+Obj x139731067305415 = PRIM_CDR(x139731067305383);
+Obj x139731067305447 = PRIM_CDR(x139731067305415);
+Obj x139731067305479 = PRIM_CDR(x139731067305447);
+Obj x139731067305511 = PRIM_EQ(Nil, x139731067305479);
+if (True == x139731067305511) {
+Obj x139731067257767 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067257799 = PRIM_CDR(x139731067257767);
+Obj x139731067257831 = PRIM_EQ(Nil, x139731067257799);
+if (True == x139731067257831) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4511,7 +4511,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4520,7 +4520,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4529,7 +4529,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4538,7 +4538,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4547,7 +4547,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4556,7 +4556,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4565,7 +4565,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4574,7 +4574,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4583,7 +4583,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664293735;
+__arg0 = x139731067592967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4594,33 +4594,33 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x140166664130695 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664085991 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664085991) {
-Obj x140166664086695 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664086727 = PRIM_EQ(symand, x140166664086695);
-if (True == x140166664086727) {
-Obj x140166664087335 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664087431 = PRIM_ISCONS(x140166664087335);
-if (True == x140166664087431) {
-Obj x140166664088487 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664088519 = PRIM_CAR(x140166664088487);
-Obj x140166664088551 = PRIM_EQ(True, x140166664088519);
-if (True == x140166664088551) {
-Obj x140166664089383 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664089415 = PRIM_CDR(x140166664089383);
-Obj x140166664089447 = PRIM_ISCONS(x140166664089415);
-if (True == x140166664089447) {
-Obj x140166664082247 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664082279 = PRIM_CDR(x140166664082247);
-Obj x140166664082311 = PRIM_CAR(x140166664082279);
-Obj x140166664082375 = PRIM_EQ(True, x140166664082311);
-if (True == x140166664082375) {
-Obj x140166664083559 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664083591 = PRIM_CDR(x140166664083559);
-Obj x140166664083623 = PRIM_CDR(x140166664083591);
-Obj x140166664083655 = PRIM_EQ(Nil, x140166664083623);
-if (True == x140166664083655) {
+Obj x139731067594343 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067582951 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067582951) {
+Obj x139731067583527 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067583591 = PRIM_EQ(symand, x139731067583527);
+if (True == x139731067583591) {
+Obj x139731067584135 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067584167 = PRIM_ISCONS(x139731067584135);
+if (True == x139731067584167) {
+Obj x139731067470503 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067470535 = PRIM_CAR(x139731067470503);
+Obj x139731067470567 = PRIM_EQ(True, x139731067470535);
+if (True == x139731067470567) {
+Obj x139731067471559 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067471623 = PRIM_CDR(x139731067471559);
+Obj x139731067471655 = PRIM_ISCONS(x139731067471623);
+if (True == x139731067471655) {
+Obj x139731067472807 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067472839 = PRIM_CDR(x139731067472807);
+Obj x139731067472871 = PRIM_CAR(x139731067472839);
+Obj x139731067472935 = PRIM_EQ(True, x139731067472871);
+if (True == x139731067472935) {
+Obj x139731067421063 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067421095 = PRIM_CDR(x139731067421063);
+Obj x139731067421127 = PRIM_CDR(x139731067421095);
+Obj x139731067421191 = PRIM_EQ(Nil, x139731067421127);
+if (True == x139731067421191) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4628,7 +4628,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4637,7 +4637,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4646,7 +4646,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4655,7 +4655,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4664,7 +4664,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4673,7 +4673,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4682,7 +4682,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664130695;
+__arg0 = x139731067594343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4693,23 +4693,23 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140166664131271 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664134343 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664134343) {
-Obj x140166664114599 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664114631 = PRIM_EQ(symnull_63, x140166664114599);
-if (True == x140166664114631) {
-Obj x140166664115335 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664115367 = PRIM_ISCONS(x140166664115335);
-if (True == x140166664115367) {
-Obj x140166664116327 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664116359 = PRIM_CAR(x140166664116327);
-Obj x140166664116391 = PRIM_EQ(Nil, x140166664116359);
-if (True == x140166664116391) {
-Obj x140166664117255 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664117287 = PRIM_CDR(x140166664117255);
-Obj x140166664117319 = PRIM_EQ(Nil, x140166664117287);
-if (True == x140166664117319) {
+Obj x139731067595303 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067594503 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067594503) {
+Obj x139731067595207 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067595239 = PRIM_EQ(symnull_63, x139731067595207);
+if (True == x139731067595239) {
+Obj x139731067595847 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067595911 = PRIM_ISCONS(x139731067595847);
+if (True == x139731067595911) {
+Obj x139731067580519 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067580551 = PRIM_CAR(x139731067580519);
+Obj x139731067580679 = PRIM_EQ(Nil, x139731067580551);
+if (True == x139731067580679) {
+Obj x139731067581543 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067581607 = PRIM_CDR(x139731067581543);
+Obj x139731067581639 = PRIM_EQ(Nil, x139731067581607);
+if (True == x139731067581639) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4717,7 +4717,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131271;
+__arg0 = x139731067595303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4726,7 +4726,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131271;
+__arg0 = x139731067595303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4735,7 +4735,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131271;
+__arg0 = x139731067595303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4744,7 +4744,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131271;
+__arg0 = x139731067595303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4753,7 +4753,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131271;
+__arg0 = x139731067595303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4764,57 +4764,57 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140166664131719 = makeNative(31, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664693095 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664693095) {
-Obj x140166664693575 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664693607 = PRIM_EQ(symnull_63, x140166664693575);
-if (True == x140166664693607) {
-Obj x140166664694279 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664694439 = PRIM_ISCONS(x140166664694279);
-if (True == x140166664694439) {
-Obj x140166664695143 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664695175 = PRIM_CAR(x140166664695143);
-Obj x140166664695207 = PRIM_ISCONS(x140166664695175);
-if (True == x140166664695207) {
-Obj x140166664470951 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664470983 = PRIM_CAR(x140166664470951);
-Obj x140166664471015 = PRIM_CAR(x140166664470983);
-Obj x140166664471047 = PRIM_EQ(symcons, x140166664471015);
-if (True == x140166664471047) {
-Obj x140166664472007 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664472039 = PRIM_CAR(x140166664472007);
-Obj x140166664472071 = PRIM_CDR(x140166664472039);
-Obj x140166664472103 = PRIM_ISCONS(x140166664472071);
-if (True == x140166664472103) {
-Obj x140166664473127 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664473159 = PRIM_CAR(x140166664473127);
-Obj x140166664473191 = PRIM_CDR(x140166664473159);
-Obj x140166664473223 = PRIM_CAR(x140166664473191);
-Obj __ = x140166664473223;
-Obj x140166664474311 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664474343 = PRIM_CAR(x140166664474311);
-Obj x140166664474375 = PRIM_CDR(x140166664474343);
-Obj x140166664474407 = PRIM_CDR(x140166664474375);
-Obj x140166664474439 = PRIM_ISCONS(x140166664474407);
-if (True == x140166664474439) {
-Obj x140166664291815 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664291847 = PRIM_CAR(x140166664291815);
-Obj x140166664291879 = PRIM_CDR(x140166664291847);
-Obj x140166664291911 = PRIM_CDR(x140166664291879);
-Obj x140166664291943 = PRIM_CAR(x140166664291911);
-__ = x140166664291943;
-Obj x140166664293831 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664293863 = PRIM_CAR(x140166664293831);
-Obj x140166664293895 = PRIM_CDR(x140166664293863);
-Obj x140166664293927 = PRIM_CDR(x140166664293895);
-Obj x140166664293959 = PRIM_CDR(x140166664293927);
-Obj x140166664293991 = PRIM_EQ(Nil, x140166664293959);
-if (True == x140166664293991) {
-Obj x140166664131655 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664131687 = PRIM_CDR(x140166664131655);
-Obj x140166664131783 = PRIM_EQ(Nil, x140166664131687);
-if (True == x140166664131783) {
+Obj x139731067596039 = makeNative(31, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067837255 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067837255) {
+Obj x139731067837799 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067837831 = PRIM_EQ(symnull_63, x139731067837799);
+if (True == x139731067837831) {
+Obj x139731067838375 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067838407 = PRIM_ISCONS(x139731067838375);
+if (True == x139731067838407) {
+Obj x139731067802247 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067802279 = PRIM_CAR(x139731067802247);
+Obj x139731067802311 = PRIM_ISCONS(x139731067802279);
+if (True == x139731067802311) {
+Obj x139731067803591 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067803623 = PRIM_CAR(x139731067803591);
+Obj x139731067803655 = PRIM_CAR(x139731067803623);
+Obj x139731067803687 = PRIM_EQ(symcons, x139731067803655);
+if (True == x139731067803687) {
+Obj x139731067804999 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067805031 = PRIM_CAR(x139731067804999);
+Obj x139731067805063 = PRIM_CDR(x139731067805031);
+Obj x139731067805095 = PRIM_ISCONS(x139731067805063);
+if (True == x139731067805095) {
+Obj x139731067728359 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067728391 = PRIM_CAR(x139731067728359);
+Obj x139731067728423 = PRIM_CDR(x139731067728391);
+Obj x139731067728455 = PRIM_CAR(x139731067728423);
+Obj __ = x139731067728455;
+Obj x139731067729703 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067729735 = PRIM_CAR(x139731067729703);
+Obj x139731067729767 = PRIM_CDR(x139731067729735);
+Obj x139731067729799 = PRIM_CDR(x139731067729767);
+Obj x139731067729831 = PRIM_ISCONS(x139731067729799);
+if (True == x139731067729831) {
+Obj x139731067731527 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067731559 = PRIM_CAR(x139731067731527);
+Obj x139731067731591 = PRIM_CDR(x139731067731559);
+Obj x139731067731623 = PRIM_CDR(x139731067731591);
+Obj x139731067731655 = PRIM_CAR(x139731067731623);
+__ = x139731067731655;
+Obj x139731067615015 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067615047 = PRIM_CAR(x139731067615015);
+Obj x139731067615207 = PRIM_CDR(x139731067615047);
+Obj x139731067615239 = PRIM_CDR(x139731067615207);
+Obj x139731067615271 = PRIM_CDR(x139731067615239);
+Obj x139731067615303 = PRIM_EQ(Nil, x139731067615271);
+if (True == x139731067615303) {
+Obj x139731067616423 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067616455 = PRIM_CDR(x139731067616423);
+Obj x139731067616487 = PRIM_EQ(Nil, x139731067616455);
+if (True == x139731067616487) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4822,7 +4822,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4831,7 +4831,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4840,7 +4840,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4849,7 +4849,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4858,7 +4858,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4867,7 +4867,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4876,7 +4876,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4885,7 +4885,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4894,7 +4894,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664131719;
+__arg0 = x139731067596039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4905,23 +4905,23 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140166664132519 = makeNative(32, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166664832231 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664832231) {
-Obj x140166664832743 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664832775 = PRIM_EQ(symnot, x140166664832743);
-if (True == x140166664832775) {
-Obj x140166664833511 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664833543 = PRIM_ISCONS(x140166664833511);
-if (True == x140166664833543) {
-Obj x140166664834375 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664834407 = PRIM_CAR(x140166664834375);
-Obj x140166664834439 = PRIM_EQ(True, x140166664834407);
-if (True == x140166664834439) {
-Obj x140166664691847 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664691879 = PRIM_CDR(x140166664691847);
-Obj x140166664691911 = PRIM_EQ(Nil, x140166664691879);
-if (True == x140166664691911) {
+Obj x139731067470439 = makeNative(32, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067861831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067861831) {
+Obj x139731067862375 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067862407 = PRIM_EQ(symnot, x139731067862375);
+if (True == x139731067862407) {
+Obj x139731067834375 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067834439 = PRIM_ISCONS(x139731067834375);
+if (True == x139731067834439) {
+Obj x139731067835143 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067835175 = PRIM_CAR(x139731067835143);
+Obj x139731067835207 = PRIM_EQ(True, x139731067835175);
+if (True == x139731067835207) {
+Obj x139731067836039 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067836071 = PRIM_CDR(x139731067836039);
+Obj x139731067836103 = PRIM_EQ(Nil, x139731067836071);
+if (True == x139731067836103) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4929,7 +4929,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664132519;
+__arg0 = x139731067470439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4938,7 +4938,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132519;
+__arg0 = x139731067470439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4947,7 +4947,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132519;
+__arg0 = x139731067470439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4956,7 +4956,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132519;
+__arg0 = x139731067470439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4965,7 +4965,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132519;
+__arg0 = x139731067470439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4976,23 +4976,23 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140166664132967 = makeNative(33, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166665045063 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665045063) {
-Obj x140166665045767 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665045799 = PRIM_EQ(symnot, x140166665045767);
-if (True == x140166665045799) {
-Obj x140166665046471 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665046503 = PRIM_ISCONS(x140166665046471);
-if (True == x140166665046503) {
-Obj x140166665047303 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665047335 = PRIM_CAR(x140166665047303);
-Obj x140166665047367 = PRIM_EQ(False, x140166665047335);
-if (True == x140166665047367) {
-Obj x140166664831047 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664831111 = PRIM_CDR(x140166664831047);
-Obj x140166664831143 = PRIM_EQ(Nil, x140166664831111);
-if (True == x140166664831143) {
+Obj x139731067471175 = makeNative(33, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067906983 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067906983) {
+Obj x139731067907623 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067907655 = PRIM_EQ(symnot, x139731067907623);
+if (True == x139731067907655) {
+Obj x139731067859079 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067859111 = PRIM_ISCONS(x139731067859079);
+if (True == x139731067859111) {
+Obj x139731067859943 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067860007 = PRIM_CAR(x139731067859943);
+Obj x139731067860039 = PRIM_EQ(False, x139731067860007);
+if (True == x139731067860039) {
+Obj x139731067860775 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067860807 = PRIM_CDR(x139731067860775);
+Obj x139731067860839 = PRIM_EQ(Nil, x139731067860807);
+if (True == x139731067860839) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5000,7 +5000,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664132967;
+__arg0 = x139731067471175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5009,7 +5009,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132967;
+__arg0 = x139731067471175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5018,7 +5018,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132967;
+__arg0 = x139731067471175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5027,7 +5027,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132967;
+__arg0 = x139731067471175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5036,7 +5036,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664132967;
+__arg0 = x139731067471175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5047,43 +5047,43 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140166664133415 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166665228935 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166665228935) {
-Obj x140166665229479 = PRIM_CAR(closureRef(co, 0));
-Obj x140166665229511 = PRIM_EQ(symif, x140166665229479);
-if (True == x140166665229511) {
-Obj x140166665230023 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665230055 = PRIM_ISCONS(x140166665230023);
-if (True == x140166665230055) {
-Obj x140166665230919 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665231047 = PRIM_CAR(x140166665230919);
-Obj x140166665231079 = PRIM_EQ(True, x140166665231047);
-if (True == x140166665231079) {
-Obj x140166665231751 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665231783 = PRIM_CDR(x140166665231751);
-Obj x140166665231815 = PRIM_ISCONS(x140166665231783);
-if (True == x140166665231815) {
-Obj x140166665162919 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665162951 = PRIM_CDR(x140166665162919);
-Obj x140166665162983 = PRIM_CAR(x140166665162951);
-Obj y = x140166665162983;
-Obj x140166665163815 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665163847 = PRIM_CDR(x140166665163815);
-Obj x140166665163879 = PRIM_CDR(x140166665163847);
-Obj x140166665163911 = PRIM_ISCONS(x140166665163879);
-if (True == x140166665163911) {
-Obj x140166665164999 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665165127 = PRIM_CDR(x140166665164999);
-Obj x140166665165287 = PRIM_CDR(x140166665165127);
-Obj x140166665165319 = PRIM_CAR(x140166665165287);
-Obj z = x140166665165319;
-Obj x140166665166439 = PRIM_CDR(closureRef(co, 0));
-Obj x140166665166471 = PRIM_CDR(x140166665166439);
-Obj x140166665166503 = PRIM_CDR(x140166665166471);
-Obj x140166665166535 = PRIM_CDR(x140166665166503);
-Obj x140166665166567 = PRIM_EQ(Nil, x140166665166535);
-if (True == x140166665166567) {
+Obj x139731067471911 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067935015 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067935015) {
+Obj x139731067935591 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067935623 = PRIM_EQ(symif, x139731067935591);
+if (True == x139731067935623) {
+Obj x139731067936103 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067936135 = PRIM_ISCONS(x139731067936103);
+if (True == x139731067936135) {
+Obj x139731067928743 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067928775 = PRIM_CAR(x139731067928743);
+Obj x139731067928807 = PRIM_EQ(True, x139731067928775);
+if (True == x139731067928807) {
+Obj x139731067929543 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067929575 = PRIM_CDR(x139731067929543);
+Obj x139731067929607 = PRIM_ISCONS(x139731067929575);
+if (True == x139731067929607) {
+Obj x139731067930567 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067930599 = PRIM_CDR(x139731067930567);
+Obj x139731067930631 = PRIM_CAR(x139731067930599);
+Obj y = x139731067930631;
+Obj x139731067931559 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067931591 = PRIM_CDR(x139731067931559);
+Obj x139731067931687 = PRIM_CDR(x139731067931591);
+Obj x139731067931751 = PRIM_ISCONS(x139731067931687);
+if (True == x139731067931751) {
+Obj x139731067932647 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067904039 = PRIM_CDR(x139731067932647);
+Obj x139731067904071 = PRIM_CDR(x139731067904039);
+Obj x139731067904103 = PRIM_CAR(x139731067904071);
+Obj z = x139731067904103;
+Obj x139731067905415 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067905447 = PRIM_CDR(x139731067905415);
+Obj x139731067905479 = PRIM_CDR(x139731067905447);
+Obj x139731067905511 = PRIM_CDR(x139731067905479);
+Obj x139731067905543 = PRIM_EQ(Nil, x139731067905511);
+if (True == x139731067905543) {
 __nargs = 2;
 __arg1 = y;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5091,7 +5091,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5100,7 +5100,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5109,7 +5109,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5118,7 +5118,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5127,7 +5127,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5136,7 +5136,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5145,7 +5145,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664133415;
+__arg0 = x139731067471911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5156,43 +5156,43 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x140166664134119 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
-Obj x140166663563111 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166663563111) {
-Obj x140166663563559 = PRIM_CAR(closureRef(co, 0));
-Obj x140166663563591 = PRIM_EQ(symif, x140166663563559);
-if (True == x140166663563591) {
-Obj x140166663564007 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663564039 = PRIM_ISCONS(x140166663564007);
-if (True == x140166663564039) {
-Obj x140166663564647 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663564679 = PRIM_CAR(x140166663564647);
-Obj x140166663564711 = PRIM_EQ(False, x140166663564679);
-if (True == x140166663564711) {
-Obj x140166663565287 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663557127 = PRIM_CDR(x140166663565287);
-Obj x140166663557159 = PRIM_ISCONS(x140166663557127);
-if (True == x140166663557159) {
-Obj x140166663557735 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663557767 = PRIM_CDR(x140166663557735);
-Obj x140166663557799 = PRIM_CAR(x140166663557767);
-Obj y = x140166663557799;
-Obj x140166663558535 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663558567 = PRIM_CDR(x140166663558535);
-Obj x140166663558599 = PRIM_CDR(x140166663558567);
-Obj x140166663558631 = PRIM_ISCONS(x140166663558599);
-if (True == x140166663558631) {
-Obj x140166663559367 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663559399 = PRIM_CDR(x140166663559367);
-Obj x140166663559431 = PRIM_CDR(x140166663559399);
-Obj x140166663559463 = PRIM_CAR(x140166663559431);
-Obj z = x140166663559463;
-Obj x140166663560391 = PRIM_CDR(closureRef(co, 0));
-Obj x140166663560423 = PRIM_CDR(x140166663560391);
-Obj x140166663560455 = PRIM_CDR(x140166663560423);
-Obj x140166663560487 = PRIM_CDR(x140166663560455);
-Obj x140166663560519 = PRIM_EQ(Nil, x140166663560487);
-if (True == x140166663560519) {
+Obj x139731067473095 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
+Obj x139731067258439 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067258439) {
+Obj x139731067259079 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067259111 = PRIM_EQ(symif, x139731067259079);
+if (True == x139731067259111) {
+Obj x139731067259527 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067259559 = PRIM_ISCONS(x139731067259527);
+if (True == x139731067259559) {
+Obj x139731067260167 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067260199 = PRIM_CAR(x139731067260167);
+Obj x139731067260231 = PRIM_EQ(False, x139731067260199);
+if (True == x139731067260231) {
+Obj x139731067953287 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067953319 = PRIM_CDR(x139731067953287);
+Obj x139731067953351 = PRIM_ISCONS(x139731067953319);
+if (True == x139731067953351) {
+Obj x139731067954439 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067954471 = PRIM_CDR(x139731067954439);
+Obj x139731067954503 = PRIM_CAR(x139731067954471);
+Obj y = x139731067954503;
+Obj x139731067955431 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067955463 = PRIM_CDR(x139731067955431);
+Obj x139731067955495 = PRIM_CDR(x139731067955463);
+Obj x139731067955591 = PRIM_ISCONS(x139731067955495);
+if (True == x139731067955591) {
+Obj x139731067956487 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067956519 = PRIM_CDR(x139731067956487);
+Obj x139731067956647 = PRIM_CDR(x139731067956519);
+Obj x139731067956679 = PRIM_CAR(x139731067956647);
+Obj z = x139731067956679;
+Obj x139731067933127 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067933159 = PRIM_CDR(x139731067933127);
+Obj x139731067933191 = PRIM_CDR(x139731067933159);
+Obj x139731067933255 = PRIM_CDR(x139731067933191);
+Obj x139731067933287 = PRIM_EQ(Nil, x139731067933255);
+if (True == x139731067933287) {
 __nargs = 2;
 __arg1 = z;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5200,7 +5200,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5209,7 +5209,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5218,7 +5218,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5227,7 +5227,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5236,7 +5236,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5245,7 +5245,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5254,7 +5254,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664134119;
+__arg0 = x139731067473095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5265,7 +5265,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x140166664114343 = makeNative(36, clofun2, 0, 0);
+Obj x139731067421031 = makeNative(36, clofun2, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -5302,12 +5302,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140166663573607 = __arg1;
+Obj x139731067374183 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 39, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = x140166663573607;
+__arg1 = x139731067374183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5317,9 +5317,9 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140166663573639 = __arg1;
+Obj x139731067374247 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = x140166663573639;
+Obj body = x139731067374247;
 pushCont(co, 40, clofun2, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rules_45arg_45count);
@@ -5333,10 +5333,10 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140166663573895 = __arg1;
+Obj x139731067374631 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = x140166663573895;
+Obj nargs = x139731067374631;
 pushCont(co, 41, clofun2, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
@@ -5350,10 +5350,10 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140166663574183 = __arg1;
+Obj x139731067374887 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = x140166663574183;
+Obj args = x139731067374887;
 pushCont(co, 42, clofun2, 2, body, args);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -5367,18 +5367,18 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140166663574759 = __arg1;
+Obj x139731067375495 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166663576999 = makeCons(symlist, args);
-Obj x140166663577063 = makeCons(x140166663576999, body);
-Obj x140166663577095 = makeCons(symmatch, x140166663577063);
-Obj x140166663577159 = makeCons(x140166663577095, Nil);
-Obj x140166663577191 = makeCons(args, x140166663577159);
-Obj x140166663577223 = makeCons(x140166663574759, x140166663577191);
-Obj x140166663577255 = makeCons(symdefun, x140166663577223);
+Obj x139731067302951 = makeCons(symlist, args);
+Obj x139731067303015 = makeCons(x139731067302951, body);
+Obj x139731067303047 = makeCons(symmatch, x139731067303015);
+Obj x139731067303111 = makeCons(x139731067303047, Nil);
+Obj x139731067303143 = makeCons(args, x139731067303111);
+Obj x139731067303239 = makeCons(x139731067375495, x139731067303143);
+Obj x139731067303271 = makeCons(symdefun, x139731067303239);
 __nargs = 2;
-__arg1 = x140166663577255;
+__arg1 = x139731067303271;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5387,20 +5387,20 @@ goto *jumpTable[co->ctx.pc.label];
 label43:
 {
 Obj n = __arg1;
-Obj x140166663760167 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == x140166663760167) {
+Obj x139731067372519 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == x139731067372519) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166663760551 = primGenSym();
-Obj x140166663760999 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 44, clofun2, 1, x140166663760551);
+Obj x139731067372903 = primGenSym();
+Obj x139731067373319 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 44, clofun2, 1, x139731067372903);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = x140166663760999;
+__arg1 = x139731067373319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5411,11 +5411,11 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140166663761031 = __arg1;
-Obj x140166663760551= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663761063 = makeCons(x140166663760551, x140166663761031);
+Obj x139731067373351 = __arg1;
+Obj x139731067372903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067373383 = makeCons(x139731067372903, x139731067373351);
 __nargs = 2;
-__arg1 = x140166663761063;
+__arg1 = x139731067373383;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5438,8 +5438,8 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140166663928487 = __arg1;
-Obj pats = x140166663928487;
+Obj x139731067421735 = __arg1;
+Obj pats = x139731067421735;
 Obj len = makeNative(1, clofun3, 1, 0);
 PUSH_CONT_0(co, 47, clofun2);
 __nargs = 3;
@@ -5455,17 +5455,17 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x140166663929351 = __arg1;
-Obj counts = x140166663929351;
-Obj x140166663929767 = PRIM_CAR(counts);
-Obj n = x140166663929767;
+Obj x139731067422695 = __arg1;
+Obj counts = x139731067422695;
+Obj x139731067422983 = PRIM_CAR(counts);
+Obj n = x139731067422983;
 Obj dif = makeNative(0, clofun3, 1, 1, n);
-Obj x140166663759175 = PRIM_CDR(counts);
+Obj x139731067424583 = PRIM_CDR(counts);
 pushCont(co, 48, clofun2, 1, n);
 __nargs = 3;
 __arg0 = globalRef(symfilter);
 __arg1 = dif;
-__arg2 = x140166663759175;
+__arg2 = x139731067424583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5475,12 +5475,12 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x140166663759207 = __arg1;
+Obj x139731067424615 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun2, 1, n);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140166663759207;
+__arg1 = x139731067424615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5490,10 +5490,10 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140166663759239 = __arg1;
+Obj x139731067424647 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663759271 = primNot(x140166663759239);
-if (True == x140166663759271) {
+Obj x139731067424711 = primNot(x139731067424647);
+if (True == x139731067424711) {
 __nargs = 2;
 __arg0 = globalRef(symerror);
 __arg1 = makeCString("inconsistent func rule args count");
@@ -5534,10 +5534,10 @@ goto *jumpTable[co->ctx.pc.label];
 label0:
 {
 Obj x = __arg1;
-Obj x140166663758311 = PRIM_EQ(closureRef(co, 0), x);
-Obj x140166663758343 = primNot(x140166663758311);
+Obj x139731067423623 = PRIM_EQ(closureRef(co, 0), x);
+Obj x139731067423687 = primNot(x139731067423623);
 __nargs = 2;
-__arg1 = x140166663758343;
+__arg1 = x139731067423687;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5546,10 +5546,10 @@ goto *jumpTable[co->ctx.pc.label];
 label1:
 {
 Obj x = __arg1;
-Obj x140166663929063 = PRIM_CDR(x);
+Obj x139731067422247 = PRIM_CDR(x);
 __nargs = 2;
 __arg0 = globalRef(symlength);
-__arg1 = x140166663929063;
+__arg1 = x139731067422247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5561,20 +5561,20 @@ label2:
 {
 Obj l1 = __arg1;
 Obj l2 = __arg2;
-Obj x140166663926791 = PRIM_EQ(l1, Nil);
-if (True == x140166663926791) {
+Obj x139731067472903 = PRIM_EQ(l1, Nil);
+if (True == x139731067472903) {
 __nargs = 2;
 __arg1 = l2;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166663927271 = PRIM_CAR(l1);
-Obj x140166663927687 = PRIM_CDR(l1);
-pushCont(co, 3, clofun3, 1, x140166663927271);
+Obj x139731067473351 = PRIM_CAR(l1);
+Obj x139731067420775 = PRIM_CDR(l1);
+pushCont(co, 3, clofun3, 1, x139731067473351);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = x140166663927687;
+__arg1 = x139731067420775;
 __arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5586,11 +5586,11 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140166663927815 = __arg1;
-Obj x140166663927271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663927847 = makeCons(x140166663927271, x140166663927815);
+Obj x139731067420839 = __arg1;
+Obj x139731067473351= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067420903 = makeCons(x139731067473351, x139731067420839);
 __nargs = 2;
-__arg1 = x140166663927847;
+__arg1 = x139731067420903;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5617,13 +5617,13 @@ label5:
 Obj res = __arg1;
 Obj fn = __arg2;
 Obj l = __arg3;
-Obj x140166663951975 = PRIM_ISCONS(l);
-if (True == x140166663951975) {
-Obj x140166663952455 = PRIM_CAR(l);
+Obj x139731067583335 = PRIM_ISCONS(l);
+if (True == x139731067583335) {
+Obj x139731067583847 = PRIM_CAR(l);
 pushCont(co, 6, clofun3, 3, l, res, fn);
 __nargs = 2;
 __arg0 = fn;
-__arg1 = x140166663952455;
+__arg1 = x139731067583847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5643,31 +5643,31 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140166663952519 = __arg1;
+Obj x139731067583879 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140166663952519) {
-Obj x140166663953063 = PRIM_CAR(l);
-Obj x140166663953127 = makeCons(x140166663953063, res);
-Obj x140166663953383 = PRIM_CDR(l);
+if (True == x139731067583879) {
+Obj x139731067584455 = PRIM_CAR(l);
+Obj x139731067469831 = makeCons(x139731067584455, res);
+Obj x139731067470311 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = x140166663953127;
+__arg1 = x139731067469831;
 __arg2 = fn;
-__arg3 = x140166663953383;
+__arg3 = x139731067470311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166663953895 = PRIM_CDR(l);
+Obj x139731067470855 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
 __arg1 = res;
 __arg2 = fn;
-__arg3 = x140166663953895;
+__arg3 = x139731067470855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5694,20 +5694,20 @@ label8:
 {
 Obj i = __arg1;
 Obj l = __arg2;
-Obj x140166664076007 = PRIM_EQ(l, Nil);
-if (True == x140166664076007) {
+Obj x139731067580967 = PRIM_EQ(l, Nil);
+if (True == x139731067580967) {
 __nargs = 2;
 __arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664076487 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj x140166664076711 = PRIM_CDR(l);
+Obj x139731067581575 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139731067581831 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = x140166664076487;
-__arg2 = x140166664076711;
+__arg1 = x139731067581575;
+__arg2 = x139731067581831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5733,10 +5733,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140166664073927 = __arg1;
+Obj x139731067595175 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166664073927) {
+if (True == x139731067595175) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = res;
@@ -5746,9 +5746,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664074727 = PRIM_CAR(rules);
-Obj x140166664074823 = makeCons(x140166664074727, res);
-pushCont(co, 11, clofun3, 1, x140166664074823);
+Obj x139731067596103 = PRIM_CAR(rules);
+Obj x139731067596167 = makeCons(x139731067596103, res);
+pushCont(co, 11, clofun3, 1, x139731067596167);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = rules;
@@ -5762,12 +5762,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166664075143 = __arg1;
-Obj x140166664074823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067596487 = __arg1;
+Obj x139731067596167= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = x140166664074823;
-__arg2 = x140166664075143;
+__arg1 = x139731067596167;
+__arg2 = x139731067596487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5795,9 +5795,9 @@ label13:
 Obj input = __arg1;
 Obj current = __arg2;
 Obj result = __arg3;
-Obj x140166664290439 = makeNative(14, clofun3, 0, 3, input, current, result);
-Obj x140166664084487 = PRIM_EQ(Nil, input);
-if (True == x140166664084487) {
+Obj x139731067613319 = makeNative(14, clofun3, 0, 3, input, current, result);
+Obj x139731067617223 = PRIM_EQ(Nil, input);
+if (True == x139731067617223) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = result;
@@ -5808,7 +5808,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664290439;
+__arg0 = x139731067613319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5819,42 +5819,42 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140166664290535 = makeNative(16, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140166664114567 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664114567) {
-Obj x140166664115047 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664115111 = PRIM_EQ(sym_61_62, x140166664115047);
-if (True == x140166664115111) {
-Obj x140166664115783 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664115815 = PRIM_ISCONS(x140166664115783);
-if (True == x140166664115815) {
-Obj x140166664116455 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664116487 = PRIM_CAR(x140166664116455);
-Obj act = x140166664116487;
-Obj x140166664117127 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664117159 = PRIM_CDR(x140166664117127);
-Obj x140166664117191 = PRIM_ISCONS(x140166664117159);
-if (True == x140166664117191) {
-Obj x140166664085511 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664085543 = PRIM_CDR(x140166664085511);
-Obj x140166664085575 = PRIM_CAR(x140166664085543);
-Obj x140166664085607 = PRIM_EQ(symwhere, x140166664085575);
-if (True == x140166664085607) {
-Obj x140166664086503 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664086567 = PRIM_CDR(x140166664086503);
-Obj x140166664086599 = PRIM_CDR(x140166664086567);
-Obj x140166664086663 = PRIM_ISCONS(x140166664086599);
-if (True == x140166664086663) {
-Obj x140166664087687 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664087911 = PRIM_CDR(x140166664087687);
-Obj x140166664087943 = PRIM_CDR(x140166664087911);
-Obj x140166664087975 = PRIM_CAR(x140166664087943);
-Obj pred = x140166664087975;
-Obj x140166664088807 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664088839 = PRIM_CDR(x140166664088807);
-Obj x140166664088871 = PRIM_CDR(x140166664088839);
-Obj x140166664088903 = PRIM_CDR(x140166664088871);
-Obj remain = x140166664088903;
+Obj x139731067613415 = makeNative(16, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139731067802055 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067802055) {
+Obj x139731067802567 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067802695 = PRIM_EQ(sym_61_62, x139731067802567);
+if (True == x139731067802695) {
+Obj x139731067803175 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067803207 = PRIM_ISCONS(x139731067803175);
+if (True == x139731067803207) {
+Obj x139731067803783 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067803847 = PRIM_CAR(x139731067803783);
+Obj act = x139731067803847;
+Obj x139731067804711 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067804743 = PRIM_CDR(x139731067804711);
+Obj x139731067804775 = PRIM_ISCONS(x139731067804743);
+if (True == x139731067804775) {
+Obj x139731067805671 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067728007 = PRIM_CDR(x139731067805671);
+Obj x139731067728039 = PRIM_CAR(x139731067728007);
+Obj x139731067728071 = PRIM_EQ(symwhere, x139731067728039);
+if (True == x139731067728071) {
+Obj x139731067728871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067728903 = PRIM_CDR(x139731067728871);
+Obj x139731067728935 = PRIM_CDR(x139731067728903);
+Obj x139731067729127 = PRIM_ISCONS(x139731067728935);
+if (True == x139731067729127) {
+Obj x139731067730055 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067730151 = PRIM_CDR(x139731067730055);
+Obj x139731067730183 = PRIM_CDR(x139731067730151);
+Obj x139731067730247 = PRIM_CAR(x139731067730183);
+Obj pred = x139731067730247;
+Obj x139731067731271 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067731303 = PRIM_CDR(x139731067731271);
+Obj x139731067731335 = PRIM_CDR(x139731067731303);
+Obj x139731067731367 = PRIM_CDR(x139731067731335);
+Obj remain = x139731067731367;
 pushCont(co, 15, clofun3, 3, act, pred, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -5866,7 +5866,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5875,7 +5875,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5884,7 +5884,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5893,7 +5893,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5902,7 +5902,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5911,7 +5911,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664290535;
+__arg0 = x139731067613415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5922,22 +5922,22 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140166664089511 = __arg1;
+Obj x139731067613351 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664089543 = makeCons(symlist, x140166664089511);
-Obj pat = x140166664089543;
-Obj x140166664082503 = makeCons(act, Nil);
-Obj x140166664082535 = makeCons(pred, x140166664082503);
-Obj x140166664082567 = makeCons(symwhere, x140166664082535);
-Obj x140166664082951 = makeCons(pat, closureRef(co, 2));
-Obj x140166664082983 = makeCons(x140166664082567, x140166664082951);
+Obj x139731067613383 = makeCons(symlist, x139731067613351);
+Obj pat = x139731067613383;
+Obj x139731067615079 = makeCons(act, Nil);
+Obj x139731067615111 = makeCons(pred, x139731067615079);
+Obj x139731067615175 = makeCons(symwhere, x139731067615111);
+Obj x139731067615495 = makeCons(pat, closureRef(co, 2));
+Obj x139731067615527 = makeCons(x139731067615175, x139731067615495);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x140166664082983;
+__arg3 = x139731067615527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5947,21 +5947,21 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140166664291079 = makeNative(18, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140166664292871 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664292871) {
-Obj x140166664293543 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664293671 = PRIM_EQ(sym_61_62, x140166664293543);
-if (True == x140166664293671) {
-Obj x140166664294279 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664130567 = PRIM_ISCONS(x140166664294279);
-if (True == x140166664130567) {
-Obj x140166664131367 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664131399 = PRIM_CAR(x140166664131367);
-Obj act = x140166664131399;
-Obj x140166664132071 = PRIM_CDR(closureRef(co, 0));
-Obj x140166664132103 = PRIM_CDR(x140166664132071);
-Obj remain = x140166664132103;
+Obj x139731067614343 = makeNative(18, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139731067834887 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067834887) {
+Obj x139731067835335 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067835367 = PRIM_EQ(sym_61_62, x139731067835335);
+if (True == x139731067835367) {
+Obj x139731067835847 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067835879 = PRIM_ISCONS(x139731067835847);
+if (True == x139731067835879) {
+Obj x139731067836327 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067836359 = PRIM_CAR(x139731067836327);
+Obj act = x139731067836359;
+Obj x139731067836871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067836903 = PRIM_CDR(x139731067836871);
+Obj remain = x139731067836903;
 pushCont(co, 17, clofun3, 2, act, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -5973,7 +5973,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291079;
+__arg0 = x139731067614343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5982,7 +5982,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291079;
+__arg0 = x139731067614343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5991,7 +5991,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140166664291079;
+__arg0 = x139731067614343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6002,18 +6002,18 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140166664132775 = __arg1;
+Obj x139731067837383 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664132807 = makeCons(symlist, x140166664132775);
-Obj pat = x140166664132807;
-Obj x140166664133991 = makeCons(pat, closureRef(co, 2));
-Obj x140166664134023 = makeCons(act, x140166664133991);
+Obj x139731067837415 = makeCons(symlist, x139731067837383);
+Obj pat = x139731067837415;
+Obj x139731067838087 = makeCons(pat, closureRef(co, 2));
+Obj x139731067838119 = makeCons(act, x139731067838087);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x140166664134023;
+__arg3 = x139731067838119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6023,18 +6023,18 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140166664291399 = makeNative(19, clofun3, 0, 0);
-Obj x140166664290695 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664290695) {
-Obj x140166664291175 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140166664291175;
-Obj x140166664291719 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140166664291719;
-Obj x140166664292327 = makeCons(x, closureRef(co, 1));
+Obj x139731067614855 = makeNative(19, clofun3, 0, 0);
+Obj x139731067861927 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067861927) {
+Obj x139731067862215 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731067862215;
+Obj x139731067862471 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731067862471;
+Obj x139731067834407 = makeCons(x, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = y;
-__arg2 = x140166664292327;
+__arg2 = x139731067834407;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6043,7 +6043,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140166664291399;
+__arg0 = x139731067614855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6093,12 +6093,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140166664834695 = __arg1;
+Obj x139731067930983 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 23, clofun3, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
-__arg1 = x140166664834695;
+__arg1 = x139731067930983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6108,9 +6108,9 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x140166664834727 = __arg1;
+Obj x139731067931015 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = x140166664834727;
+Obj value = x139731067931015;
 pushCont(co, 24, clofun3, 1, value);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -6124,18 +6124,18 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140166664835047 = __arg1;
+Obj x139731067931335 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = x140166664835047;
-Obj x140166664692071 = PRIM_ISCONS(value);
-if (True == x140166664692071) {
-Obj x140166664692711 = PRIM_CAR(value);
-Obj x140166664692743 = PRIM_EQ(symcons, x140166664692711);
-Obj x140166664692775 = primNot(x140166664692743);
-if (True == x140166664692775) {
+Obj rules = x139731067931335;
+Obj x139731067931719 = PRIM_ISCONS(value);
+if (True == x139731067931719) {
+Obj x139731067932359 = PRIM_CAR(value);
+Obj x139731067932391 = PRIM_EQ(symcons, x139731067932359);
+Obj x139731067932423 = primNot(x139731067932391);
+if (True == x139731067932423) {
 if (True == True) {
-Obj x140166664693031 = primGenSym();
-Obj val = x140166664693031;
+Obj x139731067904007 = primGenSym();
+Obj val = x139731067904007;
 pushCont(co, 27, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6159,8 +6159,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140166664694855 = primGenSym();
-Obj val = x140166664694855;
+Obj x139731067905799 = primGenSym();
+Obj val = x139731067905799;
 pushCont(co, 26, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6185,8 +6185,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140166664471303 = primGenSym();
-Obj val = x140166664471303;
+Obj x139731067907559 = primGenSym();
+Obj val = x139731067907559;
 pushCont(co, 25, clofun3, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -6213,15 +6213,15 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140166664472487 = __arg1;
+Obj x139731067859527 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664472551 = makeCons(x140166664472487, Nil);
-Obj x140166664472583 = makeCons(value, x140166664472551);
-Obj x140166664472615 = makeCons(val, x140166664472583);
-Obj x140166664472647 = makeCons(symlet, x140166664472615);
+Obj x139731067859655 = makeCons(x139731067859527, Nil);
+Obj x139731067859687 = makeCons(value, x139731067859655);
+Obj x139731067859719 = makeCons(val, x139731067859687);
+Obj x139731067859751 = makeCons(symlet, x139731067859719);
 __nargs = 2;
-__arg1 = x140166664472647;
+__arg1 = x139731067859751;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6229,15 +6229,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label26:
 {
-Obj x140166664470695 = __arg1;
+Obj x139731067906919 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664470759 = makeCons(x140166664470695, Nil);
-Obj x140166664470791 = makeCons(value, x140166664470759);
-Obj x140166664470823 = makeCons(val, x140166664470791);
-Obj x140166664470855 = makeCons(symlet, x140166664470823);
+Obj x139731067907015 = makeCons(x139731067906919, Nil);
+Obj x139731067907047 = makeCons(value, x139731067907015);
+Obj x139731067907079 = makeCons(val, x139731067907047);
+Obj x139731067907111 = makeCons(symlet, x139731067907079);
 __nargs = 2;
-__arg1 = x140166664470855;
+__arg1 = x139731067907111;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6245,15 +6245,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x140166664694247 = __arg1;
+Obj x139731067905191 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664694311 = makeCons(x140166664694247, Nil);
-Obj x140166664694343 = makeCons(value, x140166664694311);
-Obj x140166664694375 = makeCons(val, x140166664694343);
-Obj x140166664694407 = makeCons(symlet, x140166664694375);
+Obj x139731067905255 = makeCons(x139731067905191, Nil);
+Obj x139731067905287 = makeCons(value, x139731067905255);
+Obj x139731067905319 = makeCons(val, x139731067905287);
+Obj x139731067905351 = makeCons(symlet, x139731067905319);
 __nargs = 2;
-__arg1 = x140166664694407;
+__arg1 = x139731067905351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6276,14 +6276,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140166665229255 = __arg1;
+Obj x139731067302759 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166665229255) {
-Obj x140166665229703 = makeCons(makeCString("no match-help found!"), Nil);
-Obj x140166665229735 = makeCons(symerror, x140166665229703);
+if (True == x139731067302759) {
+Obj x139731067303175 = makeCons(makeCString("no match-help found!"), Nil);
+Obj x139731067303207 = makeCons(symerror, x139731067303175);
 __nargs = 2;
-__arg1 = x140166665229735;
+__arg1 = x139731067303207;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6302,15 +6302,15 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x140166665230087 = __arg1;
+Obj x139731067303527 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166665230087) {
-Obj x140166665230663 = PRIM_CDR(rules);
+if (True == x139731067303527) {
+Obj x139731067303943 = PRIM_CDR(rules);
 pushCont(co, 35, clofun3, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
-__arg1 = x140166665230663;
+__arg1 = x139731067303943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6318,10 +6318,10 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
-Obj x140166665046919 = PRIM_CAR(rules);
-Obj pat = x140166665046919;
-Obj x140166665047207 = primGenSym();
-Obj cc = x140166665047207;
+Obj x139731067934407 = PRIM_CAR(rules);
+Obj pat = x139731067934407;
+Obj x139731067934631 = primGenSym();
+Obj cc = x139731067934631;
 pushCont(co, 31, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6347,12 +6347,12 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x140166665047527 = __arg1;
+Obj x139731067934919 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140166665047527;
+Obj action = x139731067934919;
 pushCont(co, 32, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6366,7 +6366,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x140166665048039 = __arg1;
+Obj x139731067935399 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6374,7 +6374,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 33, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140166665048039;
+__arg1 = x139731067935399;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6387,18 +6387,18 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140166664831079 = __arg1;
+Obj x139731067935527 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140166664831079;
-Obj x140166664831783 = PRIM_CDR(rules);
-Obj x140166664831815 = PRIM_CDR(x140166664831783);
+Obj curr = x139731067935527;
+Obj x139731067936199 = PRIM_CDR(rules);
+Obj x139731067936231 = PRIM_CDR(x139731067936199);
 pushCont(co, 34, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140166664831815;
+__arg2 = x139731067936231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6408,19 +6408,19 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x140166664831847 = __arg1;
+Obj x139731067936263 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140166664831847;
-Obj x140166664833063 = makeCons(rest, Nil);
-Obj x140166664833095 = makeCons(Nil, x140166664833063);
-Obj x140166664833127 = makeCons(symlambda, x140166664833095);
-Obj x140166664833607 = makeCons(curr, Nil);
-Obj x140166664833639 = makeCons(x140166664833127, x140166664833607);
-Obj x140166664833671 = makeCons(cc, x140166664833639);
-Obj x140166664833703 = makeCons(symlet, x140166664833671);
+Obj rest = x139731067936263;
+Obj x139731067929383 = makeCons(rest, Nil);
+Obj x139731067929415 = makeCons(Nil, x139731067929383);
+Obj x139731067929447 = makeCons(symlambda, x139731067929415);
+Obj x139731067929703 = makeCons(curr, Nil);
+Obj x139731067929735 = makeCons(x139731067929447, x139731067929703);
+Obj x139731067929767 = makeCons(cc, x139731067929735);
+Obj x139731067929799 = makeCons(symlet, x139731067929767);
 __nargs = 2;
-__arg1 = x140166664833703;
+__arg1 = x139731067929799;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6428,15 +6428,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label35:
 {
-Obj x140166665230695 = __arg1;
+Obj x139731067303975 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166665230695) {
+if (True == x139731067303975) {
 if (True == True) {
-Obj x140166665230983 = PRIM_CAR(rules);
-Obj pat = x140166665230983;
-Obj x140166665231239 = primGenSym();
-Obj cc = x140166665231239;
+Obj x139731067304231 = PRIM_CAR(rules);
+Obj pat = x139731067304231;
+Obj x139731067304455 = primGenSym();
+Obj cc = x139731067304455;
 pushCont(co, 40, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6459,10 +6459,10 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140166665165607 = PRIM_CAR(rules);
-Obj pat = x140166665165607;
-Obj x140166665165831 = primGenSym();
-Obj cc = x140166665165831;
+Obj x139731067954631 = PRIM_CAR(rules);
+Obj pat = x139731067954631;
+Obj x139731067954887 = primGenSym();
+Obj cc = x139731067954887;
 pushCont(co, 36, clofun3, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -6488,12 +6488,12 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140166665166119 = __arg1;
+Obj x139731067955239 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140166665166119;
+Obj action = x139731067955239;
 pushCont(co, 37, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6507,7 +6507,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140166665166599 = __arg1;
+Obj x139731067955719 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6515,7 +6515,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 38, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140166665166599;
+__arg1 = x139731067955719;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6528,18 +6528,18 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140166665166727 = __arg1;
+Obj x139731067955847 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140166665166727;
-Obj x140166665044487 = PRIM_CDR(rules);
-Obj x140166665044519 = PRIM_CDR(x140166665044487);
+Obj curr = x139731067955847;
+Obj x139731067956551 = PRIM_CDR(rules);
+Obj x139731067956583 = PRIM_CDR(x139731067956551);
 pushCont(co, 39, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140166665044519;
+__arg2 = x139731067956583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6549,19 +6549,19 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140166665044551 = __arg1;
+Obj x139731067956615 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140166665044551;
-Obj x140166665045991 = makeCons(rest, Nil);
-Obj x140166665046023 = makeCons(Nil, x140166665045991);
-Obj x140166665046055 = makeCons(symlambda, x140166665046023);
-Obj x140166665046343 = makeCons(curr, Nil);
-Obj x140166665046375 = makeCons(x140166665046055, x140166665046343);
-Obj x140166665046407 = makeCons(cc, x140166665046375);
-Obj x140166665046439 = makeCons(symlet, x140166665046407);
+Obj rest = x139731067956615;
+Obj x139731067933319 = makeCons(rest, Nil);
+Obj x139731067933351 = makeCons(Nil, x139731067933319);
+Obj x139731067933383 = makeCons(symlambda, x139731067933351);
+Obj x139731067933671 = makeCons(curr, Nil);
+Obj x139731067933703 = makeCons(x139731067933383, x139731067933671);
+Obj x139731067933735 = makeCons(cc, x139731067933703);
+Obj x139731067933767 = makeCons(symlet, x139731067933735);
 __nargs = 2;
-__arg1 = x140166665046439;
+__arg1 = x139731067933767;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6569,12 +6569,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x140166665231559 = __arg1;
+Obj x139731067304743 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140166665231559;
+Obj action = x139731067304743;
 pushCont(co, 41, clofun3, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -6588,7 +6588,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140166665231975 = __arg1;
+Obj x139731067305159 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6596,7 +6596,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 42, clofun3, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140166665231975;
+__arg1 = x139731067305159;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -6609,18 +6609,18 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140166665232167 = __arg1;
+Obj x139731067305287 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140166665232167;
-Obj x140166665163175 = PRIM_CDR(rules);
-Obj x140166665163207 = PRIM_CDR(x140166665163175);
+Obj curr = x139731067305287;
+Obj x139731067305895 = PRIM_CDR(rules);
+Obj x139731067257479 = PRIM_CDR(x139731067305895);
 pushCont(co, 43, clofun3, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = x140166665163207;
+__arg2 = x139731067257479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6630,19 +6630,19 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140166665163239 = __arg1;
+Obj x139731067257511 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140166665163239;
-Obj x140166665164487 = makeCons(rest, Nil);
-Obj x140166665164519 = makeCons(Nil, x140166665164487);
-Obj x140166665164551 = makeCons(symlambda, x140166665164519);
-Obj x140166665164839 = makeCons(curr, Nil);
-Obj x140166665164871 = makeCons(x140166665164551, x140166665164839);
-Obj x140166665164903 = makeCons(cc, x140166665164871);
-Obj x140166665164935 = makeCons(symlet, x140166665164903);
+Obj rest = x139731067257511;
+Obj x139731067953543 = makeCons(rest, Nil);
+Obj x139731067953575 = makeCons(Nil, x139731067953543);
+Obj x139731067953607 = makeCons(symlambda, x139731067953575);
+Obj x139731067954119 = makeCons(curr, Nil);
+Obj x139731067954151 = makeCons(x139731067953607, x139731067954119);
+Obj x139731067954183 = makeCons(cc, x139731067954151);
+Obj x139731067954215 = makeCons(symlet, x139731067954183);
 __nargs = 2;
-__arg1 = x140166665164935;
+__arg1 = x139731067954215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6652,9 +6652,9 @@ label44:
 {
 Obj rules = __arg1;
 Obj cc = __arg2;
-Obj x140166663759591 = PRIM_CDR(rules);
-Obj x140166663759623 = PRIM_CAR(x140166663759591);
-Obj action = x140166663759623;
+Obj x139731067473575 = PRIM_CDR(rules);
+Obj x139731067473607 = PRIM_CAR(x139731067473575);
+Obj action = x139731067473607;
 pushCont(co, 45, clofun3, 2, cc, action);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
@@ -6668,13 +6668,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140166663759943 = __arg1;
+Obj x139731067420871 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140166663759943) {
-Obj x140166663760359 = PRIM_CAR(action);
-Obj x140166663760423 = PRIM_EQ(x140166663760359, symwhere);
-if (True == x140166663760423) {
+if (True == x139731067420871) {
+Obj x139731067421383 = PRIM_CAR(action);
+Obj x139731067421447 = PRIM_EQ(x139731067421383, symwhere);
+if (True == x139731067421447) {
 if (True == True) {
 pushCont(co, 0, clofun4, 2, action, cc);
 __nargs = 2;
@@ -6734,10 +6734,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj x140166663575559 = __arg1;
+Obj x139731067374919 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 47, clofun3, 2, cc, x140166663575559);
+pushCont(co, 47, clofun3, 2, cc, x139731067374919);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6750,16 +6750,16 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x140166663575943 = __arg1;
+Obj x139731067375303 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663575559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166665228359 = makeCons(cc, Nil);
-Obj x140166665228423 = makeCons(x140166665228359, Nil);
-Obj x140166665228455 = makeCons(x140166663575943, x140166665228423);
-Obj x140166665228487 = makeCons(x140166663575559, x140166665228455);
-Obj x140166665228519 = makeCons(symif, x140166665228487);
+Obj x139731067374919= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067301991 = makeCons(cc, Nil);
+Obj x139731067302055 = makeCons(x139731067301991, Nil);
+Obj x139731067302087 = makeCons(x139731067375303, x139731067302055);
+Obj x139731067302119 = makeCons(x139731067374919, x139731067302087);
+Obj x139731067302151 = makeCons(symif, x139731067302119);
 __nargs = 2;
-__arg1 = x140166665228519;
+__arg1 = x139731067302151;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6767,10 +6767,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label48:
 {
-Obj x140166663574055 = __arg1;
+Obj x139731067423655 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 49, clofun3, 2, cc, x140166663574055);
+pushCont(co, 49, clofun3, 2, cc, x139731067423655);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6783,16 +6783,16 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140166663574439 = __arg1;
+Obj x139731067424135 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663574055= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166663574855 = makeCons(cc, Nil);
-Obj x140166663574919 = makeCons(x140166663574855, Nil);
-Obj x140166663574951 = makeCons(x140166663574439, x140166663574919);
-Obj x140166663574983 = makeCons(x140166663574055, x140166663574951);
-Obj x140166663575015 = makeCons(symif, x140166663574983);
+Obj x139731067423655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067374215 = makeCons(cc, Nil);
+Obj x139731067374279 = makeCons(x139731067374215, Nil);
+Obj x139731067374311 = makeCons(x139731067424135, x139731067374279);
+Obj x139731067374343 = makeCons(x139731067423655, x139731067374311);
+Obj x139731067374375 = makeCons(symif, x139731067374343);
 __nargs = 2;
-__arg1 = x140166663575015;
+__arg1 = x139731067374375;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6820,10 +6820,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140166663760967 = __arg1;
+Obj x139731067422023 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 1, clofun4, 2, cc, x140166663760967);
+pushCont(co, 1, clofun4, 2, cc, x139731067422023);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -6836,16 +6836,16 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140166663761351 = __arg1;
+Obj x139731067422503 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166663760967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166663761767 = makeCons(cc, Nil);
-Obj x140166663761831 = makeCons(x140166663761767, Nil);
-Obj x140166663761863 = makeCons(x140166663761351, x140166663761831);
-Obj x140166663761895 = makeCons(x140166663760967, x140166663761863);
-Obj x140166663573511 = makeCons(symif, x140166663761895);
+Obj x139731067422023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067422951 = makeCons(cc, Nil);
+Obj x139731067423015 = makeCons(x139731067422951, Nil);
+Obj x139731067423047 = makeCons(x139731067422503, x139731067423015);
+Obj x139731067423079 = makeCons(x139731067422023, x139731067423047);
+Obj x139731067423111 = makeCons(symif, x139731067423079);
 __nargs = 2;
-__arg1 = x140166663573511;
+__arg1 = x139731067423111;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6871,43 +6871,43 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140166663952487 = __arg1;
+Obj x139731067595335 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140166663952487) {
-Obj x140166663952775 = PRIM_EQ(pat, expr);
-if (True == x140166663952775) {
+if (True == x139731067595335) {
+Obj x139731067595687 = PRIM_EQ(pat, expr);
+if (True == x139731067595687) {
 __nargs = 2;
 __arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166663953735 = makeCons(expr, Nil);
-Obj x140166663953767 = makeCons(pat, x140166663953735);
-Obj x140166663953799 = makeCons(sym_61, x140166663953767);
-Obj x140166663954407 = makeCons(cc, Nil);
-Obj x140166663925799 = makeCons(x140166663954407, Nil);
-Obj x140166663925831 = makeCons(body, x140166663925799);
-Obj x140166663925863 = makeCons(x140166663953799, x140166663925831);
-Obj x140166663925895 = makeCons(symif, x140166663925863);
+Obj x139731067580583 = makeCons(expr, Nil);
+Obj x139731067580615 = makeCons(pat, x139731067580583);
+Obj x139731067580647 = makeCons(sym_61, x139731067580615);
+Obj x139731067581287 = makeCons(cc, Nil);
+Obj x139731067581351 = makeCons(x139731067581287, Nil);
+Obj x139731067581383 = makeCons(body, x139731067581351);
+Obj x139731067581415 = makeCons(x139731067580647, x139731067581383);
+Obj x139731067581447 = makeCons(symif, x139731067581415);
 __nargs = 2;
-__arg1 = x140166663925895;
+__arg1 = x139731067581447;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
-Obj x140166663926151 = primIsSymbol(pat);
-if (True == x140166663926151) {
-Obj x140166663926951 = makeCons(body, Nil);
-Obj x140166663926983 = makeCons(expr, x140166663926951);
-Obj x140166663927015 = makeCons(pat, x140166663926983);
-Obj x140166663927047 = makeCons(symlet, x140166663927015);
+Obj x139731067581735 = primIsSymbol(pat);
+if (True == x139731067581735) {
+Obj x139731067582663 = makeCons(body, Nil);
+Obj x139731067582695 = makeCons(expr, x139731067582663);
+Obj x139731067582727 = makeCons(pat, x139731067582695);
+Obj x139731067582759 = makeCons(symlet, x139731067582727);
 __nargs = 2;
-__arg1 = x140166663927047;
+__arg1 = x139731067582759;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6927,32 +6927,32 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140166663927303 = __arg1;
+Obj x139731067583047 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140166663927303) {
-Obj x140166663927719 = PRIM_CAR(pat);
-Obj x140166663927783 = PRIM_EQ(x140166663927719, symquote);
-if (True == x140166663927783) {
-Obj x140166663928743 = makeCons(expr, Nil);
-Obj x140166663928775 = makeCons(pat, x140166663928743);
-Obj x140166663928807 = makeCons(sym_61, x140166663928775);
-Obj x140166663929415 = makeCons(cc, Nil);
-Obj x140166663929479 = makeCons(x140166663929415, Nil);
-Obj x140166663929511 = makeCons(body, x140166663929479);
-Obj x140166663929543 = makeCons(x140166663928807, x140166663929511);
-Obj x140166663929575 = makeCons(symif, x140166663929543);
+if (True == x139731067583047) {
+Obj x139731067583495 = PRIM_CAR(pat);
+Obj x139731067583559 = PRIM_EQ(x139731067583495, symquote);
+if (True == x139731067583559) {
+Obj x139731067470023 = makeCons(expr, Nil);
+Obj x139731067470055 = makeCons(pat, x139731067470023);
+Obj x139731067470087 = makeCons(sym_61, x139731067470055);
+Obj x139731067470823 = makeCons(cc, Nil);
+Obj x139731067470887 = makeCons(x139731067470823, Nil);
+Obj x139731067470919 = makeCons(body, x139731067470887);
+Obj x139731067470951 = makeCons(x139731067470087, x139731067470919);
+Obj x139731067470983 = makeCons(symif, x139731067470951);
 __nargs = 2;
-__arg1 = x140166663929575;
+__arg1 = x139731067470983;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166663757959 = PRIM_CAR(pat);
-Obj x140166663758023 = PRIM_EQ(x140166663757959, symcons);
-if (True == x140166663758023) {
+Obj x139731067471527 = PRIM_CAR(pat);
+Obj x139731067471591 = PRIM_EQ(x139731067471527, symcons);
+if (True == x139731067471591) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match_45cons_45expander);
 __arg1 = pat;
@@ -6991,10 +6991,10 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140166663758823 = __arg1;
+Obj x139731067472679 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symerror);
-__arg1 = x140166663758823;
+__arg1 = x139731067472679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7018,12 +7018,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140166663951783 = __arg1;
+Obj x139731067594439 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140166663951783) {
-Obj x140166663952199 = primIsSymbol(x);
-Obj x140166663952231 = primNot(x140166663952199);
-if (True == x140166663952231) {
+if (True == x139731067594439) {
+Obj x139731067594983 = primIsSymbol(x);
+Obj x139731067595015 = primNot(x139731067594983);
+if (True == x139731067595015) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7064,12 +7064,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140166664114503 = __arg1;
+Obj x139731067835399 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = x140166664114503;
+Obj x = x139731067835399;
 pushCont(co, 10, clofun4, 4, expr, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7083,17 +7083,17 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140166664114759 = __arg1;
+Obj x139731067835655 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = x140166664114759;
-Obj x140166664115079 = PRIM_ISCONS(expr);
-if (True == x140166664115079) {
-Obj x140166664115687 = PRIM_CAR(expr);
-Obj x140166664115751 = PRIM_EQ(x140166664115687, symcons);
-if (True == x140166664115751) {
+Obj y = x139731067835655;
+Obj x139731067835975 = PRIM_ISCONS(expr);
+if (True == x139731067835975) {
+Obj x139731067836391 = PRIM_CAR(expr);
+Obj x139731067836455 = PRIM_EQ(x139731067836391, symcons);
+if (True == x139731067836455) {
 if (True == True) {
 pushCont(co, 23, clofun4, 5, expr, y, body, x, cc);
 __nargs = 2;
@@ -7105,17 +7105,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664117831 = makeCons(expr, Nil);
-Obj x140166664117863 = makeCons(symcons_63, x140166664117831);
-Obj x140166664086183 = makeCons(expr, Nil);
-Obj x140166664086215 = makeCons(symcar, x140166664086183);
-Obj x140166664086919 = makeCons(expr, Nil);
-Obj x140166664086951 = makeCons(symcdr, x140166664086919);
-pushCont(co, 21, clofun4, 4, x, x140166664086215, cc, x140166664117863);
+Obj x139731067838279 = makeCons(expr, Nil);
+Obj x139731067838311 = makeCons(symcons_63, x139731067838279);
+Obj x139731067802343 = makeCons(expr, Nil);
+Obj x139731067802375 = makeCons(symcar, x139731067802343);
+Obj x139731067803111 = makeCons(expr, Nil);
+Obj x139731067803143 = makeCons(symcdr, x139731067803111);
+pushCont(co, 21, clofun4, 4, x, x139731067802375, cc, x139731067838311);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140166664086951;
+__arg2 = x139731067803143;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7136,17 +7136,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664081703 = makeCons(expr, Nil);
-Obj x140166664081735 = makeCons(symcons_63, x140166664081703);
-Obj x140166664082599 = makeCons(expr, Nil);
-Obj x140166664082631 = makeCons(symcar, x140166664082599);
-Obj x140166664083335 = makeCons(expr, Nil);
-Obj x140166664083367 = makeCons(symcdr, x140166664083335);
-pushCont(co, 16, clofun4, 4, x, x140166664082631, cc, x140166664081735);
+Obj x139731067728295 = makeCons(expr, Nil);
+Obj x139731067728327 = makeCons(symcons_63, x139731067728295);
+Obj x139731067729287 = makeCons(expr, Nil);
+Obj x139731067729319 = makeCons(symcar, x139731067729287);
+Obj x139731067730087 = makeCons(expr, Nil);
+Obj x139731067730119 = makeCons(symcdr, x139731067730087);
+pushCont(co, 16, clofun4, 4, x, x139731067729319, cc, x139731067728327);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140166664083367;
+__arg2 = x139731067730119;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7168,17 +7168,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664073959 = makeCons(expr, Nil);
-Obj x140166664073991 = makeCons(symcons_63, x140166664073959);
-Obj x140166664074887 = makeCons(expr, Nil);
-Obj x140166664074919 = makeCons(symcar, x140166664074887);
-Obj x140166664075623 = makeCons(expr, Nil);
-Obj x140166664075655 = makeCons(symcdr, x140166664075623);
-pushCont(co, 11, clofun4, 4, x, x140166664074919, cc, x140166664073991);
+Obj x139731067614727 = makeCons(expr, Nil);
+Obj x139731067614791 = makeCons(symcons_63, x139731067614727);
+Obj x139731067615943 = makeCons(expr, Nil);
+Obj x139731067616007 = makeCons(symcar, x139731067615943);
+Obj x139731067616839 = makeCons(expr, Nil);
+Obj x139731067616871 = makeCons(symcdr, x139731067616839);
+pushCont(co, 11, clofun4, 4, x, x139731067616007, cc, x139731067614791);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = x140166664075655;
+__arg2 = x139731067616871;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -7192,17 +7192,17 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166664075815 = __arg1;
+Obj x139731067616967 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664074919= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067616007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664073991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 12, clofun4, 2, cc, x140166664073991);
+Obj x139731067614791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 12, clofun4, 2, cc, x139731067614791);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140166664074919;
-__arg3 = x140166664075815;
+__arg2 = x139731067616007;
+__arg3 = x139731067616967;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7213,16 +7213,16 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140166664075879 = __arg1;
+Obj x139731067617095 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664073991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664076391 = makeCons(cc, Nil);
-Obj x140166664076455 = makeCons(x140166664076391, Nil);
-Obj x140166663950791 = makeCons(x140166664075879, x140166664076455);
-Obj x140166663950823 = makeCons(x140166664073991, x140166663950791);
-Obj x140166663950855 = makeCons(symif, x140166663950823);
+Obj x139731067614791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067592999 = makeCons(cc, Nil);
+Obj x139731067593095 = makeCons(x139731067592999, Nil);
+Obj x139731067593127 = makeCons(x139731067617095, x139731067593095);
+Obj x139731067593159 = makeCons(x139731067614791, x139731067593127);
+Obj x139731067593191 = makeCons(symif, x139731067593159);
 __nargs = 2;
-__arg1 = x140166663950855;
+__arg1 = x139731067593191;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7230,13 +7230,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label13:
 {
-Obj x140166664084519 = __arg1;
+Obj x139731067731175 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140166664084519;
+Obj e1 = x139731067731175;
 pushCont(co, 14, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7250,13 +7250,13 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140166664084775 = __arg1;
+Obj x139731067731431 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140166664084775;
+Obj e2 = x139731067731431;
 pushCont(co, 15, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7273,7 +7273,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140166664085319 = __arg1;
+Obj x139731067613479 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7281,7 +7281,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140166664085319;
+__arg3 = x139731067613479;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7292,17 +7292,17 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x140166664083463 = __arg1;
+Obj x139731067730215 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664082631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067729319= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664081735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 17, clofun4, 2, cc, x140166664081735);
+Obj x139731067728327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 17, clofun4, 2, cc, x139731067728327);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140166664082631;
-__arg3 = x140166664083463;
+__arg2 = x139731067729319;
+__arg3 = x139731067730215;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7313,16 +7313,16 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140166664083527 = __arg1;
+Obj x139731067730279 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664081735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664084071 = makeCons(cc, Nil);
-Obj x140166664084135 = makeCons(x140166664084071, Nil);
-Obj x140166664084167 = makeCons(x140166664083527, x140166664084135);
-Obj x140166664084199 = makeCons(x140166664081735, x140166664084167);
-Obj x140166664084231 = makeCons(symif, x140166664084199);
+Obj x139731067728327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067730727 = makeCons(cc, Nil);
+Obj x139731067730791 = makeCons(x139731067730727, Nil);
+Obj x139731067730823 = makeCons(x139731067730279, x139731067730791);
+Obj x139731067730855 = makeCons(x139731067728327, x139731067730823);
+Obj x139731067730887 = makeCons(symif, x139731067730855);
 __nargs = 2;
-__arg1 = x140166664084231;
+__arg1 = x139731067730887;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7330,13 +7330,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label18:
 {
-Obj x140166664088135 = __arg1;
+Obj x139731067804327 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140166664088135;
+Obj e1 = x139731067804327;
 pushCont(co, 19, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7350,13 +7350,13 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140166664088391 = __arg1;
+Obj x139731067804583 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140166664088391;
+Obj e2 = x139731067804583;
 pushCont(co, 20, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7373,7 +7373,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140166664088935 = __arg1;
+Obj x139731067805191 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7381,7 +7381,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140166664088935;
+__arg3 = x139731067805191;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7392,17 +7392,17 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x140166664087047 = __arg1;
+Obj x139731067803239 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664086215= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067802375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664117863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 22, clofun4, 2, cc, x140166664117863);
+Obj x139731067838311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 22, clofun4, 2, cc, x139731067838311);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = x140166664086215;
-__arg3 = x140166664087047;
+__arg2 = x139731067802375;
+__arg3 = x139731067803239;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7413,16 +7413,16 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x140166664087175 = __arg1;
+Obj x139731067803303 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664117863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664087655 = makeCons(cc, Nil);
-Obj x140166664087719 = makeCons(x140166664087655, Nil);
-Obj x140166664087751 = makeCons(x140166664087175, x140166664087719);
-Obj x140166664087783 = makeCons(x140166664117863, x140166664087751);
-Obj x140166664087815 = makeCons(symif, x140166664087783);
+Obj x139731067838311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067803815 = makeCons(cc, Nil);
+Obj x139731067803879 = makeCons(x139731067803815, Nil);
+Obj x139731067803911 = makeCons(x139731067803303, x139731067803879);
+Obj x139731067803943 = makeCons(x139731067838311, x139731067803911);
+Obj x139731067803975 = makeCons(symif, x139731067803943);
 __nargs = 2;
-__arg1 = x140166664087815;
+__arg1 = x139731067803975;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7430,13 +7430,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label23:
 {
-Obj x140166664116007 = __arg1;
+Obj x139731067836711 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140166664116007;
+Obj e1 = x139731067836711;
 pushCont(co, 24, clofun4, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -7450,13 +7450,13 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x140166664116423 = __arg1;
+Obj x139731067836967 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140166664116423;
+Obj e2 = x139731067836967;
 pushCont(co, 25, clofun4, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -7473,7 +7473,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140166664116967 = __arg1;
+Obj x139731067837479 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7481,7 +7481,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = x140166664116967;
+__arg3 = x139731067837479;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7493,10 +7493,10 @@ goto *jumpTable[ps.label];
 label26:
 {
 Obj exp = __arg1;
-Obj x140166664134151 = PRIM_CDR(exp);
+Obj x139731067834791 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140166664134151;
+__arg1 = x139731067834791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7507,11 +7507,11 @@ goto *jumpTable[ps.label];
 label27:
 {
 Obj pat = __arg1;
-Obj x140166664131047 = PRIM_CDR(pat);
+Obj x139731067861287 = PRIM_CDR(pat);
 pushCont(co, 28, clofun4, 1, pat);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140166664131047;
+__arg1 = x139731067861287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7521,22 +7521,22 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x140166664131079 = __arg1;
+Obj x139731067861319 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140166664131079) {
-Obj x140166664131335 = PRIM_CAR(pat);
+if (True == x139731067861319) {
+Obj x139731067861511 = PRIM_CAR(pat);
 __nargs = 2;
-__arg1 = x140166664131335;
+__arg1 = x139731067861511;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664132135 = PRIM_CAR(pat);
-Obj x140166664132935 = PRIM_CDR(pat);
-pushCont(co, 29, clofun4, 1, x140166664132135);
+Obj x139731067862055 = PRIM_CAR(pat);
+Obj x139731067862599 = PRIM_CDR(pat);
+pushCont(co, 29, clofun4, 1, x139731067862055);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140166664132935;
+__arg1 = x139731067862599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7547,13 +7547,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140166664132999 = __arg1;
-Obj x140166664132135= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664133063 = makeCons(x140166664132999, Nil);
-Obj x140166664133095 = makeCons(x140166664132135, x140166664133063);
-Obj x140166664133127 = makeCons(symcons, x140166664133095);
+Obj x139731067862631 = __arg1;
+Obj x139731067862055= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067862695 = makeCons(x139731067862631, Nil);
+Obj x139731067862727 = makeCons(x139731067862055, x139731067862695);
+Obj x139731067862759 = makeCons(symcons, x139731067862727);
 __nargs = 2;
-__arg1 = x140166664133127;
+__arg1 = x139731067862759;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7562,16 +7562,16 @@ goto *jumpTable[co->ctx.pc.label];
 label30:
 {
 Obj x = __arg1;
-Obj x140166664293159 = PRIM_EQ(x, True);
-if (True == x140166664293159) {
+Obj x139731067860231 = PRIM_EQ(x, True);
+if (True == x139731067860231) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664293575 = PRIM_EQ(x, False);
-if (True == x140166664293575) {
+Obj x139731067860519 = PRIM_EQ(x, False);
+if (True == x139731067860519) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7590,10 +7590,10 @@ goto *jumpTable[co->ctx.pc.label];
 label31:
 {
 Obj exp = __arg1;
-Obj x140166664292391 = PRIM_CDR(exp);
+Obj x139731067859591 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140166664292391;
+__arg1 = x139731067859591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7604,28 +7604,28 @@ goto *jumpTable[ps.label];
 label32:
 {
 Obj l = __arg1;
-Obj x140166664472999 = PRIM_EQ(Nil, l);
-if (True == x140166664472999) {
+Obj x139731067905703 = PRIM_EQ(Nil, l);
+if (True == x139731067905703) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664473415 = PRIM_CAR(l);
-Obj x140166664473479 = PRIM_EQ(x140166664473415, False);
-if (True == x140166664473479) {
+Obj x139731067906151 = PRIM_CAR(l);
+Obj x139731067906215 = PRIM_EQ(x139731067906151, False);
+if (True == x139731067906215) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664473895 = PRIM_CDR(l);
+Obj x139731067906631 = PRIM_CDR(l);
 pushCont(co, 33, clofun4, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140166664473895;
+__arg1 = x139731067906631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7637,24 +7637,24 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x140166664473927 = __arg1;
+Obj x139731067906663 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140166664473927;
-Obj x140166664474215 = PRIM_EQ(more, False);
-if (True == x140166664474215) {
+Obj more = x139731067906663;
+Obj x139731067906951 = PRIM_EQ(more, False);
+if (True == x139731067906951) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664290599 = PRIM_CAR(l);
-Obj x140166664291271 = makeCons(False, Nil);
-Obj x140166664291303 = makeCons(more, x140166664291271);
-Obj x140166664291335 = makeCons(x140166664290599, x140166664291303);
-Obj x140166664291367 = makeCons(symif, x140166664291335);
+Obj x139731067907495 = PRIM_CAR(l);
+Obj x139731067907943 = makeCons(False, Nil);
+Obj x139731067907975 = makeCons(more, x139731067907943);
+Obj x139731067908007 = makeCons(x139731067907495, x139731067907975);
+Obj x139731067908039 = makeCons(symif, x139731067908007);
 __nargs = 2;
-__arg1 = x140166664291367;
+__arg1 = x139731067908039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7664,10 +7664,10 @@ goto *jumpTable[co->ctx.pc.label];
 label34:
 {
 Obj exp = __arg1;
-Obj x140166664472359 = PRIM_CDR(exp);
+Obj x139731067905063 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140166664472359;
+__arg1 = x139731067905063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7678,28 +7678,28 @@ goto *jumpTable[ps.label];
 label35:
 {
 Obj l = __arg1;
-Obj x140166664694631 = PRIM_EQ(l, Nil);
-if (True == x140166664694631) {
+Obj x139731067930727 = PRIM_EQ(l, Nil);
+if (True == x139731067930727) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664695047 = PRIM_CAR(l);
-Obj x140166664695111 = PRIM_EQ(x140166664695047, True);
-if (True == x140166664695111) {
+Obj x139731067931143 = PRIM_CAR(l);
+Obj x139731067931207 = PRIM_EQ(x139731067931143, True);
+if (True == x139731067931207) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664695527 = PRIM_CDR(l);
+Obj x139731067931623 = PRIM_CDR(l);
 pushCont(co, 36, clofun4, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140166664695527;
+__arg1 = x139731067931623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7711,24 +7711,24 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x140166664695559 = __arg1;
+Obj x139731067931655 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140166664695559;
-Obj x140166664470567 = PRIM_EQ(more, True);
-if (True == x140166664470567) {
+Obj more = x139731067931655;
+Obj x139731067931943 = PRIM_EQ(more, True);
+if (True == x139731067931943) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664471111 = PRIM_CAR(l);
-Obj x140166664471559 = makeCons(more, Nil);
-Obj x140166664471591 = makeCons(True, x140166664471559);
-Obj x140166664471623 = makeCons(x140166664471111, x140166664471591);
-Obj x140166664471655 = makeCons(symif, x140166664471623);
+Obj x139731067932487 = PRIM_CAR(l);
+Obj x139731067904263 = makeCons(more, Nil);
+Obj x139731067904295 = makeCons(True, x139731067904263);
+Obj x139731067904327 = makeCons(x139731067932487, x139731067904295);
+Obj x139731067904359 = makeCons(symif, x139731067904327);
 __nargs = 2;
-__arg1 = x140166664471655;
+__arg1 = x139731067904359;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7738,13 +7738,13 @@ goto *jumpTable[co->ctx.pc.label];
 label37:
 {
 Obj exp = __arg1;
-Obj x140166664834919 = PRIM_CDR(exp);
-Obj x140166664834951 = PRIM_EQ(Nil, x140166664834919);
-if (True == x140166664834951) {
-Obj x140166664692007 = makeCons(makeCString("no cond match"), Nil);
-Obj x140166664692039 = makeCons(symerror, x140166664692007);
+Obj x139731067935847 = PRIM_CDR(exp);
+Obj x139731067935879 = PRIM_EQ(Nil, x139731067935847);
+if (True == x139731067935879) {
+Obj x139731067936295 = makeCons(makeCString("no cond match"), Nil);
+Obj x139731067936327 = makeCons(symerror, x139731067936295);
 __nargs = 2;
-__arg1 = x140166664692039;
+__arg1 = x139731067936327;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7763,11 +7763,11 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x140166664692295 = __arg1;
+Obj x139731067936583 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = x140166664692295;
-Obj x140166664692839 = PRIM_CAR(curr);
-pushCont(co, 39, clofun4, 2, exp, x140166664692839);
+Obj curr = x139731067936583;
+Obj x139731067928935 = PRIM_CAR(curr);
+pushCont(co, 39, clofun4, 2, exp, x139731067928935);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = curr;
@@ -7780,10 +7780,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140166664693223 = __arg1;
+Obj x139731067929319 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664692839= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 40, clofun4, 2, x140166664693223, x140166664692839);
+Obj x139731067928935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 40, clofun4, 2, x139731067929319, x139731067928935);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -7796,16 +7796,16 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x140166664693799 = __arg1;
-Obj x140166664693223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664692839= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664693831 = makeCons(symcond, x140166664693799);
-Obj x140166664693895 = makeCons(x140166664693831, Nil);
-Obj x140166664693927 = makeCons(x140166664693223, x140166664693895);
-Obj x140166664693959 = makeCons(x140166664692839, x140166664693927);
-Obj x140166664693991 = makeCons(symif, x140166664693959);
+Obj x139731067929895 = __arg1;
+Obj x139731067929319= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067928935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067929927 = makeCons(symcond, x139731067929895);
+Obj x139731067929991 = makeCons(x139731067929927, Nil);
+Obj x139731067930023 = makeCons(x139731067929319, x139731067929991);
+Obj x139731067930055 = makeCons(x139731067928935, x139731067930023);
+Obj x139731067930087 = makeCons(symif, x139731067930055);
 __nargs = 2;
-__arg1 = x140166664693991;
+__arg1 = x139731067930087;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7814,10 +7814,10 @@ goto *jumpTable[co->ctx.pc.label];
 label41:
 {
 Obj exp = __arg1;
-Obj x140166664834119 = PRIM_CDR(exp);
+Obj x139731067935047 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140166664834119;
+__arg1 = x139731067935047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7828,11 +7828,11 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj exp = __arg1;
-Obj x140166664831527 = PRIM_CDR(exp);
+Obj x139731067957031 = PRIM_CDR(exp);
 pushCont(co, 43, clofun4, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140166664831527;
+__arg1 = x139731067957031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7842,18 +7842,18 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140166664831559 = __arg1;
+Obj x139731067957063 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140166664831559) {
-Obj x140166664831751 = PRIM_CAR(exp);
+if (True == x139731067957063) {
+Obj x139731067932679 = PRIM_CAR(exp);
 __nargs = 2;
-__arg1 = x140166664831751;
+__arg1 = x139731067932679;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664832295 = PRIM_CAR(exp);
-pushCont(co, 44, clofun4, 2, exp, x140166664832295);
+Obj x139731067933223 = PRIM_CAR(exp);
+pushCont(co, 44, clofun4, 2, exp, x139731067933223);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -7867,10 +7867,10 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140166664832679 = __arg1;
+Obj x139731067933607 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 45, clofun4, 2, x140166664832679, x140166664832295);
+Obj x139731067933223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun4, 2, x139731067933607, x139731067933223);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -7883,13 +7883,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x140166664833223 = __arg1;
-Obj x140166664832679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun4, 2, x140166664832679, x140166664832295);
+Obj x139731067934151 = __arg1;
+Obj x139731067933607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067933223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun4, 2, x139731067933607, x139731067933223);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140166664833223;
+__arg1 = x139731067934151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7899,15 +7899,15 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x140166664833255 = __arg1;
-Obj x140166664832679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664832295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166664833319 = makeCons(x140166664833255, Nil);
-Obj x140166664833351 = makeCons(x140166664832679, x140166664833319);
-Obj x140166664833383 = makeCons(x140166664832295, x140166664833351);
-Obj x140166664833415 = makeCons(symlet, x140166664833383);
+Obj x139731067934183 = __arg1;
+Obj x139731067933607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067933223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067934247 = makeCons(x139731067934183, Nil);
+Obj x139731067934279 = makeCons(x139731067933607, x139731067934247);
+Obj x139731067934311 = makeCons(x139731067933223, x139731067934279);
+Obj x139731067934343 = makeCons(symlet, x139731067934311);
 __nargs = 2;
-__arg1 = x140166664833415;
+__arg1 = x139731067934343;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7916,10 +7916,10 @@ goto *jumpTable[co->ctx.pc.label];
 label47:
 {
 Obj x = __arg1;
-Obj x140166665047815 = PRIM_ISCONS(x);
-Obj x140166665047847 = primNot(x140166665047815);
+Obj x139731067956231 = PRIM_ISCONS(x);
+Obj x139731067956263 = primNot(x139731067956231);
 __nargs = 2;
-__arg1 = x140166665047847;
+__arg1 = x139731067956263;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7929,22 +7929,22 @@ label48:
 {
 Obj x = __arg1;
 Obj l = __arg2;
-Obj x140166665046215 = PRIM_ISCONS(l);
-if (True == x140166665046215) {
-Obj x140166665046631 = PRIM_CAR(l);
-Obj x140166665046695 = PRIM_EQ(x140166665046631, x);
-if (True == x140166665046695) {
+Obj x139731067954663 = PRIM_ISCONS(l);
+if (True == x139731067954663) {
+Obj x139731067955079 = PRIM_CAR(l);
+Obj x139731067955143 = PRIM_EQ(x139731067955079, x);
+if (True == x139731067955143) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166665047079 = PRIM_CDR(l);
+Obj x139731067955527 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
 __arg1 = x;
-__arg2 = x140166665047079;
+__arg2 = x139731067955527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7996,9 +7996,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140166665044231 = __arg1;
+Obj x139731067373735 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 1, clofun5, 2, exp, x140166665044231);
+pushCont(co, 1, clofun5, 2, exp, x139731067373735);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8011,10 +8011,10 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140166665044967 = __arg1;
+Obj x139731067953415 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665044231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 2, clofun5, 2, x140166665044967, x140166665044231);
+Obj x139731067373735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun5, 2, x139731067953415, x139731067373735);
 __nargs = 2;
 __arg0 = globalRef(symcadddr);
 __arg1 = exp;
@@ -8027,17 +8027,17 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140166665045351 = __arg1;
-Obj x140166665044967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665044231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166665045415 = makeCons(x140166665045351, Nil);
-Obj x140166665045447 = makeCons(x140166665044967, x140166665045415);
-Obj x140166665045479 = makeCons(symlambda, x140166665045447);
-Obj x140166665045543 = makeCons(x140166665045479, Nil);
-Obj x140166665045575 = makeCons(x140166665044231, x140166665045543);
-Obj x140166665045607 = makeCons(symdef, x140166665045575);
+Obj x139731067953799 = __arg1;
+Obj x139731067953415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067373735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067953863 = makeCons(x139731067953799, Nil);
+Obj x139731067953895 = makeCons(x139731067953415, x139731067953863);
+Obj x139731067953927 = makeCons(symlambda, x139731067953895);
+Obj x139731067953991 = makeCons(x139731067953927, Nil);
+Obj x139731067954023 = makeCons(x139731067373735, x139731067953991);
+Obj x139731067954055 = makeCons(symdef, x139731067954023);
 __nargs = 2;
-__arg1 = x140166665045607;
+__arg1 = x139731067954055;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8046,10 +8046,10 @@ goto *jumpTable[co->ctx.pc.label];
 label3:
 {
 Obj exp = __arg1;
-Obj x140166665166215 = PRIM_CDR(exp);
+Obj x139731067372839 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = x140166665166215;
+__arg1 = x139731067372839;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8073,11 +8073,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140166665163975 = __arg1;
+Obj x139731067423847 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665164039 = makeCons(x140166665163975, Nil);
-Obj x140166665164071 = makeCons(symquote, x140166665164039);
-pushCont(co, 6, clofun5, 2, exp, x140166665164071);
+Obj x139731067423911 = makeCons(x139731067423847, Nil);
+Obj x139731067423943 = makeCons(symquote, x139731067423911);
+pushCont(co, 6, clofun5, 2, exp, x139731067423943);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8090,10 +8090,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140166665164807 = __arg1;
+Obj x139731067424679 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665164071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 7, clofun5, 2, x140166665164807, x140166665164071);
+Obj x139731067423943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 7, clofun5, 2, x139731067424679, x139731067423943);
 __nargs = 2;
 __arg0 = globalRef(symcdddr);
 __arg1 = exp;
@@ -8106,16 +8106,16 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140166665165031 = __arg1;
-Obj x140166665164807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665164071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140166665165063 = makeCons(x140166665164807, x140166665165031);
-Obj x140166665165095 = makeCons(symlambda, x140166665165063);
-Obj x140166665165159 = makeCons(x140166665165095, Nil);
-Obj x140166665165191 = makeCons(x140166665164071, x140166665165159);
-Obj x140166665165223 = makeCons(symcora_47init_35add_45to_45_42macros_42, x140166665165191);
+Obj x139731067371655 = __arg1;
+Obj x139731067424679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067423943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731067371687 = makeCons(x139731067424679, x139731067371655);
+Obj x139731067371719 = makeCons(symlambda, x139731067371687);
+Obj x139731067371783 = makeCons(x139731067371719, Nil);
+Obj x139731067371815 = makeCons(x139731067423943, x139731067371783);
+Obj x139731067371847 = makeCons(symcora_47init_35add_45to_45_42macros_42, x139731067371815);
 __nargs = 2;
-__arg1 = x140166665165223;
+__arg1 = x139731067371847;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8124,21 +8124,21 @@ goto *jumpTable[co->ctx.pc.label];
 label8:
 {
 Obj exp = __arg1;
-Obj x140166663950631 = PRIM_ISCONS(exp);
-if (True == x140166663950631) {
-Obj x140166665228551 = PRIM_CAR(exp);
-Obj x140166665228615 = PRIM_EQ(x140166665228551, globalRef(sym_42protect_45symbol_42));
-if (True == x140166665228615) {
-Obj x140166665228807 = PRIM_CDR(exp);
+Obj x139731067471271 = PRIM_ISCONS(exp);
+if (True == x139731067471271) {
+Obj x139731067471719 = PRIM_CAR(exp);
+Obj x139731067471783 = PRIM_EQ(x139731067471719, globalRef(sym_42protect_45symbol_42));
+if (True == x139731067471783) {
+Obj x139731067472007 = PRIM_CDR(exp);
 __nargs = 2;
-__arg1 = x140166665228807;
+__arg1 = x139731067472007;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166665229223 = PRIM_CAR(exp);
-Obj x140166665229287 = PRIM_EQ(x140166665229223, symlambda);
-if (True == x140166665229287) {
+Obj x139731067472519 = PRIM_CAR(exp);
+Obj x139731067472583 = PRIM_EQ(x139731067472519, symlambda);
+if (True == x139731067472583) {
 pushCont(co, 11, clofun5, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -8149,9 +8149,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166665230951 = PRIM_CAR(exp);
-Obj x140166665231015 = PRIM_EQ(x140166665230951, symquote);
-if (True == x140166665231015) {
+Obj x139731067421159 = PRIM_CAR(exp);
+Obj x139731067421223 = PRIM_EQ(x139731067421159, symquote);
+if (True == x139731067421223) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -8181,11 +8181,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label9:
 {
-Obj x140166665232071 = __arg1;
+Obj x139731067422311 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = makeNative(10, clofun5, 1, 1, exp);
-__arg1 = x140166665232071;
+__arg1 = x139731067422311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8196,8 +8196,8 @@ goto *jumpTable[ps.label];
 label10:
 {
 Obj exp1 = __arg1;
-Obj x140166665231495 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == x140166665231495) {
+Obj x139731067421703 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == x139731067421703) {
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35macroexpand_45boot);
@@ -8221,9 +8221,9 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140166665229831 = __arg1;
+Obj x139731067473191 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 12, clofun5, 1, x140166665229831);
+pushCont(co, 12, clofun5, 1, x139731067473191);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -8236,12 +8236,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140166665230375 = __arg1;
-Obj x140166665229831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 13, clofun5, 1, x140166665229831);
+Obj x139731067473799 = __arg1;
+Obj x139731067473191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 13, clofun5, 1, x139731067473191);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = x140166665230375;
+__arg1 = x139731067473799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8251,13 +8251,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140166665230407 = __arg1;
-Obj x140166665229831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166665230471 = makeCons(x140166665230407, Nil);
-Obj x140166665230503 = makeCons(x140166665229831, x140166665230471);
-Obj x140166665230535 = makeCons(symlambda, x140166665230503);
+Obj x139731067473831 = __arg1;
+Obj x139731067473191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067473895 = makeCons(x139731067473831, Nil);
+Obj x139731067420679 = makeCons(x139731067473191, x139731067473895);
+Obj x139731067420711 = makeCons(symlambda, x139731067420679);
 __nargs = 2;
-__arg1 = x140166665230535;
+__arg1 = x139731067420711;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8281,18 +8281,18 @@ label15:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj x140166664084423 = PRIM_EQ(Nil, macros);
-if (True == x140166664084423) {
+Obj x139731067580999 = PRIM_EQ(Nil, macros);
+if (True == x139731067580999) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140166664075751 = PRIM_CAR(macros);
+Obj x139731067469959 = PRIM_CAR(macros);
 __nargs = 2;
 __arg0 = makeNative(16, clofun5, 1, 2, exp, macros);
-__arg1 = x140166664075751;
+__arg1 = x139731067469959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8304,16 +8304,16 @@ goto *jumpTable[ps.label];
 label16:
 {
 Obj item = __arg1;
-Obj x140166664084935 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140166664084935) {
-Obj x140166664085351 = PRIM_CAR(closureRef(co, 0));
-Obj x140166664073287 = PRIM_CAR(item);
-Obj x140166664073319 = PRIM_EQ(x140166664085351, x140166664073287);
-if (True == x140166664073319) {
+Obj x139731067581511 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067581511) {
+Obj x139731067581927 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067582151 = PRIM_CAR(item);
+Obj x139731067582183 = PRIM_EQ(x139731067581927, x139731067582151);
+if (True == x139731067582183) {
 if (True == True) {
-Obj x140166664073639 = PRIM_CDR(item);
+Obj x139731067582503 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140166664073639;
+__arg0 = x139731067582503;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8321,11 +8321,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664074055 = PRIM_CDR(closureRef(co, 1));
+Obj x139731067582919 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140166664074055;
+__arg2 = x139731067582919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8334,9 +8334,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140166664074375 = PRIM_CDR(item);
+Obj x139731067583239 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140166664074375;
+__arg0 = x139731067583239;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8344,11 +8344,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664074791 = PRIM_CDR(closureRef(co, 1));
+Obj x139731067583655 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140166664074791;
+__arg2 = x139731067583655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8358,9 +8358,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x140166664075111 = PRIM_CDR(item);
+Obj x139731067583975 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140166664075111;
+__arg0 = x139731067583975;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8368,11 +8368,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140166664075527 = PRIM_CDR(closureRef(co, 1));
+Obj x139731067584391 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = x140166664075527;
+__arg2 = x139731067584391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8386,11 +8386,11 @@ label17:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj x140166664083687 = makeCons(n, v);
-Obj x140166664083751 = makeCons(x140166664083687, globalRef(sym_42macros_42));
-Obj x140166664083783 = primSet(co, sym_42macros_42, x140166664083751);
+Obj x139731067596647 = makeCons(n, v);
+Obj x139731067596711 = makeCons(x139731067596647, globalRef(sym_42macros_42));
+Obj x139731067596743 = primSet(co, sym_42macros_42, x139731067596711);
 __nargs = 2;
-__arg1 = x140166664083783;
+__arg1 = x139731067596743;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8417,13 +8417,13 @@ label19:
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj x140166664088455 = PRIM_ISCONS(l);
-if (True == x140166664088455) {
-Obj x140166664089127 = PRIM_CAR(l);
+Obj x139731067617031 = PRIM_ISCONS(l);
+if (True == x139731067617031) {
+Obj x139731067593223 = PRIM_CAR(l);
 pushCont(co, 20, clofun5, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = x140166664089127;
+__arg1 = x139731067593223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8443,17 +8443,17 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x140166664089159 = __arg1;
+Obj x139731067593255 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140166664089223 = makeCons(x140166664089159, res);
-Obj x140166664089479 = PRIM_CDR(l);
+Obj x139731067593319 = makeCons(x139731067593255, res);
+Obj x139731067593575 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symmap_45h);
-__arg1 = x140166664089223;
+__arg1 = x139731067593319;
 __arg2 = f;
-__arg3 = x140166664089479;
+__arg3 = x139731067593575;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8465,15 +8465,15 @@ label21:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj x140166664086535 = PRIM_ISCONS(l);
-if (True == x140166664086535) {
-Obj x140166664087079 = PRIM_CAR(l);
-Obj x140166664087143 = makeCons(x140166664087079, res);
-Obj x140166664087367 = PRIM_CDR(l);
+Obj x139731067614695 = PRIM_ISCONS(l);
+if (True == x139731067614695) {
+Obj x139731067615367 = PRIM_CAR(l);
+Obj x139731067615431 = makeCons(x139731067615367, res);
+Obj x139731067615687 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = x140166664087143;
-__arg2 = x140166664087367;
+__arg1 = x139731067615431;
+__arg2 = x139731067615687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8491,9 +8491,9 @@ goto *jumpTable[co->ctx.pc.label];
 label22:
 {
 Obj x = __arg1;
-Obj x140166664085927 = PRIM_ISCONS(x);
+Obj x139731067613799 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = x140166664085927;
+__arg1 = x139731067613799;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8502,14 +8502,14 @@ goto *jumpTable[co->ctx.pc.label];
 label23:
 {
 Obj exp = __arg1;
-Obj x140166664116839 = PRIM_ISCONS(exp);
-if (True == x140166664116839) {
-Obj x140166664117415 = PRIM_CAR(exp);
-Obj x140166664117959 = PRIM_CDR(exp);
-pushCont(co, 24, clofun5, 1, x140166664117415);
+Obj x139731067730599 = PRIM_ISCONS(exp);
+if (True == x139731067730599) {
+Obj x139731067731143 = PRIM_CAR(exp);
+Obj x139731067731687 = PRIM_CDR(exp);
+pushCont(co, 24, clofun5, 1, x139731067731143);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = x140166664117959;
+__arg1 = x139731067731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8526,13 +8526,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label24:
 {
-Obj x140166664117991 = __arg1;
-Obj x140166664117415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140166664118055 = makeCons(x140166664117991, Nil);
-Obj x140166664118087 = makeCons(x140166664117415, x140166664118055);
-Obj x140166664118119 = makeCons(symcons, x140166664118087);
+Obj x139731067731719 = __arg1;
+Obj x139731067731143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731067731783 = makeCons(x139731067731719, Nil);
+Obj x139731067731815 = makeCons(x139731067731143, x139731067731783);
+Obj x139731067731847 = makeCons(symcons, x139731067731815);
 __nargs = 2;
-__arg1 = x140166664118119;
+__arg1 = x139731067731847;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8541,11 +8541,11 @@ goto *jumpTable[co->ctx.pc.label];
 label25:
 {
 Obj x = __arg1;
-Obj x140166664116135 = PRIM_CDR(x);
-Obj x140166664116167 = PRIM_CDR(x140166664116135);
-Obj x140166664116199 = PRIM_CDR(x140166664116167);
+Obj x139731067729927 = PRIM_CDR(x);
+Obj x139731067729959 = PRIM_CDR(x139731067729927);
+Obj x139731067729991 = PRIM_CDR(x139731067729959);
 __nargs = 2;
-__arg1 = x140166664116199;
+__arg1 = x139731067729991;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8554,12 +8554,12 @@ goto *jumpTable[co->ctx.pc.label];
 label26:
 {
 Obj x = __arg1;
-Obj x140166664115143 = PRIM_CDR(x);
-Obj x140166664115175 = PRIM_CDR(x140166664115143);
-Obj x140166664115207 = PRIM_CDR(x140166664115175);
-Obj x140166664115239 = PRIM_CAR(x140166664115207);
+Obj x139731067728967 = PRIM_CDR(x);
+Obj x139731067728999 = PRIM_CDR(x139731067728967);
+Obj x139731067729031 = PRIM_CDR(x139731067728999);
+Obj x139731067729063 = PRIM_CAR(x139731067729031);
 __nargs = 2;
-__arg1 = x140166664115239;
+__arg1 = x139731067729063;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8568,11 +8568,11 @@ goto *jumpTable[co->ctx.pc.label];
 label27:
 {
 Obj x = __arg1;
-Obj x140166664134439 = PRIM_CDR(x);
-Obj x140166664134471 = PRIM_CDR(x140166664134439);
-Obj x140166664134503 = PRIM_CAR(x140166664134471);
+Obj x139731067727879 = PRIM_CDR(x);
+Obj x139731067727911 = PRIM_CDR(x139731067727879);
+Obj x139731067727943 = PRIM_CAR(x139731067727911);
 __nargs = 2;
-__arg1 = x140166664134503;
+__arg1 = x139731067727943;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8581,10 +8581,10 @@ goto *jumpTable[co->ctx.pc.label];
 label28:
 {
 Obj x = __arg1;
-Obj x140166664133319 = PRIM_CDR(x);
-Obj x140166664133351 = PRIM_CDR(x140166664133319);
+Obj x139731067804807 = PRIM_CDR(x);
+Obj x139731067804839 = PRIM_CDR(x139731067804807);
 __nargs = 2;
-__arg1 = x140166664133351;
+__arg1 = x139731067804839;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8593,10 +8593,10 @@ goto *jumpTable[co->ctx.pc.label];
 label29:
 {
 Obj x = __arg1;
-Obj x140166664132423 = PRIM_CAR(x);
-Obj x140166664132455 = PRIM_CDR(x140166664132423);
+Obj x139731067804071 = PRIM_CAR(x);
+Obj x139731067804103 = PRIM_CDR(x139731067804071);
 __nargs = 2;
-__arg1 = x140166664132455;
+__arg1 = x139731067804103;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8605,10 +8605,10 @@ goto *jumpTable[co->ctx.pc.label];
 label30:
 {
 Obj x = __arg1;
-Obj x140166664131495 = PRIM_CAR(x);
-Obj x140166664131527 = PRIM_CAR(x140166664131495);
+Obj x139731067803335 = PRIM_CAR(x);
+Obj x139731067803367 = PRIM_CAR(x139731067803335);
 __nargs = 2;
-__arg1 = x140166664131527;
+__arg1 = x139731067803367;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8617,10 +8617,10 @@ goto *jumpTable[co->ctx.pc.label];
 label31:
 {
 Obj x = __arg1;
-Obj x140166664294311 = PRIM_CDR(x);
-Obj x140166664294343 = PRIM_CAR(x140166664294311);
+Obj x139731067802599 = PRIM_CDR(x);
+Obj x139731067802631 = PRIM_CAR(x139731067802599);
 __nargs = 2;
-__arg1 = x140166664294343;
+__arg1 = x139731067802631;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8629,9 +8629,9 @@ goto *jumpTable[co->ctx.pc.label];
 label32:
 {
 Obj x = __arg1;
-Obj x140166664293383 = PRIM_EQ(x, Nil);
+Obj x139731067801863 = PRIM_EQ(x, Nil);
 __nargs = 2;
-__arg1 = x140166664293383;
+__arg1 = x139731067801863;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];

--- a/init.cora
+++ b/init.cora
@@ -337,10 +337,7 @@
       x => x)
 
 (defun cora/init#rewrite-namespace (exp)
-  (if (and (cons? exp)
-	   (= 'ns (car exp)))
-      (cora/init#parse () "" () exp)
-      exp))
+  (cora/init#parse () "" () exp))
 
 (defun macroexpand (exp)
   (cora/init#propagate-boolean

--- a/init.cora
+++ b/init.cora
@@ -336,9 +336,16 @@
       [f . args] => (map cora/init#propagate-boolean [f . args])
       x => x)
 
+(defun cora/init#rewrite-namespace (exp)
+  (if (and (cons? exp)
+	   (= 'ns (car exp)))
+      (cora/init#parse () "" () exp)
+      exp))
+
 (defun macroexpand (exp)
   (cora/init#propagate-boolean
-   (cora/init#macroexpand-boot exp)))
+   (cora/init#rewrite-namespace
+    (cora/init#macroexpand-boot exp))))
 
 ;; ===============
 
@@ -378,6 +385,49 @@
 	  ['ns path (cons "cora/init" import)
 	  (cons 'begin (append (map (lambda (imp) ['import imp]) import)
 			  [['def '*ns-export* ['backquote export]] . body]))]))))
+
+(defun cora/init#var-with-ns (var ns)
+  (cond
+    ((= ns "") var)
+    ((symbol-cooked? var) var)
+    (true (intern (string-append ns (string-append "#" (symbol->string var)))))))
+
+(func cora/init#lookup-var
+      s ns [] => (cora/init#var-with-ns s ns)
+      s ns [import . more] => (let export (value-or (intern (string-append import "#*ns-export*")) ())
+				   (if (elem? s export)
+				       (intern (string-append import (string-append "#" (symbol->string s))))
+				       (cora/init#lookup-var s ns more))))
+
+(set 'cora/init#*builtin-prims*
+    [['set 2 "primSet"] ['car 1 "PRIM_CAR"] ['cdr 1 "PRIM_CDR"] ['cons 2 "makeCons"] ['cons? 1 "PRIM_ISCONS"]
+    ['+ 2 "PRIM_ADD"] ['- 2 "PRIM_SUB"] ['* 2 "PRIM_MUL"] ['/ 2 "primDiv"]
+    ['= 2 "PRIM_EQ"] ['> 2 "PRIM_GT"] ['< 2 "PRIM_LT"] ['gensym 0 "primGenSym"] ['symbol? 1 "primIsSymbol"]
+    ['not 1 "primNot"] ['integer? 1 "primIsNumber"] ['string? 1 "primIsString"]])
+
+(func assq
+	var [] => ()
+	var [(cons x y) . _] => (cons x y) where (= var x)
+	var [_ . y] => (assq var y))
+
+(defun cora/init#builtin? (x)
+  (not (null? (assq x cora/init#*builtin-prims*))))
+
+(func cora/init#parse
+      _ _ _ x => x where (or (number? x) (string? x) (boolean? x) (null? x))
+      _ _ _ ['quote x] => ['quote x]
+      env ns import x => (if (elem? x env) x
+				     (cora/init#lookup-var x ns import)) where (symbol? x)
+      env ns import ['lambda args body] => ['lambda args (cora/init#parse (append args env) ns import body)]
+      env ns import ['do ['import pkg] y] => ['do (cora/init#parse env ns import ['import pkg])
+      (cora/init#parse env ns (cons pkg import) y)] where (string? pkg)
+      env ns import [op . args] => [op . (map (cora/init#parse env ns import) args)]
+      where (or (cora/init#builtin? op) (= op 'if) (= op 'do))
+      env ns import ['let a b c] => ['let a (cora/init#parse env ns import b) (cora/init#parse (cons a env) ns import c)]
+      env _ _ ['ns path import body] => (cora/init#parse env path import body)
+      env ns import ['def var val] => (let var1 (cora/init#var-with-ns var ns)
+					   ['set ['quote var1] (cora/init#parse env ns import val)])
+      env ns import ls => (map (cora/init#parse env ns import) ls))
 
 (set 'cora/init#*ns-export* `(cadr caar cdar cddr caddr cadddr cdddr pair? atom?
 				   boolean? number? null?
@@ -428,3 +478,4 @@
 (set 'cora/init#length length)
 (set 'cora/init#filter filter)
 (set 'cora/init#append append)
+(set 'cora/init#assq assq)

--- a/lib/infer.cora
+++ b/lib/infer.cora
@@ -2,7 +2,7 @@
   (import "cora/lib/sys")
   (import "cora/lib/io")
 
-  (export declare check-type enable)
+  (export declare check-type tvar enable)
 
   (defun append-tvar (l ret)
     (if (null? l)

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -33,6 +33,7 @@ static Obj symbegin;
 static Obj symexport;
 static Obj symcora_47lib_47toc_35handle_45import_45eagerly;
 static Obj symcora_47lib_47toc_35generate_45c;
+static Obj symcora_47init_35symbol_45_62string;
 static Obj symcora_47lib_47toc_35generate_45entry;
 static Obj symcora_47lib_47toc_35group_45by_45mod_45h;
 static Obj symcora_47lib_47toc_35generate_45toplevel_45group;
@@ -96,30 +97,21 @@ static Obj symcora_47lib_47toc_35diff;
 static Obj symcora_47lib_47toc_35union;
 static Obj symcora_47init_35boolean_63;
 static Obj symcora_47init_35number_63;
+static Obj sym_37const;
 static Obj symquote;
 static Obj sym_37global;
+static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
+static Obj symcora_47init_35elem_63;
 static Obj symif;
 static Obj symimport;
 static Obj symdo;
 static Obj symlet;
-static Obj symns;
-static Obj sym_37const;
-static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
-static Obj symdef;
 static Obj symcora_47init_35append;
 static Obj symlambda;
 static Obj sym_37builtin;
 static Obj symcora_47init_35length;
 static Obj symcora_47init_35map;
 static Obj symcora_47lib_47toc_35parse;
-static Obj symcora_47init_35elem_63;
-static Obj symcora_47init_35value_45or;
-static Obj symcora_47lib_47toc_35lookup_45var;
-static Obj symcora_47init_35symbol_45_62string;
-static Obj symcora_47init_35string_45append;
-static Obj symcora_47init_35intern;
-static Obj symcora_47lib_47toc_47internal_35symbol_45cooked_63;
-static Obj symcora_47lib_47toc_35var_45with_45ns;
 static Obj symcora_47lib_47toc_35temp_45list;
 static Obj symcora_47init_35cadr;
 static Obj symcora_47lib_47toc_35builtin_45_62args;
@@ -174,6 +166,7 @@ symbegin = intern("begin");
 symexport = intern("export");
 symcora_47lib_47toc_35handle_45import_45eagerly = intern("cora/lib/toc#handle-import-eagerly");
 symcora_47lib_47toc_35generate_45c = intern("cora/lib/toc#generate-c");
+symcora_47init_35symbol_45_62string = intern("cora/init#symbol->string");
 symcora_47lib_47toc_35generate_45entry = intern("cora/lib/toc#generate-entry");
 symcora_47lib_47toc_35group_45by_45mod_45h = intern("cora/lib/toc#group-by-mod-h");
 symcora_47lib_47toc_35generate_45toplevel_45group = intern("cora/lib/toc#generate-toplevel-group");
@@ -237,30 +230,21 @@ symcora_47lib_47toc_35diff = intern("cora/lib/toc#diff");
 symcora_47lib_47toc_35union = intern("cora/lib/toc#union");
 symcora_47init_35boolean_63 = intern("cora/init#boolean?");
 symcora_47init_35number_63 = intern("cora/init#number?");
+sym_37const = intern("%const");
 symquote = intern("quote");
 sym_37global = intern("%global");
+symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
+symcora_47init_35elem_63 = intern("cora/init#elem?");
 symif = intern("if");
 symimport = intern("import");
 symdo = intern("do");
 symlet = intern("let");
-symns = intern("ns");
-sym_37const = intern("%const");
-symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
-symdef = intern("def");
 symcora_47init_35append = intern("cora/init#append");
 symlambda = intern("lambda");
 sym_37builtin = intern("%builtin");
 symcora_47init_35length = intern("cora/init#length");
 symcora_47init_35map = intern("cora/init#map");
 symcora_47lib_47toc_35parse = intern("cora/lib/toc#parse");
-symcora_47init_35elem_63 = intern("cora/init#elem?");
-symcora_47init_35value_45or = intern("cora/init#value-or");
-symcora_47lib_47toc_35lookup_45var = intern("cora/lib/toc#lookup-var");
-symcora_47init_35symbol_45_62string = intern("cora/init#symbol->string");
-symcora_47init_35string_45append = intern("cora/init#string-append");
-symcora_47init_35intern = intern("cora/init#intern");
-symcora_47lib_47toc_47internal_35symbol_45cooked_63 = intern("cora/lib/toc/internal#symbol-cooked?");
-symcora_47lib_47toc_35var_45with_45ns = intern("cora/lib/toc#var-with-ns");
 symcora_47lib_47toc_35temp_45list = intern("cora/lib/toc#temp-list");
 symcora_47init_35cadr = intern("cora/init#cadr");
 symcora_47lib_47toc_35builtin_45_62args = intern("cora/lib/toc#builtin->args");
@@ -322,7 +306,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f41125ec8e0 = __arg1;
+Obj x139973624518823 = __arg1;
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -336,7 +320,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f41125ec9e0 = __arg1;
+Obj x139973624519079 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -350,120 +334,118 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41125ecae0 = __arg1;
-Obj v0x7f41125ecc00 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
-Obj v0x7f41125e50e0 = primSet(co, symcora_47lib_47toc_35assq, makeNative(40, clofun9, 2, 0));
-Obj v0x7f41125e5bc0 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(36, clofun9, 3, 0));
-Obj v0x7f41125d6cc0 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(32, clofun9, 3, 0));
-Obj v0x7f41125d6f00 = primSet(co, symcora_47lib_47toc_35index, makeNative(31, clofun9, 2, 0));
-Obj v0x7f41125cf260 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(27, clofun9, 2, 0));
-Obj v0x7f41125cf660 = makeCons(makeCString("primSet"), Nil);
-Obj v0x7f41125cf680 = makeCons(MAKE_NUMBER(2), v0x7f41125cf660);
-Obj v0x7f41125cf6a0 = makeCons(symset, v0x7f41125cf680);
-Obj v0x7f41125cf9c0 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj v0x7f41125cf9e0 = makeCons(MAKE_NUMBER(1), v0x7f41125cf9c0);
-Obj v0x7f41125cfa00 = makeCons(symcar, v0x7f41125cf9e0);
-Obj v0x7f41125cfd20 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj v0x7f41125cfd40 = makeCons(MAKE_NUMBER(1), v0x7f41125cfd20);
-Obj v0x7f41125cfd60 = makeCons(symcdr, v0x7f41125cfd40);
-Obj v0x7f41125cd080 = makeCons(makeCString("makeCons"), Nil);
-Obj v0x7f41125cd0a0 = makeCons(MAKE_NUMBER(2), v0x7f41125cd080);
-Obj v0x7f41125cd0c0 = makeCons(symcons, v0x7f41125cd0a0);
-Obj v0x7f41125cd3e0 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj v0x7f41125cd400 = makeCons(MAKE_NUMBER(1), v0x7f41125cd3e0);
-Obj v0x7f41125cd420 = makeCons(symcons_63, v0x7f41125cd400);
-Obj v0x7f4112743420 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj v0x7f4112743440 = makeCons(MAKE_NUMBER(2), v0x7f4112743420);
-Obj v0x7f4112743480 = makeCons(sym_43, v0x7f4112743440);
-Obj v0x7f41127439e0 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj v0x7f4112743a00 = makeCons(MAKE_NUMBER(2), v0x7f41127439e0);
-Obj v0x7f4112743a20 = makeCons(sym_45, v0x7f4112743a00);
-Obj v0x7f4112743fc0 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj v0x7f411273e000 = makeCons(MAKE_NUMBER(2), v0x7f4112743fc0);
-Obj v0x7f411273e040 = makeCons(sym_42, v0x7f411273e000);
-Obj v0x7f411273e4c0 = makeCons(makeCString("primDiv"), Nil);
-Obj v0x7f411273e500 = makeCons(MAKE_NUMBER(2), v0x7f411273e4c0);
-Obj v0x7f411273e520 = makeCons(sym_47, v0x7f411273e500);
-Obj v0x7f411273eb00 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj v0x7f411273eb40 = makeCons(MAKE_NUMBER(2), v0x7f411273eb00);
-Obj v0x7f411273eb60 = makeCons(sym_61, v0x7f411273eb40);
-Obj v0x7f411273efe0 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj v0x7f411272d000 = makeCons(MAKE_NUMBER(2), v0x7f411273efe0);
-Obj v0x7f411272d020 = makeCons(sym_62, v0x7f411272d000);
-Obj v0x7f411272d5c0 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj v0x7f411272d5e0 = makeCons(MAKE_NUMBER(2), v0x7f411272d5c0);
-Obj v0x7f411272d680 = makeCons(sym_60, v0x7f411272d5e0);
-Obj v0x7f411272daa0 = makeCons(makeCString("primGenSym"), Nil);
-Obj v0x7f411272dac0 = makeCons(MAKE_NUMBER(0), v0x7f411272daa0);
-Obj v0x7f411272dae0 = makeCons(symgensym, v0x7f411272dac0);
-Obj v0x7f411272df00 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj v0x7f411272df20 = makeCons(MAKE_NUMBER(1), v0x7f411272df00);
-Obj v0x7f411272df60 = makeCons(symsymbol_63, v0x7f411272df20);
-Obj v0x7f41126cf380 = makeCons(makeCString("primNot"), Nil);
-Obj v0x7f41126cf3a0 = makeCons(MAKE_NUMBER(1), v0x7f41126cf380);
-Obj v0x7f41126cf3c0 = makeCons(symnot, v0x7f41126cf3a0);
-Obj v0x7f41126cf7e0 = makeCons(makeCString("primIsNumber"), Nil);
-Obj v0x7f41126cf820 = makeCons(MAKE_NUMBER(1), v0x7f41126cf7e0);
-Obj v0x7f41126cf840 = makeCons(syminteger_63, v0x7f41126cf820);
-Obj v0x7f41126cfbc0 = makeCons(makeCString("primIsString"), Nil);
-Obj v0x7f41126cfbe0 = makeCons(MAKE_NUMBER(1), v0x7f41126cfbc0);
-Obj v0x7f41126cfc00 = makeCons(symstring_63, v0x7f41126cfbe0);
-Obj v0x7f41126cfc40 = makeCons(v0x7f41126cfc00, Nil);
-Obj v0x7f41126cfc60 = makeCons(v0x7f41126cf840, v0x7f41126cfc40);
-Obj v0x7f41126cfca0 = makeCons(v0x7f41126cf3c0, v0x7f41126cfc60);
-Obj v0x7f41126cfcc0 = makeCons(v0x7f411272df60, v0x7f41126cfca0);
-Obj v0x7f41126cfce0 = makeCons(v0x7f411272dae0, v0x7f41126cfcc0);
-Obj v0x7f41126cfd00 = makeCons(v0x7f411272d680, v0x7f41126cfce0);
-Obj v0x7f41126cfd20 = makeCons(v0x7f411272d020, v0x7f41126cfd00);
-Obj v0x7f41126cfd40 = makeCons(v0x7f411273eb60, v0x7f41126cfd20);
-Obj v0x7f41126cfd60 = makeCons(v0x7f411273e520, v0x7f41126cfd40);
-Obj v0x7f41126cfd80 = makeCons(v0x7f411273e040, v0x7f41126cfd60);
-Obj v0x7f41126cfdc0 = makeCons(v0x7f4112743a20, v0x7f41126cfd80);
-Obj v0x7f41126cfde0 = makeCons(v0x7f4112743480, v0x7f41126cfdc0);
-Obj v0x7f41126cfe00 = makeCons(v0x7f41125cd420, v0x7f41126cfde0);
-Obj v0x7f41126cfe20 = makeCons(v0x7f41125cd0c0, v0x7f41126cfe00);
-Obj v0x7f41126cfe40 = makeCons(v0x7f41125cfd60, v0x7f41126cfe20);
-Obj v0x7f41126cfe60 = makeCons(v0x7f41125cfa00, v0x7f41126cfe40);
-Obj v0x7f41126cfe80 = makeCons(v0x7f41125cf6a0, v0x7f41126cfe60);
-Obj v0x7f41126cfea0 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, v0x7f41126cfe80);
-Obj v0x7f41126b52a0 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(24, clofun9, 1, 0));
-Obj v0x7f41126b56e0 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(21, clofun9, 1, 0));
-Obj v0x7f41126b5b20 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(18, clofun9, 1, 0));
-Obj v0x7f41126af3e0 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(15, clofun9, 2, 0));
-Obj v0x7f41126afa80 = primSet(co, symcora_47lib_47toc_35var_45with_45ns, makeNative(10, clofun9, 2, 0));
-Obj v0x7f41126a7c40 = primSet(co, symcora_47lib_47toc_35lookup_45var, makeNative(0, clofun9, 3, 0));
-Obj v0x7f41126afe60 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 5, 0));
-Obj v0x7f41126690e0 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
-Obj v0x7f411261b320 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
-Obj v0x7f41125ec7a0 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
-Obj v0x7f41126b5f80 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
-Obj v0x7f41125fee40 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
-Obj v0x7f41125fb240 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
-Obj v0x7f4112529720 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
-Obj v0x7f411273ece0 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
-Obj v0x7f4112603f80 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
-Obj v0x7f41125c16a0 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
-Obj v0x7f41125c02e0 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
-Obj v0x7f41125c0b80 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
-Obj v0x7f4112563c40 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
-Obj v0x7f411252c280 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
-Obj v0x7f4112570500 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
-Obj v0x7f4112512200 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
-Obj v0x7f41124eb7c0 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
-Obj v0x7f41124ebac0 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
-Obj v0x7f41124ebbe0 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
-Obj v0x7f41124d9240 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
-Obj v0x7f41124d98a0 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
-Obj v0x7f41124cb500 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
-Obj v0x7f41124cbfe0 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
-Obj v0x7f41124c4e20 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
-Obj v0x7f4112485ce0 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
-Obj v0x7f4112485f60 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
-Obj v0x7f411245b180 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
-Obj v0x7f411245b3a0 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
-Obj v0x7f411245b5c0 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
-Obj v0x7f411243c460 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
-Obj v0x7f411243cf80 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
+Obj x139973624519335 = __arg1;
+Obj x139973624519623 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
+Obj x139973624373415 = primSet(co, symcora_47lib_47toc_35assq, makeNative(19, clofun9, 2, 0));
+Obj x139973624376391 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(15, clofun9, 3, 0));
+Obj x139973624343943 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(11, clofun9, 3, 0));
+Obj x139973624344519 = primSet(co, symcora_47lib_47toc_35index, makeNative(10, clofun9, 2, 0));
+Obj x139973624277799 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(6, clofun9, 2, 0));
+Obj x139973624278823 = makeCons(makeCString("primSet"), Nil);
+Obj x139973624278855 = makeCons(MAKE_NUMBER(2), x139973624278823);
+Obj x139973624278887 = makeCons(symset, x139973624278855);
+Obj x139973624222375 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x139973624222439 = makeCons(MAKE_NUMBER(1), x139973624222375);
+Obj x139973624222471 = makeCons(symcar, x139973624222439);
+Obj x139973624223303 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x139973624223335 = makeCons(MAKE_NUMBER(1), x139973624223303);
+Obj x139973624223367 = makeCons(symcdr, x139973624223335);
+Obj x139973624224231 = makeCons(makeCString("makeCons"), Nil);
+Obj x139973624224263 = makeCons(MAKE_NUMBER(2), x139973624224231);
+Obj x139973624224295 = makeCons(symcons, x139973624224263);
+Obj x139973624225735 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x139973624225767 = makeCons(MAKE_NUMBER(1), x139973624225735);
+Obj x139973624078343 = makeCons(symcons_63, x139973624225767);
+Obj x139973624079175 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x139973624079207 = makeCons(MAKE_NUMBER(2), x139973624079175);
+Obj x139973624079239 = makeCons(sym_43, x139973624079207);
+Obj x139973624080103 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x139973624080135 = makeCons(MAKE_NUMBER(2), x139973624080103);
+Obj x139973624080167 = makeCons(sym_45, x139973624080135);
+Obj x139973624080999 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x139973624081031 = makeCons(MAKE_NUMBER(2), x139973624080999);
+Obj x139973624081063 = makeCons(sym_42, x139973624081031);
+Obj x139973624081927 = makeCons(makeCString("primDiv"), Nil);
+Obj x139973624081959 = makeCons(MAKE_NUMBER(2), x139973624081927);
+Obj x139973624081991 = makeCons(sym_47, x139973624081959);
+Obj x139973624000903 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x139973624000935 = makeCons(MAKE_NUMBER(2), x139973624000903);
+Obj x139973624000967 = makeCons(sym_61, x139973624000935);
+Obj x139973625852615 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x139973625852647 = makeCons(MAKE_NUMBER(2), x139973625852615);
+Obj x139973625852711 = makeCons(sym_62, x139973625852647);
+Obj x139973625853543 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x139973625853575 = makeCons(MAKE_NUMBER(2), x139973625853543);
+Obj x139973625853607 = makeCons(sym_60, x139973625853575);
+Obj x139973625854599 = makeCons(makeCString("primGenSym"), Nil);
+Obj x139973625854631 = makeCons(MAKE_NUMBER(0), x139973625854599);
+Obj x139973625854663 = makeCons(symgensym, x139973625854631);
+Obj x139973625855527 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x139973625855559 = makeCons(MAKE_NUMBER(1), x139973625855527);
+Obj x139973625855591 = makeCons(symsymbol_63, x139973625855559);
+Obj x139973625823655 = makeCons(makeCString("primNot"), Nil);
+Obj x139973625823687 = makeCons(MAKE_NUMBER(1), x139973625823655);
+Obj x139973625823719 = makeCons(symnot, x139973625823687);
+Obj x139973625824551 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x139973625824583 = makeCons(MAKE_NUMBER(1), x139973625824551);
+Obj x139973625824615 = makeCons(syminteger_63, x139973625824583);
+Obj x139973625825511 = makeCons(makeCString("primIsString"), Nil);
+Obj x139973625825543 = makeCons(MAKE_NUMBER(1), x139973625825511);
+Obj x139973625825575 = makeCons(symstring_63, x139973625825543);
+Obj x139973625825639 = makeCons(x139973625825575, Nil);
+Obj x139973625825671 = makeCons(x139973625824615, x139973625825639);
+Obj x139973625825703 = makeCons(x139973625823719, x139973625825671);
+Obj x139973625825735 = makeCons(x139973625855591, x139973625825703);
+Obj x139973625825767 = makeCons(x139973625854663, x139973625825735);
+Obj x139973625825831 = makeCons(x139973625853607, x139973625825767);
+Obj x139973625825863 = makeCons(x139973625852711, x139973625825831);
+Obj x139973625825895 = makeCons(x139973624000967, x139973625825863);
+Obj x139973625826055 = makeCons(x139973624081991, x139973625825895);
+Obj x139973625826087 = makeCons(x139973624081063, x139973625826055);
+Obj x139973625826119 = makeCons(x139973624080167, x139973625826087);
+Obj x139973625826151 = makeCons(x139973624079239, x139973625826119);
+Obj x139973625826183 = makeCons(x139973624078343, x139973625826151);
+Obj x139973625826215 = makeCons(x139973624224295, x139973625826183);
+Obj x139973625826247 = makeCons(x139973624223367, x139973625826215);
+Obj x139973625826279 = makeCons(x139973624222471, x139973625826247);
+Obj x139973625826311 = makeCons(x139973624278887, x139973625826279);
+Obj x139973625826375 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139973625826311);
+Obj x139973625788199 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(3, clofun9, 1, 0));
+Obj x139973625790023 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(0, clofun9, 1, 0));
+Obj x139973625029351 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(47, clofun8, 1, 0));
+Obj x139973625031751 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(44, clofun8, 2, 0));
+Obj x139973624000519 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 5, 0));
+Obj x139973623731207 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
+Obj x139973623686567 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
+Obj x139973624913959 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
+Obj x139973625853895 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
+Obj x139973624684967 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
+Obj x139973624686215 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
+Obj x139973623688295 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
+Obj x139973625825031 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
+Obj x139973624531911 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
+Obj x139973623686791 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
+Obj x139973623681383 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
+Obj x139973623683143 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
+Obj x139973623668359 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
+Obj x139973623649223 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
+Obj x139973623473447 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
+Obj x139973625853863 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
+Obj x139973625029671 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
+Obj x139973625030887 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
+Obj x139973625031591 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
+Obj x139973625013767 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
+Obj x139973624914407 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
+Obj x139973624891655 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
+Obj x139973624846631 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
+Obj x139973624640039 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
+Obj x139973624080007 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
+Obj x139973624081607 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
+Obj x139973624000999 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
+Obj x139973624001671 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
+Obj x139973624003047 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
+Obj x139973623733703 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
+Obj x139973623689031 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -478,21 +460,21 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41126cb360 = __arg1;
-Obj v0x7f41127439a0 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
-Obj v0x7f411272d9c0 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
-Obj v0x7f41126cb640 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
-Obj v0x7f41126afd40 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
-Obj v0x7f411261b140 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
-Obj v0x7f4112603c40 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
-Obj v0x7f41125fb760 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
-Obj v0x7f41125cfb40 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
-Obj v0x7f4112563d40 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
-Obj v0x7f4112563f00 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
-Obj v0x7f411252c3e0 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
-Obj v0x7f411252cfe0 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
+Obj x139973623682183 = __arg1;
+Obj x139973623684135 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
+Obj x139973623675399 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
+Obj x139973623666343 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
+Obj x139973623579751 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
+Obj x139973623521063 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
+Obj x139973623476199 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
+Obj x139973623427303 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
+Obj x139973622169959 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
+Obj x139973625789703 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
+Obj x139973625790343 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
+Obj x139973625030247 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
+Obj x139973625015271 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
 __nargs = 2;
-__arg1 = v0x7f411252cfe0;
+__arg1 = x139973625015271;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -502,9 +484,9 @@ label5:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-Obj v0x7f411252c6c0 = primGenSym();
-Obj globals = v0x7f411252c6c0;
-Obj v0x7f411252c800 = primSet(co, globals, Nil);
+Obj x139973625031367 = primGenSym();
+Obj globals = x139973625031367;
+Obj x139973625032135 = primSet(co, globals, Nil);
 pushCont(co, 6, clofun0, 3, from, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35compile);
@@ -518,11 +500,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f411252c9c0 = __arg1;
+Obj x139973625012327 = __arg1;
 Obj from= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun0, 3, v0x7f411252c9c0, to, globals);
+pushCont(co, 7, clofun0, 3, x139973625012327, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35preprocess);
 __arg1 = from;
@@ -535,14 +517,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411252cc00 = __arg1;
-Obj v0x7f411252c9c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973625013447 = __arg1;
+Obj x139973625012327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun0, 3, v0x7f411252c9c0, to, globals);
+pushCont(co, 8, clofun0, 3, x139973625012327, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand);
-__arg1 = v0x7f411252cc00;
+__arg1 = x139973625013447;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -552,14 +534,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f411252cc20 = __arg1;
-Obj v0x7f411252c9c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973625013479 = __arg1;
+Obj x139973625012327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 9, clofun0, 2, to, globals);
 __nargs = 2;
-__arg0 = v0x7f411252c9c0;
-__arg1 = v0x7f411252cc20;
+__arg0 = x139973625012327;
+__arg1 = x139973625013479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -569,10 +551,10 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f411252cc40 = __arg1;
+Obj x139973625013511 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj bc = v0x7f411252cc40;
+Obj bc = x139973625013511;
 pushCont(co, 10, clofun0, 2, bc, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35open_45output_45file);
@@ -586,10 +568,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f411252cd40 = __arg1;
+Obj x139973625014151 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stream = v0x7f411252cd40;
+Obj stream = x139973625014151;
 pushCont(co, 11, clofun0, 1, stream);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45c);
@@ -605,7 +587,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f411252cf20 = __arg1;
+Obj x139973625014855 = __arg1;
 Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35close_45output_45file);
@@ -633,8 +615,8 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f411252c2a0 = __arg1;
-Obj sexp = v0x7f411252c2a0;
+Obj x139973625029863 = __arg1;
+Obj sexp = x139973625029863;
 pushCont(co, 14, clofun0, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -648,7 +630,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f411252c3c0 = __arg1;
+Obj x139973625030215 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
@@ -659,16 +641,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj v0x7f411272d300 = __arg1;
-Obj v0x7f411272d320 = __arg2;
-Obj v0x7f411272d340 = __arg3;
-Obj v0x7f411272d360 = co->args[4];
-Obj v0x7f411272d600 = makeNative(18, clofun0, 0, 4, v0x7f411272d300, v0x7f411272d320, v0x7f411272d340, v0x7f411272d360);
-Obj v0x7f4112563840 = PRIM_EQ(Nil, v0x7f411272d300);
-if (True == v0x7f4112563840) {
-Obj type = v0x7f411272d320;
-Obj code = v0x7f411272d340;
-Obj k = v0x7f411272d360;
+Obj x139973624846183 = __arg1;
+Obj x139973624846215 = __arg2;
+Obj x139973624846247 = __arg3;
+Obj x139973624846279 = co->args[4];
+Obj x139973624847015 = makeNative(18, clofun0, 0, 4, x139973624846183, x139973624846215, x139973624846247, x139973624846279);
+Obj x139973625787335 = PRIM_EQ(Nil, x139973624846183);
+if (True == x139973625787335) {
+Obj type = x139973624846215;
+Obj code = x139973624846247;
+Obj k = x139973624846279;
 pushCont(co, 16, clofun0, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -680,7 +662,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d600;
+__arg0 = x139973624847015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -691,10 +673,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f4112563b20 = __arg1;
+Obj x139973625788295 = __arg1;
 Obj code= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 17, clofun0, 2, k, v0x7f4112563b20);
+pushCont(co, 17, clofun0, 2, k, x139973625788295);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
 __arg1 = code;
@@ -707,13 +689,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f4112563ca0 = __arg1;
+Obj x139973625789447 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112563b20= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139973625788295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = k;
-__arg1 = v0x7f4112563b20;
-__arg2 = v0x7f4112563ca0;
+__arg1 = x139973625788295;
+__arg2 = x139973625789447;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -723,30 +705,30 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f411272d960 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f4112570580 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112570580) {
-Obj v0x7f41125707a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125707e0 = PRIM_ISCONS(v0x7f41125707a0);
-if (True == v0x7f41125707e0) {
-Obj v0x7f4112570b20 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112570b40 = PRIM_CAR(v0x7f4112570b20);
-Obj v0x7f4112570b60 = PRIM_EQ(sym_58type, v0x7f4112570b40);
-if (True == v0x7f4112570b60) {
-Obj v0x7f4112570de0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112570e00 = PRIM_CDR(v0x7f4112570de0);
-Obj exp = v0x7f4112570e00;
-Obj v0x7f4112570f60 = PRIM_CDR(closureRef(co, 0));
-Obj more = v0x7f4112570f60;
+Obj x139973624848071 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973622145831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973622145831) {
+Obj x139973625852135 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625852231 = PRIM_ISCONS(x139973625852135);
+if (True == x139973625852231) {
+Obj x139973625853671 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625853703 = PRIM_CAR(x139973625853671);
+Obj x139973625853831 = PRIM_EQ(sym_58type, x139973625853703);
+if (True == x139973625853831) {
+Obj x139973625854535 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625854823 = PRIM_CDR(x139973625854535);
+Obj exp = x139973625854823;
+Obj x139973625855143 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139973625855143;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj v0x7f4112563440 = makeCons(symbegin, exp);
-Obj v0x7f4112563480 = makeCons(v0x7f4112563440, type);
+Obj x139973625823751 = makeCons(symbegin, exp);
+Obj x139973625824039 = makeCons(x139973625823751, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = v0x7f4112563480;
+__arg2 = x139973625824039;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -756,7 +738,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d960;
+__arg0 = x139973624848071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -765,7 +747,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d960;
+__arg0 = x139973624848071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -774,7 +756,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d960;
+__arg0 = x139973624848071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -785,30 +767,30 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f411272dda0 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41125c0060 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125c0060) {
-Obj v0x7f41125c0300 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125c0320 = PRIM_ISCONS(v0x7f41125c0300);
-if (True == v0x7f41125c0320) {
-Obj v0x7f41125c06e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125c0700 = PRIM_CAR(v0x7f41125c06e0);
-Obj v0x7f41125c0760 = PRIM_EQ(sym_58declare, v0x7f41125c0700);
-if (True == v0x7f41125c0760) {
-Obj v0x7f41125c0a00 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125c0a20 = PRIM_CDR(v0x7f41125c0a00);
-Obj exp = v0x7f41125c0a20;
-Obj v0x7f41125c0c40 = PRIM_CDR(closureRef(co, 0));
-Obj more = v0x7f41125c0c40;
+Obj x139973624685735 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973622162951 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973622162951) {
+Obj x139973622163367 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622163399 = PRIM_ISCONS(x139973622163367);
+if (True == x139973622163399) {
+Obj x139973622164007 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622164039 = PRIM_CAR(x139973622164007);
+Obj x139973622164071 = PRIM_EQ(sym_58declare, x139973622164039);
+if (True == x139973622164071) {
+Obj x139973622164487 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622164519 = PRIM_CDR(x139973622164487);
+Obj exp = x139973622164519;
+Obj x139973622164775 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139973622164775;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj v0x7f4112570120 = makeCons(symdeclare, exp);
-Obj v0x7f4112570240 = makeCons(v0x7f4112570120, type);
+Obj x139973622145063 = makeCons(symdeclare, exp);
+Obj x139973622145127 = makeCons(x139973622145063, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = v0x7f4112570240;
+__arg2 = x139973622145127;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -818,7 +800,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dda0;
+__arg0 = x139973624685735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -827,7 +809,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dda0;
+__arg0 = x139973624685735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -836,7 +818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dda0;
+__arg0 = x139973624685735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -847,33 +829,33 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f41126cf1c0 = makeNative(21, clofun0, 0, 0);
-Obj v0x7f41125cd540 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cd540) {
-Obj v0x7f41125cd7c0 = PRIM_CAR(closureRef(co, 0));
-Obj exp = v0x7f41125cd7c0;
-Obj v0x7f41125cd8e0 = PRIM_CDR(closureRef(co, 0));
-Obj more = v0x7f41125cd8e0;
+Obj x139973624687239 = makeNative(21, clofun0, 0, 0);
+Obj x139973622171207 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973622171207) {
+Obj x139973622171463 = PRIM_CAR(closureRef(co, 0));
+Obj exp = x139973622171463;
+Obj x139973622171719 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139973622171719;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj v0x7f41125c1460 = makeCons(exp, Nil);
-Obj v0x7f41125c1480 = makeCons(symbackquote, v0x7f41125c1460);
-Obj v0x7f41125c14c0 = makeCons(v0x7f41125c1480, Nil);
-Obj v0x7f41125c14e0 = makeCons(symmacroexpand, v0x7f41125c14c0);
-Obj v0x7f41125c17c0 = makeCons(symtvar, Nil);
-Obj v0x7f41125c1ae0 = makeCons(Nil, Nil);
-Obj v0x7f41125c1b00 = makeCons(Nil, v0x7f41125c1ae0);
-Obj v0x7f41125c1b20 = makeCons(v0x7f41125c17c0, v0x7f41125c1b00);
-Obj v0x7f41125c1b40 = makeCons(v0x7f41125c14e0, v0x7f41125c1b20);
-Obj v0x7f41125c1b60 = makeCons(symcora_47lib_47infer_35check_45type, v0x7f41125c1b40);
-Obj v0x7f41125c1c20 = makeCons(v0x7f41125c1b60, type);
-Obj v0x7f41125c1e00 = makeCons(exp, code);
+Obj x139973622173383 = makeCons(exp, Nil);
+Obj x139973622173415 = makeCons(symbackquote, x139973622173383);
+Obj x139973622173479 = makeCons(x139973622173415, Nil);
+Obj x139973622173511 = makeCons(symmacroexpand, x139973622173479);
+Obj x139973622161639 = makeCons(symtvar, Nil);
+Obj x139973622162087 = makeCons(Nil, Nil);
+Obj x139973622162119 = makeCons(Nil, x139973622162087);
+Obj x139973622162151 = makeCons(x139973622161639, x139973622162119);
+Obj x139973622162183 = makeCons(x139973622173511, x139973622162151);
+Obj x139973622162215 = makeCons(symcora_47lib_47infer_35check_45type, x139973622162183);
+Obj x139973622162279 = makeCons(x139973622162215, type);
+Obj x139973622162535 = makeCons(exp, code);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = v0x7f41125c1c20;
-__arg3 = v0x7f41125c1e00;
+__arg2 = x139973622162279;
+__arg3 = x139973622162535;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -882,7 +864,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1c0;
+__arg0 = x139973624687239;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -905,22 +887,22 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f411273e3a0 = __arg1;
-Obj v0x7f411273e420 = makeNative(23, clofun0, 0, 1, v0x7f411273e3a0);
-Obj v0x7f41125d27c0 = PRIM_ISCONS(v0x7f411273e3a0);
-if (True == v0x7f41125d27c0) {
-Obj v0x7f41125d2b80 = PRIM_CAR(v0x7f411273e3a0);
-Obj v0x7f41125d2ba0 = PRIM_EQ(symdefine_45library, v0x7f41125d2b80);
-if (True == v0x7f41125d2ba0) {
-Obj v0x7f41125d2ec0 = PRIM_CDR(v0x7f411273e3a0);
-Obj v0x7f41125d2ee0 = PRIM_ISCONS(v0x7f41125d2ec0);
-if (True == v0x7f41125d2ee0) {
-Obj v0x7f41125cf2e0 = PRIM_CDR(v0x7f411273e3a0);
-Obj v0x7f41125cf300 = PRIM_CAR(v0x7f41125cf2e0);
-Obj __ = v0x7f41125cf300;
-Obj v0x7f41125cf5e0 = PRIM_CDR(v0x7f411273e3a0);
-Obj v0x7f41125cf600 = PRIM_CDR(v0x7f41125cf5e0);
-Obj remain = v0x7f41125cf600;
+Obj x139973624890791 = __arg1;
+Obj x139973624891015 = makeNative(23, clofun0, 0, 1, x139973624890791);
+Obj x139973622208519 = PRIM_ISCONS(x139973624890791);
+if (True == x139973622208519) {
+Obj x139973622208967 = PRIM_CAR(x139973624890791);
+Obj x139973622208999 = PRIM_EQ(symdefine_45library, x139973622208967);
+if (True == x139973622208999) {
+Obj x139973622209415 = PRIM_CDR(x139973624890791);
+Obj x139973622209447 = PRIM_ISCONS(x139973622209415);
+if (True == x139973622209447) {
+Obj x139973622209863 = PRIM_CDR(x139973624890791);
+Obj x139973622209895 = PRIM_CAR(x139973622209863);
+Obj __ = x139973622209895;
+Obj x139973622210311 = PRIM_CDR(x139973624890791);
+Obj x139973622210343 = PRIM_CDR(x139973622210311);
+Obj remain = x139973622210343;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -931,7 +913,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e420;
+__arg0 = x139973624891015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -940,7 +922,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e420;
+__arg0 = x139973624891015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -949,7 +931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e420;
+__arg0 = x139973624891015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -960,14 +942,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f411273e6a0 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d6da0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d6da0) {
-Obj v0x7f41125d20a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d20c0 = PRIM_EQ(symbegin, v0x7f41125d20a0);
-if (True == v0x7f41125d20c0) {
-Obj v0x7f41125d2280 = PRIM_CDR(closureRef(co, 0));
-Obj remain = v0x7f41125d2280;
+Obj x139973624891783 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
+Obj x139973622207111 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973622207111) {
+Obj x139973622207559 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622207591 = PRIM_EQ(symbegin, x139973622207559);
+if (True == x139973622207591) {
+Obj x139973622207847 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139973622207847;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -978,7 +960,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e6a0;
+__arg0 = x139973624891783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -987,7 +969,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e6a0;
+__arg0 = x139973624891783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -998,21 +980,21 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f411273e860 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125e5940 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125e5940) {
-Obj v0x7f41125e5cc0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125e5ce0 = PRIM_ISCONS(v0x7f41125e5cc0);
-if (True == v0x7f41125e5ce0) {
-Obj v0x7f41125d6060 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d6080 = PRIM_CAR(v0x7f41125d6060);
-Obj v0x7f41125d6100 = PRIM_EQ(symexport, v0x7f41125d6080);
-if (True == v0x7f41125d6100) {
-Obj v0x7f41125d6540 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d6560 = PRIM_CDR(v0x7f41125d6540);
-Obj more = v0x7f41125d6560;
-Obj v0x7f41125d67a0 = PRIM_CDR(closureRef(co, 0));
-Obj remain = v0x7f41125d67a0;
+Obj x139973624892455 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
+Obj x139973622224967 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973622224967) {
+Obj x139973622225383 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622225415 = PRIM_ISCONS(x139973622225383);
+if (True == x139973622225415) {
+Obj x139973622226023 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622226055 = PRIM_CAR(x139973622226023);
+Obj x139973622226087 = PRIM_EQ(symexport, x139973622226055);
+if (True == x139973622226087) {
+Obj x139973622226503 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622226535 = PRIM_CDR(x139973622226503);
+Obj more = x139973622226535;
+Obj x139973622226791 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139973622226791;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -1023,7 +1005,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e860;
+__arg0 = x139973624892455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1032,7 +1014,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e860;
+__arg0 = x139973624892455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1041,7 +1023,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e860;
+__arg0 = x139973624892455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1052,31 +1034,31 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f411273ebe0 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
-Obj v0x7f41125ec320 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125ec320) {
-Obj v0x7f41125ec580 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125ec5a0 = PRIM_ISCONS(v0x7f41125ec580);
-if (True == v0x7f41125ec5a0) {
-Obj v0x7f41125eca40 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125eca60 = PRIM_CAR(v0x7f41125eca40);
-Obj v0x7f41125eca80 = PRIM_EQ(symimport, v0x7f41125eca60);
-if (True == v0x7f41125eca80) {
-Obj v0x7f41125ecee0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125ecf00 = PRIM_CDR(v0x7f41125ecee0);
-Obj v0x7f41125ecf40 = PRIM_ISCONS(v0x7f41125ecf00);
-if (True == v0x7f41125ecf40) {
-Obj v0x7f41125e7460 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125e7480 = PRIM_CDR(v0x7f41125e7460);
-Obj v0x7f41125e74a0 = PRIM_CAR(v0x7f41125e7480);
-Obj pkg = v0x7f41125e74a0;
-Obj v0x7f41125e7b00 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125e7b40 = PRIM_CDR(v0x7f41125e7b00);
-Obj v0x7f41125e7c20 = PRIM_CDR(v0x7f41125e7b40);
-Obj v0x7f41125e7c40 = PRIM_EQ(Nil, v0x7f41125e7c20);
-if (True == v0x7f41125e7c40) {
-Obj v0x7f41125e7de0 = PRIM_CDR(closureRef(co, 0));
-Obj remain = v0x7f41125e7de0;
+Obj x139973624893255 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
+Obj x139973623420263 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623420263) {
+Obj x139973623420679 = PRIM_CAR(closureRef(co, 0));
+Obj x139973623420711 = PRIM_ISCONS(x139973623420679);
+if (True == x139973623420711) {
+Obj x139973623421319 = PRIM_CAR(closureRef(co, 0));
+Obj x139973623421351 = PRIM_CAR(x139973623421319);
+Obj x139973623421383 = PRIM_EQ(symimport, x139973623421351);
+if (True == x139973623421383) {
+Obj x139973623421959 = PRIM_CAR(closureRef(co, 0));
+Obj x139973623421991 = PRIM_CDR(x139973623421959);
+Obj x139973623422023 = PRIM_ISCONS(x139973623421991);
+if (True == x139973623422023) {
+Obj x139973623422599 = PRIM_CAR(closureRef(co, 0));
+Obj x139973623422631 = PRIM_CDR(x139973623422599);
+Obj x139973623422663 = PRIM_CAR(x139973623422631);
+Obj pkg = x139973623422663;
+Obj x139973622223303 = PRIM_CAR(closureRef(co, 0));
+Obj x139973622223335 = PRIM_CDR(x139973622223303);
+Obj x139973622223367 = PRIM_CDR(x139973622223335);
+Obj x139973622223399 = PRIM_EQ(Nil, x139973622223367);
+if (True == x139973622223399) {
+Obj x139973622223655 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139973622223655;
 pushCont(co, 26, clofun0, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -1088,7 +1070,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ebe0;
+__arg0 = x139973624893255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1097,7 +1079,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ebe0;
+__arg0 = x139973624893255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1106,7 +1088,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ebe0;
+__arg0 = x139973624893255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1115,7 +1097,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ebe0;
+__arg0 = x139973624893255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1124,7 +1106,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ebe0;
+__arg0 = x139973624893255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1135,7 +1117,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f41125e5000 = __arg1;
+Obj x139973622223911 = __arg1;
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -1149,7 +1131,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f411273eee0 = makeNative(28, clofun0, 0, 0);
+Obj x139973624845095 = makeNative(28, clofun0, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
@@ -1191,11 +1173,11 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f41125fe200 = __arg1;
+Obj x139973623452423 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups = v0x7f41125fe200;
+Obj groups = x139973623452423;
 pushCont(co, 31, clofun0, 3, globals, to, groups);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -1209,11 +1191,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f41125fe3a0 = __arg1;
+Obj x139973623452679 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj maxid = v0x7f41125fe3a0;
+Obj maxid = x139973623452679;
 pushCont(co, 32, clofun0, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1228,7 +1210,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f41125fe4c0 = __arg1;
+Obj x139973623452967 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1247,7 +1229,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41125fe7e0 = __arg1;
+Obj x139973623453383 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1266,7 +1248,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f41125fee20 = __arg1;
+Obj x139973623454567 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1285,7 +1267,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41125fb080 = __arg1;
+Obj x139973623454887 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1303,7 +1285,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41125fb420 = __arg1;
+Obj x139973623455399 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1311,7 +1293,7 @@ pushCont(co, 37, clofun0, 3, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45entry);
 __arg1 = to;
-__arg2 = v0x7f41125fb420;
+__arg2 = x139973623455399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1321,7 +1303,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41125fb4c0 = __arg1;
+Obj x139973623455431 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1367,12 +1349,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41125fec40 = __arg1;
+Obj x139973623454215 = __arg1;
 PUSH_CONT_0(co, 41, clofun0);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = closureRef(co, 1);
-__arg2 = v0x7f41125fec40;
+__arg2 = x139973623454215;
 __arg3 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1383,7 +1365,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj v0x7f41125feca0 = __arg1;
+Obj x139973623454279 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 1);
@@ -1413,7 +1395,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f411261bcc0 = __arg1;
+Obj x139973623473575 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 44, clofun0, 2, globals, to);
@@ -1430,7 +1412,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f411261be00 = __arg1;
+Obj x139973623473863 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 45, clofun0, 1, to);
@@ -1447,7 +1429,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f4112603b40 = __arg1;
+Obj x139973623475975 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1477,7 +1459,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj v0x7f41126031e0 = __arg1;
+Obj x139973623474471 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 48, clofun0, 1, sym);
 __nargs = 3;
@@ -1493,7 +1475,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f4112603480 = __arg1;
+Obj x139973623474759 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun0, 1, sym);
 __nargs = 3;
@@ -1509,7 +1491,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f4112603660 = __arg1;
+Obj x139973623475111 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
@@ -1544,12 +1526,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f4112603960 = __arg1;
+Obj x139973623475623 = __arg1;
 PUSH_CONT_0(co, 1, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
-__arg2 = v0x7f4112603960;
+__arg2 = x139973623475623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1559,7 +1541,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f4112603980 = __arg1;
+Obj x139973623475655 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1588,7 +1570,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f411261b860 = __arg1;
+Obj x139973623472999 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 4, clofun1);
 __nargs = 3;
@@ -1604,7 +1586,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f411261b9c0 = __arg1;
+Obj x139973623473287 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1618,16 +1600,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f4112743620 = __arg1;
-Obj v0x7f4112743640 = __arg2;
-Obj v0x7f4112743660 = __arg3;
-Obj v0x7f4112743680 = co->args[4];
-Obj v0x7f4112743820 = makeNative(8, clofun1, 0, 4, v0x7f4112743620, v0x7f4112743640, v0x7f4112743660, v0x7f4112743680);
-Obj res = v0x7f4112743620;
-Obj idx = v0x7f4112743640;
-Obj acc = v0x7f4112743660;
-Obj v0x7f4112669920 = PRIM_EQ(Nil, v0x7f4112743680);
-if (True == v0x7f4112669920) {
+Obj x139973624915527 = __arg1;
+Obj x139973624915559 = __arg2;
+Obj x139973624915591 = __arg3;
+Obj x139973624915623 = co->args[4];
+Obj x139973624916455 = makeNative(8, clofun1, 0, 4, x139973624915527, x139973624915559, x139973624915591, x139973624915623);
+Obj res = x139973624915527;
+Obj idx = x139973624915559;
+Obj acc = x139973624915591;
+Obj x139973623519591 = PRIM_EQ(Nil, x139973624915623);
+if (True == x139973623519591) {
 pushCont(co, 6, clofun1, 2, acc, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -1639,7 +1621,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743820;
+__arg0 = x139973624916455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1650,11 +1632,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f4112669dc0 = __arg1;
+Obj x139973623520359 = __arg1;
 Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112669e00 = primNot(v0x7f4112669dc0);
-if (True == v0x7f4112669e00) {
+Obj x139973623520391 = primNot(x139973623520359);
+if (True == x139973623520391) {
 pushCont(co, 7, clofun1, 1, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1678,12 +1660,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411261b060 = __arg1;
+Obj x139973623520839 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411261b0a0 = makeCons(v0x7f411261b060, res);
+Obj x139973623520903 = makeCons(x139973623520839, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = v0x7f411261b0a0;
+__arg1 = x139973623520903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1693,18 +1675,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f4112743ca0 = makeNative(10, clofun1, 0, 0);
+Obj x139973624917511 = makeNative(10, clofun1, 0, 0);
 Obj res = closureRef(co, 0);
 Obj idx = closureRef(co, 1);
 Obj acc = closureRef(co, 2);
-Obj v0x7f41126a75c0 = PRIM_ISCONS(closureRef(co, 3));
-if (True == v0x7f41126a75c0) {
-Obj v0x7f41126a76e0 = PRIM_CAR(closureRef(co, 3));
-Obj bc = v0x7f41126a76e0;
-Obj v0x7f41126a7960 = PRIM_CDR(closureRef(co, 3));
-Obj more = v0x7f41126a7960;
-Obj v0x7f41126a7b40 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-if (True == v0x7f41126a7b40) {
+Obj x139973623581415 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139973623581415) {
+Obj x139973623581735 = PRIM_CAR(closureRef(co, 3));
+Obj bc = x139973623581735;
+Obj x139973623582055 = PRIM_CDR(closureRef(co, 3));
+Obj more = x139973623582055;
+Obj x139973623582375 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+if (True == x139973623582375) {
 pushCont(co, 9, clofun1, 3, res, bc, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1715,13 +1697,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f4112669360 = PRIM_ADD(idx, MAKE_NUMBER(1));
-Obj v0x7f4112669460 = makeCons(bc, acc);
+Obj x139973623518503 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj x139973623518759 = makeCons(bc, acc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
 __arg1 = res;
-__arg2 = v0x7f4112669360;
-__arg3 = v0x7f4112669460;
+__arg2 = x139973623518503;
+__arg3 = x139973623518759;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1731,7 +1713,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743ca0;
+__arg0 = x139973624917511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1742,18 +1724,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f41126a7e20 = __arg1;
+Obj x139973623517479 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41126a7f00 = makeCons(v0x7f41126a7e20, res);
-Obj v0x7f41126690a0 = makeCons(bc, more);
+Obj x139973623517543 = makeCons(x139973623517479, res);
+Obj x139973623517959 = makeCons(bc, more);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = v0x7f41126a7f00;
+__arg1 = x139973623517543;
 __arg2 = MAKE_NUMBER(0);
 __arg3 = Nil;
-co->args[4] = v0x7f41126690a0;
+co->args[4] = x139973623517959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1791,7 +1773,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f41126cb940 = __arg1;
+Obj x139973623667303 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1799,7 +1781,7 @@ pushCont(co, 13, clofun1, 3, maxid, group, to);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = to;
-__arg2 = v0x7f41126cb940;
+__arg2 = x139973623667303;
 __arg3 = maxid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1810,7 +1792,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f41126cb980 = __arg1;
+Obj x139973623667367 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1828,7 +1810,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f41126cbaa0 = __arg1;
+Obj x139973623667719 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1846,7 +1828,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f41126cbbc0 = __arg1;
+Obj x139973623668007 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1864,7 +1846,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f41126cbce0 = __arg1;
+Obj x139973623668391 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1882,7 +1864,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f41126cbe00 = __arg1;
+Obj x139973623668679 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1900,7 +1882,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41126cbf20 = __arg1;
+Obj x139973623648519 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1918,7 +1900,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f41126b50a0 = __arg1;
+Obj x139973623648871 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1936,7 +1918,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f41126b5380 = __arg1;
+Obj x139973623649255 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1953,7 +1935,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f41126b5780 = __arg1;
+Obj x139973623649895 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1962,7 +1944,7 @@ __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = v0x7f41126b5780;
+__arg3 = x139973623649895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1972,7 +1954,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f41126b57c0 = __arg1;
+Obj x139973623649927 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1990,7 +1972,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f41126b5a00 = __arg1;
+Obj x139973623650215 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2008,7 +1990,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f41126b5b80 = __arg1;
+Obj x139973623650567 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2026,7 +2008,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f41126b5f40 = __arg1;
+Obj x139973623651239 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 26, clofun1, 1, to);
 __nargs = 3;
@@ -2042,7 +2024,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f41126af200 = __arg1;
+Obj x139973623651591 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 27, clofun1, 1, to);
 __nargs = 3;
@@ -2058,7 +2040,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f41126af360 = __arg1;
+Obj x139973623651879 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun1, 1, to);
 __nargs = 3;
@@ -2074,7 +2056,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj v0x7f41126af560 = __arg1;
+Obj x139973623652199 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun1, 1, to);
 __nargs = 3;
@@ -2090,7 +2072,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj v0x7f41126af780 = __arg1;
+Obj x139973623578791 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun1, 1, to);
 __nargs = 3;
@@ -2106,7 +2088,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f41126af900 = __arg1;
+Obj x139973623579175 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun1, 1, to);
 __nargs = 3;
@@ -2122,7 +2104,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f41126afb00 = __arg1;
+Obj x139973623579527 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2155,8 +2137,8 @@ label33:
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj v0x7f411272dea0 = PRIM_EQ(i, MAKE_NUMBER(0));
-if (True == v0x7f411272dea0) {
+Obj x139973623676423 = PRIM_EQ(i, MAKE_NUMBER(0));
+if (True == x139973623676423) {
 pushCont(co, 36, clofun1, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2168,8 +2150,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41126cf540 = PRIM_LT(i, n);
-if (True == v0x7f41126cf540) {
+Obj x139973623665095 = PRIM_LT(i, n);
+if (True == x139973623665095) {
 pushCont(co, 34, clofun1, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2192,7 +2174,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj v0x7f41126cf7a0 = __arg1;
+Obj x139973623665415 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2210,15 +2192,15 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41126cfa00 = __arg1;
+Obj x139973623665767 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41126cffe0 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139973623666279 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
-__arg2 = v0x7f41126cffe0;
+__arg2 = x139973623666279;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2229,7 +2211,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41126cf1a0 = __arg1;
+Obj x139973623676775 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2246,12 +2228,12 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41126cf680 = __arg1;
-Obj v0x7f41126cf6a0 = __arg2;
-Obj v0x7f41126cf7c0 = makeNative(38, clofun1, 0, 2, v0x7f41126cf680, v0x7f41126cf6a0);
-Obj fn = v0x7f41126cf680;
-Obj v0x7f411272d8c0 = PRIM_EQ(Nil, v0x7f41126cf6a0);
-if (True == v0x7f411272d8c0) {
+Obj x139973625015047 = __arg1;
+Obj x139973625015079 = __arg2;
+Obj x139973625015559 = makeNative(38, clofun1, 0, 2, x139973625015047, x139973625015079);
+Obj fn = x139973625015047;
+Obj x139973623675207 = PRIM_EQ(Nil, x139973625015079);
+if (True == x139973623675207) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2259,7 +2241,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf7c0;
+__arg0 = x139973625015559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2270,14 +2252,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41126cf940 = makeNative(40, clofun1, 0, 0);
+Obj x139973625016167 = makeNative(40, clofun1, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj v0x7f411273e620 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f411273e620) {
-Obj v0x7f411273e8e0 = PRIM_CAR(closureRef(co, 1));
-Obj x = v0x7f411273e8e0;
-Obj v0x7f411273ef20 = PRIM_CDR(closureRef(co, 1));
-Obj y = v0x7f411273ef20;
+Obj x139973623673191 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973623673191) {
+Obj x139973623673543 = PRIM_CAR(closureRef(co, 1));
+Obj x = x139973623673543;
+Obj x139973623673991 = PRIM_CDR(closureRef(co, 1));
+Obj y = x139973623673991;
 pushCont(co, 39, clofun1, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
@@ -2289,7 +2271,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf940;
+__arg0 = x139973625016167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2300,7 +2282,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f411272d0e0 = __arg1;
+Obj x139973623674375 = __arg1;
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -2343,11 +2325,11 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f4112743720 = __arg1;
+Obj x139973623683911 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun1);
 __nargs = 2;
-__arg0 = v0x7f4112743720;
+__arg0 = x139973623683911;
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2358,11 +2340,11 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41127437e0 = __arg1;
+Obj x139973623683975 = __arg1;
 PUSH_CONT_0(co, 44, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert_45pass);
-__arg1 = v0x7f41127437e0;
+__arg1 = x139973623683975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2372,11 +2354,11 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f4112743800 = __arg1;
+Obj x139973623684039 = __arg1;
 PUSH_CONT_0(co, 45, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45pass);
-__arg1 = v0x7f4112743800;
+__arg1 = x139973623684039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2386,11 +2368,11 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f41127438e0 = __arg1;
+Obj x139973623684071 = __arg1;
 PUSH_CONT_0(co, 46, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack_45pass);
-__arg1 = v0x7f41127438e0;
+__arg1 = x139973623684071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2400,10 +2382,10 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f4112743980 = __arg1;
+Obj x139973623684103 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda_45pass);
-__arg1 = v0x7f4112743980;
+__arg1 = x139973623684103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2427,9 +2409,9 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f41126cb180 = __arg1;
+Obj x139973623681607 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj obj = v0x7f41126cb180;
+Obj obj = x139973623681607;
 pushCont(co, 49, clofun1, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35cddr);
@@ -2443,9 +2425,9 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f41126cb280 = __arg1;
+Obj x139973623681863 = __arg1;
 Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fns = v0x7f41126cb280;
+Obj fns = x139973623681863;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
 __arg1 = obj;
@@ -2479,12 +2461,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f41126cf080 = __arg1;
-Obj v0x7f41126cf0a0 = __arg2;
-Obj v0x7f41126cf160 = makeNative(1, clofun2, 0, 2, v0x7f41126cf080, v0x7f41126cf0a0);
-Obj obj = v0x7f41126cf080;
-Obj v0x7f411243cee0 = PRIM_EQ(Nil, v0x7f41126cf0a0);
-if (True == v0x7f411243cee0) {
+Obj x139973625012775 = __arg1;
+Obj x139973625012807 = __arg2;
+Obj x139973625013223 = makeNative(1, clofun2, 0, 2, x139973625012775, x139973625012807);
+Obj obj = x139973625012775;
+Obj x139973623688711 = PRIM_EQ(Nil, x139973625012807);
+if (True == x139973623688711) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2492,7 +2474,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf160;
+__arg0 = x139973625013223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2503,19 +2485,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f41126cf320 = makeNative(2, clofun2, 0, 0);
+Obj x139973625013799 = makeNative(2, clofun2, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj v0x7f411243c880 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f411243c880) {
-Obj v0x7f411243c980 = PRIM_CAR(closureRef(co, 1));
-Obj hd = v0x7f411243c980;
-Obj v0x7f411243ca80 = PRIM_CDR(closureRef(co, 1));
-Obj more = v0x7f411243ca80;
-Obj v0x7f411243ccc0 = makeCons(obj, Nil);
-Obj v0x7f411243cce0 = makeCons(hd, v0x7f411243ccc0);
+Obj x139973623686311 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973623686311) {
+Obj x139973623686663 = PRIM_CAR(closureRef(co, 1));
+Obj hd = x139973623686663;
+Obj x139973623687175 = PRIM_CDR(closureRef(co, 1));
+Obj more = x139973623687175;
+Obj x139973623687943 = makeCons(obj, Nil);
+Obj x139973623687975 = makeCons(hd, x139973623687943);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = v0x7f411243cce0;
+__arg1 = x139973623687975;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2524,7 +2506,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf320;
+__arg0 = x139973625013799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2561,9 +2543,9 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f411245b800 = __arg1;
+Obj x139973624004103 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = v0x7f411245b800;
+Obj v = x139973624004103;
 pushCont(co, 5, clofun2, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
@@ -2579,7 +2561,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f411245b940 = __arg1;
+Obj x139973623730343 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 6, clofun2, 2, exp, v);
@@ -2597,7 +2579,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f411245ba80 = __arg1;
+Obj x139973623730759 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 7, clofun2, 1, v);
@@ -2614,18 +2596,18 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411245bba0 = __arg1;
+Obj x139973623731079 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1 = v0x7f411245bba0;
-Obj v0x7f411245bfc0 = makeCons(e1, Nil);
-Obj v0x7f411245bfe0 = makeCons(Nil, v0x7f411245bfc0);
-Obj v0x7f411243c340 = makeCons(Nil, v0x7f411245bfe0);
-Obj v0x7f411243c360 = makeCons(symlambda, v0x7f411243c340);
+Obj e1 = x139973623731079;
+Obj x139973623733095 = makeCons(e1, Nil);
+Obj x139973623733127 = makeCons(Nil, x139973623733095);
+Obj x139973623733159 = makeCons(Nil, x139973623733127);
+Obj x139973623733191 = makeCons(symlambda, x139973623733159);
 pushCont(co, 8, clofun2, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f411243c360;
+__arg2 = x139973623733191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2635,7 +2617,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f411243c380 = __arg1;
+Obj x139973623733223 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -2710,76 +2692,76 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f411272d420 = __arg1;
-Obj v0x7f411272d500 = __arg2;
-Obj v0x7f411272d520 = __arg3;
-Obj v0x7f411272d640 = makeNative(21, clofun2, 0, 3, v0x7f411272d420, v0x7f411272d500, v0x7f411272d520);
-Obj w = v0x7f411272d420;
-Obj v0x7f41124ad760 = PRIM_ISCONS(v0x7f411272d500);
-if (True == v0x7f41124ad760) {
-Obj v0x7f41124ad8a0 = PRIM_CAR(v0x7f411272d500);
-Obj label = v0x7f41124ad8a0;
-Obj v0x7f41124ada60 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f41124ada80 = PRIM_ISCONS(v0x7f41124ada60);
-if (True == v0x7f41124ada80) {
-Obj v0x7f41124adcc0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f41124add00 = PRIM_CAR(v0x7f41124adcc0);
-Obj v0x7f41124add60 = PRIM_ISCONS(v0x7f41124add00);
-if (True == v0x7f41124add60) {
-Obj v0x7f411248cc80 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248cca0 = PRIM_CAR(v0x7f411248cc80);
-Obj v0x7f411248ccc0 = PRIM_CAR(v0x7f411248cca0);
-Obj v0x7f411248cce0 = PRIM_EQ(symlambda, v0x7f411248ccc0);
-if (True == v0x7f411248cce0) {
-Obj v0x7f411248cfc0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248cfe0 = PRIM_CAR(v0x7f411248cfc0);
-Obj v0x7f411248a000 = PRIM_CDR(v0x7f411248cfe0);
-Obj v0x7f411248a020 = PRIM_ISCONS(v0x7f411248a000);
-if (True == v0x7f411248a020) {
-Obj v0x7f411248a300 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248a320 = PRIM_CAR(v0x7f411248a300);
-Obj v0x7f411248a340 = PRIM_CDR(v0x7f411248a320);
-Obj v0x7f411248a360 = PRIM_CAR(v0x7f411248a340);
-Obj params = v0x7f411248a360;
-Obj v0x7f411248a6e0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248a700 = PRIM_CAR(v0x7f411248a6e0);
-Obj v0x7f411248a720 = PRIM_CDR(v0x7f411248a700);
-Obj v0x7f411248a740 = PRIM_CDR(v0x7f411248a720);
-Obj v0x7f411248a760 = PRIM_ISCONS(v0x7f411248a740);
-if (True == v0x7f411248a760) {
-Obj v0x7f411248aae0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248ab00 = PRIM_CAR(v0x7f411248aae0);
-Obj v0x7f411248ab20 = PRIM_CDR(v0x7f411248ab00);
-Obj v0x7f411248ab40 = PRIM_CDR(v0x7f411248ab20);
-Obj v0x7f411248ab60 = PRIM_CAR(v0x7f411248ab40);
-Obj actives = v0x7f411248ab60;
-Obj v0x7f411248af80 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f411248afa0 = PRIM_CAR(v0x7f411248af80);
-Obj v0x7f411248afc0 = PRIM_CDR(v0x7f411248afa0);
-Obj v0x7f411248afe0 = PRIM_CDR(v0x7f411248afc0);
-Obj v0x7f4112487000 = PRIM_CDR(v0x7f411248afe0);
-Obj v0x7f4112487020 = PRIM_ISCONS(v0x7f4112487000);
-if (True == v0x7f4112487020) {
-Obj v0x7f4112487440 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f4112487460 = PRIM_CAR(v0x7f4112487440);
-Obj v0x7f4112487480 = PRIM_CDR(v0x7f4112487460);
-Obj v0x7f41124874a0 = PRIM_CDR(v0x7f4112487480);
-Obj v0x7f41124874c0 = PRIM_CDR(v0x7f41124874a0);
-Obj v0x7f41124874e0 = PRIM_CAR(v0x7f41124874c0);
-Obj body = v0x7f41124874e0;
-Obj v0x7f41124879c0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f41124879e0 = PRIM_CAR(v0x7f41124879c0);
-Obj v0x7f4112487a00 = PRIM_CDR(v0x7f41124879e0);
-Obj v0x7f4112487a20 = PRIM_CDR(v0x7f4112487a00);
-Obj v0x7f4112487a40 = PRIM_CDR(v0x7f4112487a20);
-Obj v0x7f4112487a60 = PRIM_CDR(v0x7f4112487a40);
-Obj v0x7f4112487a80 = PRIM_EQ(Nil, v0x7f4112487a60);
-if (True == v0x7f4112487a80) {
-Obj v0x7f4112487ce0 = PRIM_CDR(v0x7f411272d500);
-Obj v0x7f4112487d00 = PRIM_CDR(v0x7f4112487ce0);
-Obj v0x7f4112487d20 = PRIM_EQ(Nil, v0x7f4112487d00);
-if (True == v0x7f4112487d20) {
-Obj maxid = v0x7f411272d520;
+Obj x139973625028967 = __arg1;
+Obj x139973625028999 = __arg2;
+Obj x139973625029031 = __arg3;
+Obj x139973625029639 = makeNative(21, clofun2, 0, 3, x139973625028967, x139973625028999, x139973625029031);
+Obj w = x139973625028967;
+Obj x139973624529447 = PRIM_ISCONS(x139973625028999);
+if (True == x139973624529447) {
+Obj x139973624529863 = PRIM_CAR(x139973625028999);
+Obj label = x139973624529863;
+Obj x139973624530535 = PRIM_CDR(x139973625028999);
+Obj x139973624530567 = PRIM_ISCONS(x139973624530535);
+if (True == x139973624530567) {
+Obj x139973624531687 = PRIM_CDR(x139973625028999);
+Obj x139973624531719 = PRIM_CAR(x139973624531687);
+Obj x139973624531751 = PRIM_ISCONS(x139973624531719);
+if (True == x139973624531751) {
+Obj x139973624516935 = PRIM_CDR(x139973625028999);
+Obj x139973624516967 = PRIM_CAR(x139973624516935);
+Obj x139973624516999 = PRIM_CAR(x139973624516967);
+Obj x139973624517063 = PRIM_EQ(symlambda, x139973624516999);
+if (True == x139973624517063) {
+Obj x139973624518247 = PRIM_CDR(x139973625028999);
+Obj x139973624518279 = PRIM_CAR(x139973624518247);
+Obj x139973624518311 = PRIM_CDR(x139973624518279);
+Obj x139973624518343 = PRIM_ISCONS(x139973624518311);
+if (True == x139973624518343) {
+Obj x139973624519783 = PRIM_CDR(x139973625028999);
+Obj x139973624520007 = PRIM_CAR(x139973624519783);
+Obj x139973624520039 = PRIM_CDR(x139973624520007);
+Obj x139973624520167 = PRIM_CAR(x139973624520039);
+Obj params = x139973624520167;
+Obj x139973624415335 = PRIM_CDR(x139973625028999);
+Obj x139973624415367 = PRIM_CAR(x139973624415335);
+Obj x139973624415527 = PRIM_CDR(x139973624415367);
+Obj x139973624415559 = PRIM_CDR(x139973624415527);
+Obj x139973624415591 = PRIM_ISCONS(x139973624415559);
+if (True == x139973624415591) {
+Obj x139973624417831 = PRIM_CDR(x139973625028999);
+Obj x139973624417863 = PRIM_CAR(x139973624417831);
+Obj x139973624417895 = PRIM_CDR(x139973624417863);
+Obj x139973624417927 = PRIM_CDR(x139973624417895);
+Obj x139973624417959 = PRIM_CAR(x139973624417927);
+Obj actives = x139973624417959;
+Obj x139973624375431 = PRIM_CDR(x139973625028999);
+Obj x139973624375783 = PRIM_CAR(x139973624375431);
+Obj x139973624375815 = PRIM_CDR(x139973624375783);
+Obj x139973624375847 = PRIM_CDR(x139973624375815);
+Obj x139973624375879 = PRIM_CDR(x139973624375847);
+Obj x139973624375911 = PRIM_ISCONS(x139973624375879);
+if (True == x139973624375911) {
+Obj x139973624341319 = PRIM_CDR(x139973625028999);
+Obj x139973624341415 = PRIM_CAR(x139973624341319);
+Obj x139973624341479 = PRIM_CDR(x139973624341415);
+Obj x139973624341511 = PRIM_CDR(x139973624341479);
+Obj x139973624341543 = PRIM_CDR(x139973624341511);
+Obj x139973624341575 = PRIM_CAR(x139973624341543);
+Obj body = x139973624341575;
+Obj x139973624344391 = PRIM_CDR(x139973625028999);
+Obj x139973624344423 = PRIM_CAR(x139973624344391);
+Obj x139973624344455 = PRIM_CDR(x139973624344423);
+Obj x139973624344487 = PRIM_CDR(x139973624344455);
+Obj x139973624275079 = PRIM_CDR(x139973624344487);
+Obj x139973624275143 = PRIM_CDR(x139973624275079);
+Obj x139973624275271 = PRIM_EQ(Nil, x139973624275143);
+if (True == x139973624275271) {
+Obj x139973624276071 = PRIM_CDR(x139973625028999);
+Obj x139973624276103 = PRIM_CDR(x139973624276071);
+Obj x139973624276167 = PRIM_EQ(Nil, x139973624276103);
+if (True == x139973624276167) {
+Obj maxid = x139973625029031;
 pushCont(co, 14, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2792,7 +2774,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2801,7 +2783,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2810,7 +2792,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2819,7 +2801,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2828,7 +2810,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2837,7 +2819,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2846,7 +2828,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2855,7 +2837,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2864,7 +2846,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d640;
+__arg0 = x139973625029639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2875,18 +2857,18 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f4112487e80 = __arg1;
+Obj x139973624276775 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj v0x7f4112485100 = PRIM_SUB(maxid, label);
+Obj x139973624278023 = PRIM_SUB(maxid, label);
 pushCont(co, 15, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = v0x7f4112485100;
+__arg1 = x139973624278023;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2897,7 +2879,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f4112485140 = __arg1;
+Obj x139973624278087 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2908,7 +2890,7 @@ pushCont(co, 16, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = v0x7f4112485140;
+__arg2 = x139973624278087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2918,7 +2900,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f4112485160 = __arg1;
+Obj x139973624278471 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2939,7 +2921,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f4112485280 = __arg1;
+Obj x139973624221703 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2962,7 +2944,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41124853e0 = __arg1;
+Obj x139973624222503 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2985,17 +2967,17 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f4112485540 = __arg1;
+Obj x139973624223463 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj v0x7f4112485700 = makeCons(maxid, label);
+Obj x139973624224647 = makeCons(maxid, label);
 pushCont(co, 20, clofun2, 1, w);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = v0x7f4112485700;
+__arg1 = x139973624224647;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
@@ -3008,7 +2990,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f4112485780 = __arg1;
+Obj x139973624224775 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3023,7 +3005,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f411272dc60 = makeNative(24, clofun2, 0, 0);
+Obj x139973625031879 = makeNative(24, clofun2, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
 Obj maxid = closureRef(co, 2);
@@ -3040,7 +3022,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f41124ad400 = __arg1;
+Obj x139973624642727 = __arg1;
 Obj other= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 23, clofun2);
 __nargs = 2;
@@ -3055,7 +3037,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f41124ad500 = __arg1;
+Obj x139973624643079 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35display);
 __arg1 = makeCString("\n");
@@ -3080,16 +3062,16 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f411273ea00 = __arg1;
-Obj v0x7f411273ea20 = __arg2;
-Obj v0x7f411273ea40 = __arg3;
-Obj v0x7f411273eaa0 = co->args[4];
-Obj v0x7f411273ec20 = makeNative(26, clofun2, 0, 4, v0x7f411273ea00, v0x7f411273ea20, v0x7f411273ea40, v0x7f411273eaa0);
-Obj fn = v0x7f411273ea00;
-Obj w = v0x7f411273ea20;
-Obj idx = v0x7f411273ea40;
-Obj v0x7f41124c4d80 = PRIM_EQ(Nil, v0x7f411273eaa0);
-if (True == v0x7f41124c4d80) {
+Obj x139973625825927 = __arg1;
+Obj x139973625825959 = __arg2;
+Obj x139973625825991 = __arg3;
+Obj x139973625826023 = co->args[4];
+Obj x139973625787591 = makeNative(26, clofun2, 0, 4, x139973625825927, x139973625825959, x139973625825991, x139973625826023);
+Obj fn = x139973625825927;
+Obj w = x139973625825959;
+Obj idx = x139973625825991;
+Obj x139973624639623 = PRIM_EQ(Nil, x139973625826023);
+if (True == x139973624639623) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3097,7 +3079,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec20;
+__arg0 = x139973625787591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3108,16 +3090,16 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411273ef60 = makeNative(28, clofun2, 0, 0);
+Obj x139973625789351 = makeNative(28, clofun2, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj v0x7f41124c4520 = PRIM_ISCONS(closureRef(co, 3));
-if (True == v0x7f41124c4520) {
-Obj v0x7f41124c4620 = PRIM_CAR(closureRef(co, 3));
-Obj a = v0x7f41124c4620;
-Obj v0x7f41124c4720 = PRIM_CDR(closureRef(co, 3));
-Obj b = v0x7f41124c4720;
+Obj x139973624685191 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139973624685191) {
+Obj x139973624685575 = PRIM_CAR(closureRef(co, 3));
+Obj a = x139973624685575;
+Obj x139973624686407 = PRIM_CDR(closureRef(co, 3));
+Obj b = x139973624686407;
 pushCont(co, 27, clofun2, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
@@ -3131,7 +3113,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef60;
+__arg0 = x139973625789351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3142,17 +3124,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f41124c4880 = __arg1;
+Obj x139973624686791 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f41124c4a80 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj x139973624687527 = PRIM_ADD(idx, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
 __arg1 = fn;
 __arg2 = w;
-__arg3 = v0x7f41124c4a80;
+__arg3 = x139973624687527;
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3192,7 +3174,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f41124cba60 = __arg1;
+Obj x139973624893319 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3212,7 +3194,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f41124cbbe0 = __arg1;
+Obj x139973624844903 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 32, clofun2, 2, i, w);
@@ -3229,7 +3211,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f41124cbda0 = __arg1;
+Obj x139973624845543 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 33, clofun2, 1, w);
@@ -3246,7 +3228,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41124cbee0 = __arg1;
+Obj x139973624846311 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3278,7 +3260,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41124d9b60 = __arg1;
+Obj x139973624915495 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3298,11 +3280,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41124d9cc0 = __arg1;
+Obj x139973624916295 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124d9de0 = PRIM_LT(i, MAKE_NUMBER(4));
-if (True == v0x7f41124d9de0) {
+Obj x139973624916903 = PRIM_LT(i, MAKE_NUMBER(4));
+if (True == x139973624916903) {
 pushCont(co, 39, clofun2, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3329,7 +3311,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41124cb2c0 = __arg1;
+Obj x139973624890439 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 38, clofun2, 1, w);
@@ -3346,7 +3328,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41124cb420 = __arg1;
+Obj x139973624891207 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3361,7 +3343,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f41124d9f20 = __arg1;
+Obj x139973624917447 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 40, clofun2, 1, w);
@@ -3378,7 +3360,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41124cb0a0 = __arg1;
+Obj x139973624917927 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3410,7 +3392,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f41124d94e0 = __arg1;
+Obj x139973625015143 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3429,7 +3411,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41124d9660 = __arg1;
+Obj x139973625015943 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 44, clofun2, 1, w);
 __nargs = 3;
@@ -3445,7 +3427,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f41124d97c0 = __arg1;
+Obj x139973624914055 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3463,9 +3445,9 @@ label45:
 Obj w = __arg1;
 Obj label = __arg2;
 Obj maxid = __arg3;
-Obj v0x7f41124ebf00 = PRIM_SUB(maxid, label);
-Obj v0x7f41124ebf40 = primDiv(v0x7f41124ebf00, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-Obj gid = v0x7f41124ebf40;
+Obj x139973625012711 = PRIM_SUB(maxid, label);
+Obj x139973625012871 = primDiv(x139973625012711, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+Obj gid = x139973625012871;
 pushCont(co, 46, clofun2, 2, w, gid);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3480,7 +3462,7 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f41124d9140 = __arg1;
+Obj x139973625013415 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -3516,18 +3498,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f4112743b20 = __arg1;
-Obj v0x7f4112743b40 = __arg2;
-Obj v0x7f4112743b60 = __arg3;
-Obj v0x7f4112743b80 = co->args[4];
-Obj v0x7f4112743ba0 = co->args[5];
-Obj v0x7f4112743e20 = makeNative(49, clofun2, 0, 5, v0x7f4112743b20, v0x7f4112743b40, v0x7f4112743b60, v0x7f4112743b80, v0x7f4112743ba0);
-Obj self = v0x7f4112743b20;
-Obj env = v0x7f4112743b40;
-Obj fn = v0x7f4112743b60;
-Obj w = v0x7f4112743b80;
-Obj v0x7f41124eb700 = PRIM_EQ(Nil, v0x7f4112743ba0);
-if (True == v0x7f41124eb700) {
+Obj x139973625854279 = __arg1;
+Obj x139973625854311 = __arg2;
+Obj x139973625854343 = __arg3;
+Obj x139973625854375 = co->args[4];
+Obj x139973625854407 = co->args[5];
+Obj x139973625855303 = makeNative(49, clofun2, 0, 5, x139973625854279, x139973625854311, x139973625854343, x139973625854375, x139973625854407);
+Obj self = x139973625854279;
+Obj env = x139973625854311;
+Obj fn = x139973625854343;
+Obj w = x139973625854375;
+Obj x139973625029255 = PRIM_EQ(Nil, x139973625854407);
+if (True == x139973625029255) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3535,7 +3517,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743e20;
+__arg0 = x139973625855303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3546,17 +3528,17 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f411273e1e0 = makeNative(3, clofun3, 0, 0);
+Obj x139973625823783 = makeNative(3, clofun3, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj v0x7f41125127e0 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125127e0) {
-Obj v0x7f4112512960 = PRIM_CAR(closureRef(co, 4));
-Obj a = v0x7f4112512960;
-Obj v0x7f4112512aa0 = PRIM_CDR(closureRef(co, 4));
-Obj b = v0x7f4112512aa0;
+Obj x139973625823239 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973625823239) {
+Obj x139973625823623 = PRIM_CAR(closureRef(co, 4));
+Obj a = x139973625823623;
+Obj x139973625824199 = PRIM_CDR(closureRef(co, 4));
+Obj b = x139973625824199;
 pushCont(co, 0, clofun3, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
@@ -3571,7 +3553,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1e0;
+__arg0 = x139973625823783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3602,7 +3584,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f4112512c60 = __arg1;
+Obj x139973625825095 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3621,14 +3603,14 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f4112512ee0 = __arg1;
+Obj x139973625787623 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj v0x7f4112512f00 = primNot(v0x7f4112512ee0);
-if (True == v0x7f4112512f00) {
+Obj x139973625787655 = primNot(x139973625787623);
+if (True == x139973625787655) {
 pushCont(co, 2, clofun3, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3658,7 +3640,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f41124eb040 = __arg1;
+Obj x139973625787911 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3692,28 +3674,28 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41127432e0 = __arg1;
-Obj v0x7f4112743300 = __arg2;
-Obj v0x7f4112743320 = __arg3;
-Obj v0x7f4112743460 = makeNative(27, clofun3, 0, 0);
-Obj self = v0x7f41127432e0;
-Obj w = v0x7f4112743300;
-Obj v0x7f4112570a20 = PRIM_ISCONS(v0x7f4112743320);
-if (True == v0x7f4112570a20) {
-Obj v0x7f4112570c40 = PRIM_CAR(v0x7f4112743320);
-Obj v0x7f4112570c60 = PRIM_EQ(sym_37continuation, v0x7f4112570c40);
-if (True == v0x7f4112570c60) {
-Obj v0x7f4112570e80 = PRIM_CDR(v0x7f4112743320);
-Obj v0x7f4112570ea0 = PRIM_ISCONS(v0x7f4112570e80);
-if (True == v0x7f4112570ea0) {
-Obj v0x7f41125630e0 = PRIM_CDR(v0x7f4112743320);
-Obj v0x7f4112563100 = PRIM_CAR(v0x7f41125630e0);
-Obj label = v0x7f4112563100;
-Obj v0x7f4112563360 = PRIM_CDR(v0x7f4112743320);
-Obj v0x7f4112563380 = PRIM_CDR(v0x7f4112563360);
-Obj stacks = v0x7f4112563380;
-Obj v0x7f4112563500 = PRIM_EQ(stacks, Nil);
-if (True == v0x7f4112563500) {
+Obj x139973624375015 = __arg1;
+Obj x139973624375047 = __arg2;
+Obj x139973624375079 = __arg3;
+Obj x139973625852487 = makeNative(27, clofun3, 0, 0);
+Obj self = x139973624375015;
+Obj w = x139973624375047;
+Obj x139973623474439 = PRIM_ISCONS(x139973624375079);
+if (True == x139973623474439) {
+Obj x139973623474887 = PRIM_CAR(x139973624375079);
+Obj x139973623474919 = PRIM_EQ(sym_37continuation, x139973623474887);
+if (True == x139973623474919) {
+Obj x139973623475335 = PRIM_CDR(x139973624375079);
+Obj x139973623475367 = PRIM_ISCONS(x139973623475335);
+if (True == x139973623475367) {
+Obj x139973623475783 = PRIM_CDR(x139973624375079);
+Obj x139973623475815 = PRIM_CAR(x139973623475783);
+Obj label = x139973623475815;
+Obj x139973623451655 = PRIM_CDR(x139973624375079);
+Obj x139973623451687 = PRIM_CDR(x139973623451655);
+Obj stacks = x139973623451687;
+Obj x139973623452039 = PRIM_EQ(stacks, Nil);
+if (True == x139973623452039) {
 pushCont(co, 16, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3738,7 +3720,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743460;
+__arg0 = x139973625852487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3747,7 +3729,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743460;
+__arg0 = x139973625852487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3756,7 +3738,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743460;
+__arg0 = x139973625852487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3767,17 +3749,17 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f411252ca80 = __arg1;
+Obj x139973623427879 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f411252ce20 = PRIM_CAR(self);
-Obj v0x7f411252ce60 = PRIM_SUB(v0x7f411252ce20, label);
+Obj x139973623428647 = PRIM_CAR(self);
+Obj x139973623428711 = PRIM_SUB(x139973623428647, label);
 pushCont(co, 6, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = v0x7f411252ce60;
+__arg1 = x139973623428711;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3788,7 +3770,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f411252cea0 = __arg1;
+Obj x139973623428775 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3797,7 +3779,7 @@ pushCont(co, 7, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = v0x7f411252cea0;
+__arg2 = x139973623428775;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3807,7 +3789,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411252cec0 = __arg1;
+Obj x139973623428807 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3826,18 +3808,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f4112529020 = __arg1;
+Obj x139973623429095 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f4112529260 = PRIM_CAR(self);
+Obj x139973623429575 = PRIM_CAR(self);
 pushCont(co, 9, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = v0x7f4112529260;
+__arg3 = x139973623429575;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3847,12 +3829,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f4112529280 = __arg1;
+Obj x139973623429607 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112529400 = PRIM_EQ(stacks, Nil);
-if (True == v0x7f4112529400) {
+Obj x139973623429959 = PRIM_EQ(stacks, Nil);
+if (True == x139973623429959) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3879,7 +3861,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f4112529680 = __arg1;
+Obj x139973623430439 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3896,7 +3878,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f4112529860 = __arg1;
+Obj x139973623430887 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3904,7 +3886,7 @@ pushCont(co, 12, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = v0x7f4112529860;
+__arg2 = x139973623430887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3914,7 +3896,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f4112529880 = __arg1;
+Obj x139973623430919 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3932,7 +3914,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112529f60 = __arg1;
+Obj x139973625852423 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3962,7 +3944,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f4112529ae0 = __arg1;
+Obj x139973625851943 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -3979,17 +3961,17 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f4112563600 = __arg1;
+Obj x139973623452263 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f41125639a0 = PRIM_CAR(self);
-Obj v0x7f41125639e0 = PRIM_SUB(v0x7f41125639a0, label);
+Obj x139973623453031 = PRIM_CAR(self);
+Obj x139973623453095 = PRIM_SUB(x139973623453031, label);
 pushCont(co, 17, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = v0x7f41125639e0;
+__arg1 = x139973623453095;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4000,7 +3982,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f4112563a40 = __arg1;
+Obj x139973623453159 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4009,7 +3991,7 @@ pushCont(co, 18, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = v0x7f4112563a40;
+__arg2 = x139973623453159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4019,7 +4001,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f4112563a60 = __arg1;
+Obj x139973623453191 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4038,18 +4020,18 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f4112563ba0 = __arg1;
+Obj x139973623453479 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f4112563e20 = PRIM_CAR(self);
+Obj x139973623453959 = PRIM_CAR(self);
 pushCont(co, 20, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = v0x7f4112563e20;
+__arg3 = x139973623453959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4059,12 +4041,12 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f4112563e40 = __arg1;
+Obj x139973623453991 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f411252c000 = PRIM_EQ(stacks, Nil);
-if (True == v0x7f411252c000) {
+Obj x139973623454343 = PRIM_EQ(stacks, Nil);
+if (True == x139973623454343) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4091,7 +4073,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f411252c2e0 = __arg1;
+Obj x139973623454823 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4108,7 +4090,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f411252c4a0 = __arg1;
+Obj x139973623455271 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4116,7 +4098,7 @@ pushCont(co, 23, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = v0x7f411252c4a0;
+__arg2 = x139973623455271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4126,7 +4108,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f411252c580 = __arg1;
+Obj x139973623455303 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4144,7 +4126,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f411252c8c0 = __arg1;
+Obj x139973623427463 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4174,7 +4156,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411252c780 = __arg1;
+Obj x139973623427143 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -4207,8 +4189,8 @@ Obj self = __arg1;
 Obj env = __arg2;
 Obj w = __arg3;
 Obj x1 = co->args[4];
-Obj v0x7f411252c4c0 = primIsSymbol(x1);
-if (True == v0x7f411252c4c0) {
+Obj x139973623649799 = primIsSymbol(x1);
+if (True == x139973623649799) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = w;
@@ -4219,22 +4201,22 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f411273e580 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
-Obj v0x7f41125c0200 = PRIM_ISCONS(x1);
-if (True == v0x7f41125c0200) {
-Obj v0x7f41125c0480 = PRIM_CAR(x1);
-Obj v0x7f41125c04a0 = PRIM_EQ(sym_37global, v0x7f41125c0480);
-if (True == v0x7f41125c04a0) {
-Obj v0x7f41125c0720 = PRIM_CDR(x1);
-Obj v0x7f41125c0740 = PRIM_ISCONS(v0x7f41125c0720);
-if (True == v0x7f41125c0740) {
-Obj v0x7f41125c09a0 = PRIM_CDR(x1);
-Obj v0x7f41125c09c0 = PRIM_CAR(v0x7f41125c09a0);
-Obj x = v0x7f41125c09c0;
-Obj v0x7f41125c0e40 = PRIM_CDR(x1);
-Obj v0x7f41125c0e60 = PRIM_CDR(v0x7f41125c0e40);
-Obj v0x7f41125c0e80 = PRIM_EQ(Nil, v0x7f41125c0e60);
-if (True == v0x7f41125c0e80) {
+Obj x139973624684615 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
+Obj x139973623517415 = PRIM_ISCONS(x1);
+if (True == x139973623517415) {
+Obj x139973623517863 = PRIM_CAR(x1);
+Obj x139973623517927 = PRIM_EQ(sym_37global, x139973623517863);
+if (True == x139973623517927) {
+Obj x139973623518407 = PRIM_CDR(x1);
+Obj x139973623518439 = PRIM_ISCONS(x139973623518407);
+if (True == x139973623518439) {
+Obj x139973623518919 = PRIM_CDR(x1);
+Obj x139973623518951 = PRIM_CAR(x139973623518919);
+Obj x = x139973623518951;
+Obj x139973623519623 = PRIM_CDR(x1);
+Obj x139973623519655 = PRIM_CDR(x139973623519623);
+Obj x139973623519687 = PRIM_EQ(Nil, x139973623519655);
+if (True == x139973623519687) {
 pushCont(co, 29, clofun3, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4247,7 +4229,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e580;
+__arg0 = x139973624684615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4256,7 +4238,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e580;
+__arg0 = x139973624684615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4265,7 +4247,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e580;
+__arg0 = x139973624684615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4274,7 +4256,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e580;
+__arg0 = x139973624684615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4286,7 +4268,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj v0x7f41125c0fc0 = __arg1;
+Obj x139973623472423 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 30, clofun3, 1, w);
@@ -4303,7 +4285,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f4112570100 = __arg1;
+Obj x139973623472711 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4318,22 +4300,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f411273e720 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41125cdcc0 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125cdcc0) {
-Obj v0x7f41125c10a0 = PRIM_CAR(closureRef(co, 2));
-Obj v0x7f41125c10c0 = PRIM_EQ(sym_37closure_45ref, v0x7f41125c10a0);
-if (True == v0x7f41125c10c0) {
-Obj v0x7f41125c1320 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125c1340 = PRIM_ISCONS(v0x7f41125c1320);
-if (True == v0x7f41125c1340) {
-Obj v0x7f41125c1500 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125c1520 = PRIM_CAR(v0x7f41125c1500);
-Obj idx = v0x7f41125c1520;
-Obj v0x7f41125c1920 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125c1940 = PRIM_CDR(v0x7f41125c1920);
-Obj v0x7f41125c1960 = PRIM_EQ(Nil, v0x7f41125c1940);
-if (True == v0x7f41125c1960) {
+Obj x139973624685127 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973623578887 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973623578887) {
+Obj x139973623579367 = PRIM_CAR(closureRef(co, 2));
+Obj x139973623579399 = PRIM_EQ(sym_37closure_45ref, x139973623579367);
+if (True == x139973623579399) {
+Obj x139973623579911 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623579943 = PRIM_ISCONS(x139973623579911);
+if (True == x139973623579943) {
+Obj x139973623580391 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623580423 = PRIM_CAR(x139973623580391);
+Obj idx = x139973623580423;
+Obj x139973623581127 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623581159 = PRIM_CDR(x139973623581127);
+Obj x139973623581191 = PRIM_EQ(Nil, x139973623581159);
+if (True == x139973623581191) {
 pushCont(co, 32, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4346,7 +4328,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e720;
+__arg0 = x139973624685127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4355,7 +4337,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e720;
+__arg0 = x139973624685127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4364,7 +4346,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e720;
+__arg0 = x139973624685127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4373,7 +4355,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e720;
+__arg0 = x139973624685127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4384,7 +4366,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f41125c1aa0 = __arg1;
+Obj x139973623581511 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun3);
 __nargs = 3;
@@ -4400,7 +4382,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41125c1c60 = __arg1;
+Obj x139973623581831 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4414,22 +4396,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f411273e900 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41125cf3e0 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125cf3e0) {
-Obj v0x7f41125cf7e0 = PRIM_CAR(closureRef(co, 2));
-Obj v0x7f41125cf800 = PRIM_EQ(sym_37stack_45ref, v0x7f41125cf7e0);
-if (True == v0x7f41125cf800) {
-Obj v0x7f41125cfae0 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125cfb20 = PRIM_ISCONS(v0x7f41125cfae0);
-if (True == v0x7f41125cfb20) {
-Obj v0x7f41125cfdc0 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125cfde0 = PRIM_CAR(v0x7f41125cfdc0);
-Obj idx = v0x7f41125cfde0;
-Obj v0x7f41125cd2c0 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125cd2e0 = PRIM_CDR(v0x7f41125cd2c0);
-Obj v0x7f41125cd360 = PRIM_EQ(Nil, v0x7f41125cd2e0);
-if (True == v0x7f41125cd360) {
+Obj x139973624685639 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973623648807 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973623648807) {
+Obj x139973623649351 = PRIM_CAR(closureRef(co, 2));
+Obj x139973623649383 = PRIM_EQ(sym_37stack_45ref, x139973623649351);
+if (True == x139973623649383) {
+Obj x139973623649831 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623649863 = PRIM_ISCONS(x139973623649831);
+if (True == x139973623649863) {
+Obj x139973623650279 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623650311 = PRIM_CAR(x139973623650279);
+Obj idx = x139973623650311;
+Obj x139973623650919 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623650951 = PRIM_CDR(x139973623650919);
+Obj x139973623650983 = PRIM_EQ(Nil, x139973623650951);
+if (True == x139973623650983) {
 pushCont(co, 35, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4442,7 +4424,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e900;
+__arg0 = x139973624685639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4451,7 +4433,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e900;
+__arg0 = x139973624685639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4460,7 +4442,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e900;
+__arg0 = x139973624685639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4469,7 +4451,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e900;
+__arg0 = x139973624685639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4480,7 +4462,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41125cd4e0 = __arg1;
+Obj x139973623651271 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 36, clofun3);
 __nargs = 3;
@@ -4496,7 +4478,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41125cd6a0 = __arg1;
+Obj x139973623651559 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4510,24 +4492,24 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f411273eae0 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj v0x7f41125e7fe0 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125e7fe0) {
-Obj v0x7f41125e52e0 = PRIM_CAR(closureRef(co, 2));
-Obj v0x7f41125e5300 = PRIM_EQ(sym_37const, v0x7f41125e52e0);
-if (True == v0x7f41125e5300) {
-Obj v0x7f41125e55e0 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125e5600 = PRIM_ISCONS(v0x7f41125e55e0);
-if (True == v0x7f41125e5600) {
-Obj v0x7f41125e59c0 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125e59e0 = PRIM_CAR(v0x7f41125e59c0);
-Obj x = v0x7f41125e59e0;
-Obj v0x7f41125e5e40 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41125e5e60 = PRIM_CDR(v0x7f41125e5e40);
-Obj v0x7f41125e5e80 = PRIM_EQ(Nil, v0x7f41125e5e60);
-if (True == v0x7f41125e5e80) {
-Obj v0x7f41125e5fc0 = primIsSymbol(x);
-if (True == v0x7f41125e5fc0) {
+Obj x139973624686183 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139973623673063 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973623673063) {
+Obj x139973623673607 = PRIM_CAR(closureRef(co, 2));
+Obj x139973623673671 = PRIM_EQ(sym_37const, x139973623673607);
+if (True == x139973623673671) {
+Obj x139973623674215 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623674279 = PRIM_ISCONS(x139973623674215);
+if (True == x139973623674279) {
+Obj x139973623674727 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623674759 = PRIM_CAR(x139973623674727);
+Obj x = x139973623674759;
+Obj x139973623675463 = PRIM_CDR(closureRef(co, 2));
+Obj x139973623675495 = PRIM_CDR(x139973623675463);
+Obj x139973623675527 = PRIM_EQ(Nil, x139973623675495);
+if (True == x139973623675527) {
+Obj x139973623676007 = primIsSymbol(x);
+if (True == x139973623676007) {
 pushCont(co, 44, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4551,7 +4533,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273eae0;
+__arg0 = x139973624686183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4560,7 +4542,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273eae0;
+__arg0 = x139973624686183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4569,7 +4551,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273eae0;
+__arg0 = x139973624686183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4578,7 +4560,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273eae0;
+__arg0 = x139973624686183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4589,9 +4571,9 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41125d6580 = __arg1;
+Obj x139973623676839 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41125d6580) {
+if (True == x139973623676839) {
 pushCont(co, 42, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4603,8 +4585,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125d6ca0 = primIsString(x);
-if (True == v0x7f41125d6ca0) {
+Obj x139973623665607 = primIsString(x);
+if (True == x139973623665607) {
 pushCont(co, 39, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4616,8 +4598,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125d2560 = PRIM_EQ(x, Nil);
-if (True == v0x7f41125d2560) {
+Obj x139973623667015 = PRIM_EQ(x, Nil);
+if (True == x139973623667015) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4628,8 +4610,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125d28a0 = PRIM_EQ(x, True);
-if (True == v0x7f41125d28a0) {
+Obj x139973623667527 = PRIM_EQ(x, True);
+if (True == x139973623667527) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4640,8 +4622,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125d2bc0 = PRIM_EQ(x, False);
-if (True == v0x7f41125d2bc0) {
+Obj x139973623668039 = PRIM_EQ(x, False);
+if (True == x139973623668039) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4669,7 +4651,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f41125d6e60 = __arg1;
+Obj x139973623665927 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun3);
 __nargs = 2;
@@ -4684,12 +4666,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41125d2120 = __arg1;
+Obj x139973623666439 = __arg1;
 PUSH_CONT_0(co, 41, clofun3);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = v0x7f41125d2120;
+__arg2 = x139973623666439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4699,7 +4681,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj v0x7f41125d2140 = __arg1;
+Obj x139973623666503 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4713,7 +4695,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f41125d67c0 = __arg1;
+Obj x139973623664871 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun3);
 __nargs = 3;
@@ -4729,7 +4711,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41125d6960 = __arg1;
+Obj x139973623665159 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4743,7 +4725,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f41125d6140 = __arg1;
+Obj x139973623676327 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
@@ -4758,42 +4740,42 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f411273ec40 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f4112603a00 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112603a00) {
-Obj v0x7f4112603cc0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112603ce0 = PRIM_EQ(symlet, v0x7f4112603cc0);
-if (True == v0x7f4112603ce0) {
-Obj v0x7f41125fe060 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fe0a0 = PRIM_ISCONS(v0x7f41125fe060);
-if (True == v0x7f41125fe0a0) {
-Obj v0x7f41125fe2e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fe300 = PRIM_CAR(v0x7f41125fe2e0);
-Obj a = v0x7f41125fe300;
-Obj v0x7f41125fe600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fe620 = PRIM_CDR(v0x7f41125fe600);
-Obj v0x7f41125fe640 = PRIM_ISCONS(v0x7f41125fe620);
-if (True == v0x7f41125fe640) {
-Obj v0x7f41125fe9e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fea00 = PRIM_CDR(v0x7f41125fe9e0);
-Obj v0x7f41125fea20 = PRIM_CAR(v0x7f41125fea00);
-Obj b = v0x7f41125fea20;
-Obj v0x7f41125fee80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125feea0 = PRIM_CDR(v0x7f41125fee80);
-Obj v0x7f41125feec0 = PRIM_CDR(v0x7f41125feea0);
-Obj v0x7f41125feee0 = PRIM_ISCONS(v0x7f41125feec0);
-if (True == v0x7f41125feee0) {
-Obj v0x7f41125fb440 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fb460 = PRIM_CDR(v0x7f41125fb440);
-Obj v0x7f41125fb480 = PRIM_CDR(v0x7f41125fb460);
-Obj v0x7f41125fb4a0 = PRIM_CAR(v0x7f41125fb480);
-Obj c = v0x7f41125fb4a0;
-Obj v0x7f41125fba40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fba60 = PRIM_CDR(v0x7f41125fba40);
-Obj v0x7f41125fba80 = PRIM_CDR(v0x7f41125fba60);
-Obj v0x7f41125fbaa0 = PRIM_CDR(v0x7f41125fba80);
-Obj v0x7f41125fbae0 = PRIM_EQ(Nil, v0x7f41125fbaa0);
-if (True == v0x7f41125fbae0) {
+Obj x139973624686695 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973624002503 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624002503) {
+Obj x139973624003303 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624003431 = PRIM_EQ(symlet, x139973624003303);
+if (True == x139973624003431) {
+Obj x139973624004167 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624004199 = PRIM_ISCONS(x139973624004167);
+if (True == x139973624004199) {
+Obj x139973623730471 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623730503 = PRIM_CAR(x139973623730471);
+Obj a = x139973623730503;
+Obj x139973623731303 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623731335 = PRIM_CDR(x139973623731303);
+Obj x139973623731527 = PRIM_ISCONS(x139973623731335);
+if (True == x139973623731527) {
+Obj x139973623732135 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623732167 = PRIM_CDR(x139973623732135);
+Obj x139973623732391 = PRIM_CAR(x139973623732167);
+Obj b = x139973623732391;
+Obj x139973623733351 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623733447 = PRIM_CDR(x139973623733351);
+Obj x139973623733479 = PRIM_CDR(x139973623733447);
+Obj x139973623733511 = PRIM_ISCONS(x139973623733479);
+if (True == x139973623733511) {
+Obj x139973623685703 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623685735 = PRIM_CDR(x139973623685703);
+Obj x139973623685767 = PRIM_CDR(x139973623685735);
+Obj x139973623685799 = PRIM_CAR(x139973623685767);
+Obj c = x139973623685799;
+Obj x139973623686919 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623686951 = PRIM_CDR(x139973623686919);
+Obj x139973623686983 = PRIM_CDR(x139973623686951);
+Obj x139973623687015 = PRIM_CDR(x139973623686983);
+Obj x139973623687047 = PRIM_EQ(Nil, x139973623687015);
+if (True == x139973623687047) {
 pushCont(co, 46, clofun3, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -4806,7 +4788,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4815,7 +4797,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4824,7 +4806,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4833,7 +4815,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4842,7 +4824,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4851,7 +4833,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ec40;
+__arg0 = x139973624686695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4862,13 +4844,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f41125fbd40 = __arg1;
+Obj x139973623687367 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj idx = v0x7f41125fbd40;
-Obj v0x7f41125fbf00 = PRIM_LT(idx, MAKE_NUMBER(0));
-if (True == v0x7f41125fbf00) {
+Obj idx = x139973623687367;
+Obj x139973623687815 = PRIM_LT(idx, MAKE_NUMBER(0));
+if (True == x139973623687815) {
 pushCont(co, 1, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4896,7 +4878,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj v0x7f41125ece00 = __arg1;
+Obj x139973623682375 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4914,7 +4896,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f41125ecf20 = __arg1;
+Obj x139973623682695 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4934,7 +4916,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f41125e7180 = __arg1;
+Obj x139973623683239 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 0, clofun4, 2, a, c);
@@ -4971,14 +4953,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f41125e7440 = __arg1;
+Obj x139973623683559 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125e77a0 = makeCons(a, closureRef(co, 2));
+Obj x139973623684007 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = v0x7f41125e77a0;
+__arg2 = x139973623684007;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -4990,7 +4972,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f41125ec000 = __arg1;
+Obj x139973623688103 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5008,7 +4990,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f41125ec2e0 = __arg1;
+Obj x139973623688423 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5026,7 +5008,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41125ec440 = __arg1;
+Obj x139973623688807 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5046,7 +5028,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41125ec600 = __arg1;
+Obj x139973623681191 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 5, clofun4, 2, a, c);
@@ -5063,14 +5045,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41125ec840 = __arg1;
+Obj x139973623681511 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125ecac0 = makeCons(a, closureRef(co, 2));
+Obj x139973623681959 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = v0x7f41125ecac0;
+__arg2 = x139973623681959;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -5082,31 +5064,31 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f411273ef00 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f4112669060 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112669060) {
-Obj v0x7f41126692e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112669300 = PRIM_ISCONS(v0x7f41126692e0);
-if (True == v0x7f4112669300) {
-Obj v0x7f4112669580 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41126695a0 = PRIM_CAR(v0x7f4112669580);
-Obj v0x7f41126695c0 = PRIM_EQ(sym_37builtin, v0x7f41126695a0);
-if (True == v0x7f41126695c0) {
-Obj v0x7f4112669a20 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112669a80 = PRIM_CDR(v0x7f4112669a20);
-Obj v0x7f4112669aa0 = PRIM_ISCONS(v0x7f4112669a80);
-if (True == v0x7f4112669aa0) {
-Obj v0x7f4112669e80 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112669ea0 = PRIM_CDR(v0x7f4112669e80);
-Obj v0x7f4112669ec0 = PRIM_CAR(v0x7f4112669ea0);
-Obj f = v0x7f4112669ec0;
-Obj v0x7f411261b300 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411261b340 = PRIM_CDR(v0x7f411261b300);
-Obj v0x7f411261b360 = PRIM_CDR(v0x7f411261b340);
-Obj v0x7f411261b380 = PRIM_EQ(Nil, v0x7f411261b360);
-if (True == v0x7f411261b380) {
-Obj v0x7f411261b580 = PRIM_CDR(closureRef(co, 0));
-Obj args = v0x7f411261b580;
+Obj x139973624687687 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973624276487 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624276487) {
+Obj x139973624277319 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624277351 = PRIM_ISCONS(x139973624277319);
+if (True == x139973624277351) {
+Obj x139973624278119 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624278151 = PRIM_CAR(x139973624278119);
+Obj x139973624278311 = PRIM_EQ(sym_37builtin, x139973624278151);
+if (True == x139973624278311) {
+Obj x139973624222119 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624222151 = PRIM_CDR(x139973624222119);
+Obj x139973624222183 = PRIM_ISCONS(x139973624222151);
+if (True == x139973624222183) {
+Obj x139973624223655 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624223687 = PRIM_CDR(x139973624223655);
+Obj x139973624223751 = PRIM_CAR(x139973624223687);
+Obj f = x139973624223751;
+Obj x139973624225063 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624225159 = PRIM_CDR(x139973624225063);
+Obj x139973624225191 = PRIM_CDR(x139973624225159);
+Obj x139973624225223 = PRIM_EQ(Nil, x139973624225191);
+if (True == x139973624225223) {
+Obj x139973624078471 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139973624078471;
 pushCont(co, 7, clofun4, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62name);
@@ -5118,7 +5100,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef00;
+__arg0 = x139973624687687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5127,7 +5109,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef00;
+__arg0 = x139973624687687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5136,7 +5118,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef00;
+__arg0 = x139973624687687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5145,7 +5127,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef00;
+__arg0 = x139973624687687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5154,7 +5136,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef00;
+__arg0 = x139973624687687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5165,14 +5147,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411261b820 = __arg1;
+Obj x139973624079303 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 8, clofun4, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = v0x7f411261b820;
+__arg2 = x139973624079303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5182,11 +5164,11 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f411261b840 = __arg1;
+Obj x139973624079335 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f411261b9e0 = PRIM_EQ(f, symset);
-if (True == v0x7f411261b9e0) {
+Obj x139973624079815 = PRIM_EQ(f, symset);
+if (True == x139973624079815) {
 pushCont(co, 11, clofun4, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5213,7 +5195,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f4112603100 = __arg1;
+Obj x139973624081703 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 10, clofun4);
 __nargs = 5;
@@ -5231,7 +5213,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f4112603380 = __arg1;
+Obj x139973624000647 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5245,7 +5227,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f411261bba0 = __arg1;
+Obj x139973624080071 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 12, clofun4);
 __nargs = 5;
@@ -5263,7 +5245,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f411261bde0 = __arg1;
+Obj x139973624081223 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5277,42 +5259,42 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f411272d100 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41126cf880 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41126cf880) {
-Obj v0x7f41126cfb60 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41126cfb80 = PRIM_EQ(symif, v0x7f41126cfb60);
-if (True == v0x7f41126cfb80) {
-Obj v0x7f41126b5160 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b5180 = PRIM_ISCONS(v0x7f41126b5160);
-if (True == v0x7f41126b5180) {
-Obj v0x7f41126b5420 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b5440 = PRIM_CAR(v0x7f41126b5420);
-Obj a = v0x7f41126b5440;
-Obj v0x7f41126b5880 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b58a0 = PRIM_CDR(v0x7f41126b5880);
-Obj v0x7f41126b58c0 = PRIM_ISCONS(v0x7f41126b58a0);
-if (True == v0x7f41126b58c0) {
-Obj v0x7f41126b5c40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b5c60 = PRIM_CDR(v0x7f41126b5c40);
-Obj v0x7f41126b5c80 = PRIM_CAR(v0x7f41126b5c60);
-Obj b = v0x7f41126b5c80;
-Obj v0x7f41126af0e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126af100 = PRIM_CDR(v0x7f41126af0e0);
-Obj v0x7f41126af140 = PRIM_CDR(v0x7f41126af100);
-Obj v0x7f41126af1a0 = PRIM_ISCONS(v0x7f41126af140);
-if (True == v0x7f41126af1a0) {
-Obj v0x7f41126af600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126af620 = PRIM_CDR(v0x7f41126af600);
-Obj v0x7f41126af660 = PRIM_CDR(v0x7f41126af620);
-Obj v0x7f41126af680 = PRIM_CAR(v0x7f41126af660);
-Obj c = v0x7f41126af680;
-Obj v0x7f41126afc40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126afc80 = PRIM_CDR(v0x7f41126afc40);
-Obj v0x7f41126afca0 = PRIM_CDR(v0x7f41126afc80);
-Obj v0x7f41126afcc0 = PRIM_CDR(v0x7f41126afca0);
-Obj v0x7f41126afce0 = PRIM_EQ(Nil, v0x7f41126afcc0);
-if (True == v0x7f41126afce0) {
+Obj x139973624688423 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973624518407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624518407) {
+Obj x139973624519239 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624519271 = PRIM_EQ(symif, x139973624519239);
+if (True == x139973624519271) {
+Obj x139973624520199 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624520231 = PRIM_ISCONS(x139973624520199);
+if (True == x139973624520231) {
+Obj x139973624414343 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624414375 = PRIM_CAR(x139973624414343);
+Obj a = x139973624414375;
+Obj x139973624415399 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624415431 = PRIM_CDR(x139973624415399);
+Obj x139973624415495 = PRIM_ISCONS(x139973624415431);
+if (True == x139973624415495) {
+Obj x139973624416871 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624416903 = PRIM_CDR(x139973624416871);
+Obj x139973624416967 = PRIM_CAR(x139973624416903);
+Obj b = x139973624416967;
+Obj x139973624418151 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624418183 = PRIM_CDR(x139973624418151);
+Obj x139973624373319 = PRIM_CDR(x139973624418183);
+Obj x139973624373351 = PRIM_ISCONS(x139973624373319);
+if (True == x139973624373351) {
+Obj x139973624374663 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624374695 = PRIM_CDR(x139973624374663);
+Obj x139973624374727 = PRIM_CDR(x139973624374695);
+Obj x139973624374823 = PRIM_CAR(x139973624374727);
+Obj c = x139973624374823;
+Obj x139973624376711 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624376743 = PRIM_CDR(x139973624376711);
+Obj x139973624376775 = PRIM_CDR(x139973624376743);
+Obj x139973624376807 = PRIM_CDR(x139973624376775);
+Obj x139973624377287 = PRIM_EQ(Nil, x139973624376807);
+if (True == x139973624377287) {
 pushCont(co, 14, clofun4, 3, a, b, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5325,7 +5307,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5334,7 +5316,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5343,7 +5325,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5352,7 +5334,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5361,7 +5343,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5370,7 +5352,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d100;
+__arg0 = x139973624688423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5381,7 +5363,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f41126afec0 = __arg1;
+Obj x139973624340775 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5401,7 +5383,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f41126a7100 = __arg1;
+Obj x139973624341447 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 16, clofun4, 2, b, c);
@@ -5418,7 +5400,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f41126a7220 = __arg1;
+Obj x139973624341767 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 17, clofun4, 1, c);
@@ -5437,7 +5419,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f41126a7520 = __arg1;
+Obj x139973624342855 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun4, 1, c);
 __nargs = 3;
@@ -5453,7 +5435,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41126a7660 = __arg1;
+Obj x139973624343303 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 19, clofun4);
 __nargs = 5;
@@ -5471,7 +5453,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f41126a7920 = __arg1;
+Obj x139973624344135 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5485,30 +5467,30 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f411272d3c0 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41124add40 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124add40) {
-Obj v0x7f41124adf60 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124adf80 = PRIM_EQ(sym_37closure, v0x7f41124adf60);
-if (True == v0x7f41124adf80) {
-Obj v0x7f411248c120 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248c140 = PRIM_ISCONS(v0x7f411248c120);
-if (True == v0x7f411248c140) {
-Obj v0x7f411248c300 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248c320 = PRIM_CAR(v0x7f411248c300);
-Obj label = v0x7f411248c320;
-Obj v0x7f411248c560 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248c580 = PRIM_CDR(v0x7f411248c560);
-Obj v0x7f411248c5a0 = PRIM_ISCONS(v0x7f411248c580);
-if (True == v0x7f411248c5a0) {
-Obj v0x7f411248c7e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411248c800 = PRIM_CDR(v0x7f411248c7e0);
-Obj v0x7f411248c820 = PRIM_CAR(v0x7f411248c800);
-Obj nargs = v0x7f411248c820;
-Obj v0x7f41127430a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112743160 = PRIM_CDR(v0x7f41127430a0);
-Obj v0x7f4112743180 = PRIM_CDR(v0x7f4112743160);
-Obj frees = v0x7f4112743180;
+Obj x139973624640231 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973624847399 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624847399) {
+Obj x139973624848167 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624848263 = PRIM_EQ(sym_37closure, x139973624848167);
+if (True == x139973624848263) {
+Obj x139973624685255 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624685287 = PRIM_ISCONS(x139973624685255);
+if (True == x139973624685287) {
+Obj x139973624685895 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624686087 = PRIM_CAR(x139973624685895);
+Obj label = x139973624686087;
+Obj x139973624686951 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624686983 = PRIM_CDR(x139973624686951);
+Obj x139973624687015 = PRIM_ISCONS(x139973624686983);
+if (True == x139973624687015) {
+Obj x139973624687879 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624688039 = PRIM_CDR(x139973624687879);
+Obj x139973624688071 = PRIM_CAR(x139973624688039);
+Obj nargs = x139973624688071;
+Obj x139973624639943 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624639975 = PRIM_CDR(x139973624639943);
+Obj x139973624640007 = PRIM_CDR(x139973624639975);
+Obj frees = x139973624640007;
 pushCont(co, 21, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5521,7 +5503,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d3c0;
+__arg0 = x139973624640231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5530,7 +5512,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d3c0;
+__arg0 = x139973624640231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5539,7 +5521,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d3c0;
+__arg0 = x139973624640231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5548,7 +5530,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d3c0;
+__arg0 = x139973624640231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5559,16 +5541,16 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f4112743500 = __arg1;
+Obj x139973624640583 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112743dc0 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f4112743e80 = PRIM_SUB(v0x7f4112743dc0, label);
+Obj x139973624641895 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624642087 = PRIM_SUB(x139973624641895, label);
 pushCont(co, 22, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = v0x7f4112743e80;
+__arg1 = x139973624642087;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5579,7 +5561,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f4112743f60 = __arg1;
+Obj x139973624642151 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5587,7 +5569,7 @@ pushCont(co, 23, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = v0x7f4112743f60;
+__arg2 = x139973624642151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5597,7 +5579,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f4112743f80 = __arg1;
+Obj x139973624642183 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5615,17 +5597,17 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f411273e200 = __arg1;
+Obj x139973624642919 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f411273e6c0 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624529063 = PRIM_CAR(closureRef(co, 1));
 pushCont(co, 25, clofun4, 2, nargs, frees);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
 __arg2 = label;
-__arg3 = v0x7f411273e6c0;
+__arg3 = x139973624529063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5635,7 +5617,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f411273e6e0 = __arg1;
+Obj x139973624529095 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 26, clofun4, 2, nargs, frees);
@@ -5652,7 +5634,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411273ec60 = __arg1;
+Obj x139973624529543 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 27, clofun4, 1, frees);
@@ -5669,7 +5651,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f411273efc0 = __arg1;
+Obj x139973624530023 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun4, 1, frees);
 __nargs = 3;
@@ -5685,7 +5667,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj v0x7f411272d160 = __arg1;
+Obj x139973624530311 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun4, 1, frees);
 __nargs = 2;
@@ -5700,13 +5682,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj v0x7f411272d580 = __arg1;
+Obj x139973624531175 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = v0x7f411272d580;
+__arg2 = x139973624531175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5716,7 +5698,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f411272d5a0 = __arg1;
+Obj x139973624531207 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun4, 1, frees);
 __nargs = 2;
@@ -5731,10 +5713,10 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f411272da80 = __arg1;
+Obj x139973624532039 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272db00 = primNot(v0x7f411272da80);
-if (True == v0x7f411272db00) {
+Obj x139973624532071 = primNot(x139973624532039);
+if (True == x139973624532071) {
 pushCont(co, 32, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5761,7 +5743,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f411272dcc0 = __arg1;
+Obj x139973624532583 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun4);
 __nargs = 5;
@@ -5779,7 +5761,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f411272dec0 = __arg1;
+Obj x139973624532871 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5793,31 +5775,31 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f411272d6a0 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj v0x7f41124c47e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124c47e0) {
-Obj v0x7f41124c49a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124c49c0 = PRIM_EQ(symdo, v0x7f41124c49a0);
-if (True == v0x7f41124c49c0) {
-Obj v0x7f41124c4b60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c4b80 = PRIM_ISCONS(v0x7f41124c4b60);
-if (True == v0x7f41124c4b80) {
-Obj v0x7f41124c4d20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c4d40 = PRIM_CAR(v0x7f41124c4d20);
-Obj a = v0x7f41124c4d40;
-Obj v0x7f41124c4fc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124c4fe0 = PRIM_CDR(v0x7f41124c4fc0);
-Obj v0x7f41124ad000 = PRIM_ISCONS(v0x7f41124c4fe0);
-if (True == v0x7f41124ad000) {
-Obj v0x7f41124ad260 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ad280 = PRIM_CDR(v0x7f41124ad260);
-Obj v0x7f41124ad2a0 = PRIM_CAR(v0x7f41124ad280);
-Obj b = v0x7f41124ad2a0;
-Obj v0x7f41124ad5c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124ad5e0 = PRIM_CDR(v0x7f41124ad5c0);
-Obj v0x7f41124ad600 = PRIM_CDR(v0x7f41124ad5e0);
-Obj v0x7f41124ad620 = PRIM_EQ(Nil, v0x7f41124ad600);
-if (True == v0x7f41124ad620) {
+Obj x139973624640999 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139973624914919 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624914919) {
+Obj x139973624915879 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624915975 = PRIM_EQ(symdo, x139973624915879);
+if (True == x139973624915975) {
+Obj x139973624916583 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624916615 = PRIM_ISCONS(x139973624916583);
+if (True == x139973624916615) {
+Obj x139973624917351 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624917383 = PRIM_CAR(x139973624917351);
+Obj a = x139973624917383;
+Obj x139973624889991 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624890023 = PRIM_CDR(x139973624889991);
+Obj x139973624890055 = PRIM_ISCONS(x139973624890023);
+if (True == x139973624890055) {
+Obj x139973624890919 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624890951 = PRIM_CDR(x139973624890919);
+Obj x139973624891175 = PRIM_CAR(x139973624890951);
+Obj b = x139973624891175;
+Obj x139973624892679 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624892711 = PRIM_CDR(x139973624892679);
+Obj x139973624892743 = PRIM_CDR(x139973624892711);
+Obj x139973624892775 = PRIM_EQ(Nil, x139973624892743);
+if (True == x139973624892775) {
 pushCont(co, 35, clofun4, 1, b);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5832,7 +5814,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d6a0;
+__arg0 = x139973624640999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5841,7 +5823,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d6a0;
+__arg0 = x139973624640999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5850,7 +5832,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d6a0;
+__arg0 = x139973624640999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5859,7 +5841,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d6a0;
+__arg0 = x139973624640999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5868,7 +5850,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d6a0;
+__arg0 = x139973624640999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5879,7 +5861,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41124ad780 = __arg1;
+Obj x139973624844423 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 36, clofun4, 1, b);
 __nargs = 3;
@@ -5895,7 +5877,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41124ad8c0 = __arg1;
+Obj x139973624845351 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5912,22 +5894,22 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f411272d880 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj v0x7f41124d9e20 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124d9e20) {
-Obj v0x7f41124cb000 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124cb020 = PRIM_EQ(symreturn, v0x7f41124cb000);
-if (True == v0x7f41124cb020) {
-Obj v0x7f41124cb1c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cb1e0 = PRIM_ISCONS(v0x7f41124cb1c0);
-if (True == v0x7f41124cb1e0) {
-Obj v0x7f41124cb380 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cb3a0 = PRIM_CAR(v0x7f41124cb380);
-Obj x = v0x7f41124cb3a0;
-Obj v0x7f41124cb600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124cb620 = PRIM_CDR(v0x7f41124cb600);
-Obj v0x7f41124cb640 = PRIM_EQ(Nil, v0x7f41124cb620);
-if (True == v0x7f41124cb640) {
+Obj x139973624641735 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139973625789159 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625789159) {
+Obj x139973625789895 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625789927 = PRIM_EQ(symreturn, x139973625789895);
+if (True == x139973625789927) {
+Obj x139973625028775 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625028839 = PRIM_ISCONS(x139973625028775);
+if (True == x139973625028839) {
+Obj x139973625029735 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625029799 = PRIM_CAR(x139973625029735);
+Obj x = x139973625029799;
+Obj x139973625030759 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625030823 = PRIM_CDR(x139973625030759);
+Obj x139973625030855 = PRIM_EQ(Nil, x139973625030823);
+if (True == x139973625030855) {
 pushCont(co, 38, clofun4, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5940,7 +5922,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d880;
+__arg0 = x139973624641735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5949,7 +5931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d880;
+__arg0 = x139973624641735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5958,7 +5940,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d880;
+__arg0 = x139973624641735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5967,7 +5949,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d880;
+__arg0 = x139973624641735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5978,7 +5960,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41124cb8a0 = __arg1;
+Obj x139973625031335 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 39, clofun4, 1, x);
 __nargs = 3;
@@ -5994,7 +5976,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f41124cbb00 = __arg1;
+Obj x139973625032039 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun4);
 __nargs = 5;
@@ -6012,7 +5994,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41124cbce0 = __arg1;
+Obj x139973625032647 = __arg1;
 PUSH_CONT_0(co, 41, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6027,7 +6009,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj v0x7f41124cbe00 = __arg1;
+Obj x139973625012743 = __arg1;
 PUSH_CONT_0(co, 42, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6042,7 +6024,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f41124cbf20 = __arg1;
+Obj x139973625013287 = __arg1;
 PUSH_CONT_0(co, 43, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6057,15 +6039,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41124c4040 = __arg1;
-Obj v0x7f41124c4200 = PRIM_CDR(closureRef(co, 2));
-Obj v0x7f41124c42e0 = PRIM_CAR(closureRef(co, 2));
+Obj x139973625013703 = __arg1;
+Obj x139973625014727 = PRIM_CDR(closureRef(co, 2));
+Obj x139973625014951 = PRIM_CAR(closureRef(co, 2));
 PUSH_CONT_0(co, 44, clofun4);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
-__arg2 = v0x7f41124c4200;
-__arg3 = v0x7f41124c42e0;
+__arg2 = x139973625014727;
+__arg3 = x139973625014951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6075,7 +6057,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f41124c4300 = __arg1;
+Obj x139973625015015 = __arg1;
 PUSH_CONT_0(co, 45, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6090,7 +6072,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f41124c4420 = __arg1;
+Obj x139973625015783 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6104,22 +6086,22 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f411272da00 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj v0x7f41124d9220 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41124d9220) {
-Obj v0x7f41124d93e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41124d9400 = PRIM_EQ(symtailcall, v0x7f41124d93e0);
-if (True == v0x7f41124d9400) {
-Obj v0x7f41124d95a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d95c0 = PRIM_ISCONS(v0x7f41124d95a0);
-if (True == v0x7f41124d95c0) {
-Obj v0x7f41124d9760 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9780 = PRIM_CAR(v0x7f41124d9760);
-Obj exp = v0x7f41124d9780;
-Obj v0x7f41124d99e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124d9a00 = PRIM_CDR(v0x7f41124d99e0);
-Obj v0x7f41124d9a20 = PRIM_EQ(Nil, v0x7f41124d9a00);
-if (True == v0x7f41124d9a20) {
+Obj x139973624642247 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139973625854471 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625854471) {
+Obj x139973625855239 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625855271 = PRIM_EQ(symtailcall, x139973625855239);
+if (True == x139973625855271) {
+Obj x139973625855847 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625855911 = PRIM_ISCONS(x139973625855847);
+if (True == x139973625855911) {
+Obj x139973625823815 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625823911 = PRIM_CAR(x139973625823815);
+Obj exp = x139973625823911;
+Obj x139973625825127 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625825159 = PRIM_CDR(x139973625825127);
+Obj x139973625825351 = PRIM_EQ(Nil, x139973625825159);
+if (True == x139973625825351) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6133,7 +6115,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da00;
+__arg0 = x139973624642247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6142,7 +6124,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da00;
+__arg0 = x139973624642247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6151,7 +6133,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da00;
+__arg0 = x139973624642247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6160,7 +6142,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da00;
+__arg0 = x139973624642247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6171,31 +6153,31 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj v0x7f411272db60 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj v0x7f41125126e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125126e0) {
-Obj v0x7f41125128e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112512900 = PRIM_EQ(symcall, v0x7f41125128e0);
-if (True == v0x7f4112512900) {
-Obj v0x7f4112512ae0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512b00 = PRIM_ISCONS(v0x7f4112512ae0);
-if (True == v0x7f4112512b00) {
-Obj v0x7f4112512cc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512ce0 = PRIM_CAR(v0x7f4112512cc0);
-Obj exp = v0x7f4112512ce0;
-Obj v0x7f4112512f80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112512fa0 = PRIM_CDR(v0x7f4112512f80);
-Obj v0x7f4112512fc0 = PRIM_ISCONS(v0x7f4112512fa0);
-if (True == v0x7f4112512fc0) {
-Obj v0x7f41124eb200 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb220 = PRIM_CDR(v0x7f41124eb200);
-Obj v0x7f41124eb240 = PRIM_CAR(v0x7f41124eb220);
-Obj cont = v0x7f41124eb240;
-Obj v0x7f41124eb640 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41124eb660 = PRIM_CDR(v0x7f41124eb640);
-Obj v0x7f41124eb680 = PRIM_CDR(v0x7f41124eb660);
-Obj v0x7f41124eb6a0 = PRIM_EQ(Nil, v0x7f41124eb680);
-if (True == v0x7f41124eb6a0) {
+Obj x139973624642791 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139973623517895 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623517895) {
+Obj x139973623518343 = PRIM_CAR(closureRef(co, 0));
+Obj x139973623518375 = PRIM_EQ(symcall, x139973623518343);
+if (True == x139973623518375) {
+Obj x139973623518791 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623518823 = PRIM_ISCONS(x139973623518791);
+if (True == x139973623518823) {
+Obj x139973623519239 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623519271 = PRIM_CAR(x139973623519239);
+Obj exp = x139973623519271;
+Obj x139973623519847 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623519879 = PRIM_CDR(x139973623519847);
+Obj x139973623519911 = PRIM_ISCONS(x139973623519879);
+if (True == x139973623519911) {
+Obj x139973623520487 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623520519 = PRIM_CDR(x139973623520487);
+Obj x139973623520551 = PRIM_CAR(x139973623520519);
+Obj cont = x139973623520551;
+Obj x139973623472167 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623472199 = PRIM_CDR(x139973623472167);
+Obj x139973623472231 = PRIM_CDR(x139973623472199);
+Obj x139973623472263 = PRIM_EQ(Nil, x139973623472231);
+if (True == x139973623472263) {
 pushCont(co, 48, clofun4, 1, exp);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45cont);
@@ -6209,7 +6191,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272db60;
+__arg0 = x139973624642791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6218,7 +6200,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272db60;
+__arg0 = x139973624642791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6227,7 +6209,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272db60;
+__arg0 = x139973624642791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6236,7 +6218,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272db60;
+__arg0 = x139973624642791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6245,7 +6227,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272db60;
+__arg0 = x139973624642791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6256,7 +6238,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f41124eb800 = __arg1;
+Obj x139973625852199 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -6273,13 +6255,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f411272dd80 = makeNative(11, clofun5, 0, 0);
-Obj v0x7f411252cf00 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411252cf00) {
-Obj v0x7f4112529000 = PRIM_CAR(closureRef(co, 0));
-Obj f = v0x7f4112529000;
-Obj v0x7f4112529120 = PRIM_CDR(closureRef(co, 0));
-Obj args = v0x7f4112529120;
+Obj x139973624643527 = makeNative(11, clofun5, 0, 0);
+Obj x139973623652071 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623652071) {
+Obj x139973623652327 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139973623652327;
+Obj x139973623578855 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139973623578855;
 pushCont(co, 0, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6292,7 +6274,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dd80;
+__arg0 = x139973624643527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6323,7 +6305,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f4112529240 = __arg1;
+Obj x139973623579143 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 1, clofun5, 2, f, args);
@@ -6339,15 +6321,15 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f4112529500 = __arg1;
+Obj x139973623579783 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112529520 = PRIM_ADD(MAKE_NUMBER(1), v0x7f4112529500);
+Obj x139973623579815 = PRIM_ADD(MAKE_NUMBER(1), x139973623579783);
 pushCont(co, 2, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 2);
-__arg2 = v0x7f4112529520;
+__arg2 = x139973623579815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6357,7 +6339,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj v0x7f4112529540 = __arg1;
+Obj x139973623579847 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 3, clofun5, 2, f, args);
@@ -6374,17 +6356,17 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f4112529660 = __arg1;
+Obj x139973623580135 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125298a0 = makeCons(f, args);
+Obj x139973623580679 = makeCons(f, args);
 PUSH_CONT_0(co, 4, clofun5);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = MAKE_NUMBER(0);
-co->args[4] = v0x7f41125298a0;
+co->args[4] = x139973623580679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6394,7 +6376,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41125298c0 = __arg1;
+Obj x139973623580711 = __arg1;
 PUSH_CONT_0(co, 5, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6409,7 +6391,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41125299e0 = __arg1;
+Obj x139973623580999 = __arg1;
 PUSH_CONT_0(co, 6, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6424,7 +6406,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f4112529b20 = __arg1;
+Obj x139973623581287 = __arg1;
 PUSH_CONT_0(co, 7, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6439,7 +6421,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f4112529f20 = __arg1;
+Obj x139973623581575 = __arg1;
 PUSH_CONT_0(co, 8, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6454,15 +6436,15 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f4112512060 = __arg1;
-Obj v0x7f4112512220 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f4112512320 = PRIM_CAR(closureRef(co, 1));
+Obj x139973623581863 = __arg1;
+Obj x139973623582311 = PRIM_CDR(closureRef(co, 1));
+Obj x139973623582535 = PRIM_CAR(closureRef(co, 1));
 PUSH_CONT_0(co, 9, clofun5);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 2);
-__arg2 = v0x7f4112512220;
-__arg3 = v0x7f4112512320;
+__arg2 = x139973623582311;
+__arg3 = x139973623582535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6472,7 +6454,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f4112512340 = __arg1;
+Obj x139973623582567 = __arg1;
 PUSH_CONT_0(co, 10, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6487,7 +6469,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f4112512460 = __arg1;
+Obj x139973623517319 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -6528,10 +6510,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112563ec0 = __arg1;
+Obj x139973623648455 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val = v0x7f4112563ec0;
+Obj val = x139973623648455;
 pushCont(co, 14, clofun5, 3, sym, val, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -6546,21 +6528,21 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f411252c020 = __arg1;
+Obj x139973623648743 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == v0x7f411252c020) {
+if (True == x139973623648743) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f411252c240 = makeCons(sym, val);
-Obj v0x7f411252c260 = primSet(co, globals, v0x7f411252c240);
+Obj x139973623649159 = makeCons(sym, val);
+Obj x139973623649191 = primSet(co, globals, x139973623649159);
 __nargs = 2;
-__arg1 = v0x7f411252c260;
+__arg1 = x139973623649191;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6569,16 +6551,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj v0x7f4112743c20 = __arg1;
-Obj v0x7f4112743c40 = __arg2;
-Obj v0x7f4112743c60 = __arg3;
-Obj v0x7f4112743c80 = co->args[4];
-Obj v0x7f4112743e40 = makeNative(16, clofun5, 0, 4, v0x7f4112743c20, v0x7f4112743c40, v0x7f4112743c60, v0x7f4112743c80);
-Obj self = v0x7f4112743c20;
-Obj w = v0x7f4112743c40;
-Obj i = v0x7f4112743c60;
-Obj v0x7f4112563b60 = PRIM_EQ(Nil, v0x7f4112743c80);
-if (True == v0x7f4112563b60) {
+Obj x139973624845223 = __arg1;
+Obj x139973624845255 = __arg2;
+Obj x139973624845287 = __arg3;
+Obj x139973624845319 = co->args[4];
+Obj x139973624846023 = makeNative(16, clofun5, 0, 4, x139973624845223, x139973624845255, x139973624845287, x139973624845319);
+Obj self = x139973624845223;
+Obj w = x139973624845255;
+Obj i = x139973624845287;
+Obj x139973623668199 = PRIM_EQ(Nil, x139973624845319);
+if (True == x139973623668199) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -6586,7 +6568,7 @@ if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743e40;
+__arg0 = x139973624846023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6597,19 +6579,19 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f411273e120 = makeNative(28, clofun5, 0, 0);
+Obj x139973624847047 = makeNative(28, clofun5, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj v0x7f4112570220 = PRIM_ISCONS(closureRef(co, 3));
-if (True == v0x7f4112570220) {
-Obj v0x7f4112570320 = PRIM_CAR(closureRef(co, 3));
-Obj x = v0x7f4112570320;
-Obj v0x7f4112570420 = PRIM_CDR(closureRef(co, 3));
-Obj more = v0x7f4112570420;
-Obj v0x7f4112570640 = PRIM_GT(i, MAKE_NUMBER(3));
-Obj v0x7f4112570660 = primNot(v0x7f4112570640);
-if (True == v0x7f4112570660) {
+Obj x139973623684423 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139973623684423) {
+Obj x139973623684743 = PRIM_CAR(closureRef(co, 3));
+Obj x = x139973623684743;
+Obj x139973623684999 = PRIM_CDR(closureRef(co, 3));
+Obj more = x139973623684999;
+Obj x139973623673287 = PRIM_GT(i, MAKE_NUMBER(3));
+Obj x139973623673319 = primNot(x139973623673287);
+if (True == x139973623673319) {
 pushCont(co, 23, clofun5, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6634,7 +6616,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e120;
+__arg0 = x139973624847047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6645,7 +6627,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f4112563080 = __arg1;
+Obj x139973623665671 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6665,7 +6647,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41125631a0 = __arg1;
+Obj x139973623665959 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6685,7 +6667,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f4112563280 = __arg1;
+Obj x139973623666183 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6705,7 +6687,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f4112563420 = __arg1;
+Obj x139973623666471 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6727,7 +6709,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f4112563580 = __arg1;
+Obj x139973623666823 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6746,17 +6728,17 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f4112563700 = __arg1;
+Obj x139973623667111 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f41125638c0 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139973623667559 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = v0x7f41125638c0;
+__arg3 = x139973623667559;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6767,7 +6749,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f41125707c0 = __arg1;
+Obj x139973623673639 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6787,7 +6769,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f41125708a0 = __arg1;
+Obj x139973623673927 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6807,7 +6789,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f4112570a00 = __arg1;
+Obj x139973623674247 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6829,7 +6811,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f4112570ba0 = __arg1;
+Obj x139973623674599 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6848,17 +6830,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f4112570cc0 = __arg1;
+Obj x139973623674887 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj v0x7f4112570ee0 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139973623675367 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = v0x7f4112570ee0;
+__arg3 = x139973623675367;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6883,8 +6865,8 @@ label29:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj v0x7f41125c0540 = primGenSym();
-Obj tmp = v0x7f41125c0540;
+Obj x139973623681927 = primGenSym();
+Obj tmp = x139973623681927;
 pushCont(co, 30, clofun5, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
@@ -6898,15 +6880,15 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f41125c0a60 = __arg1;
+Obj x139973623682951 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125c0aa0 = makeCons(v0x7f41125c0a60, Nil);
-Obj v0x7f41125c0b20 = makeCons(x, v0x7f41125c0aa0);
-Obj v0x7f41125c0b40 = makeCons(tmp, v0x7f41125c0b20);
-Obj v0x7f41125c0b60 = makeCons(symlet, v0x7f41125c0b40);
+Obj x139973623683015 = makeCons(x139973623682951, Nil);
+Obj x139973623683047 = makeCons(x, x139973623683015);
+Obj x139973623683079 = makeCons(tmp, x139973623683047);
+Obj x139973623683111 = makeCons(symlet, x139973623683079);
 __nargs = 2;
-__arg1 = v0x7f41125c0b60;
+__arg1 = x139973623683111;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6930,10 +6912,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f41125c19a0 = __arg1;
+Obj x139973623687463 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj idx = v0x7f41125c19a0;
+Obj idx = x139973623687463;
 pushCont(co, 33, clofun5, 3, val, idx, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -6948,22 +6930,22 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41125c1ac0 = __arg1;
+Obj x139973623687783 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cur = v0x7f41125c1ac0;
-Obj v0x7f41125c1e80 = makeCons(val, Nil);
-Obj v0x7f41125c1ea0 = makeCons(idx, v0x7f41125c1e80);
-Obj v0x7f41125c1ee0 = makeCons(v0x7f41125c1ea0, cur);
-Obj cur1 = v0x7f41125c1ee0;
-Obj v0x7f41125c0140 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj cur = x139973623687783;
+Obj x139973623688519 = makeCons(val, Nil);
+Obj x139973623688551 = makeCons(idx, x139973623688519);
+Obj x139973623688615 = makeCons(x139973623688551, cur);
+Obj cur1 = x139973623688615;
+Obj x139973623681063 = PRIM_ADD(idx, MAKE_NUMBER(1));
 pushCont(co, 34, clofun5, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
 __arg1 = v;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = v0x7f41125c0140;
+__arg3 = x139973623681063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6973,7 +6955,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f41125c0160 = __arg1;
+Obj x139973623681127 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -6990,60 +6972,60 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f4112743120 = __arg1;
-Obj v0x7f4112743140 = __arg2;
-Obj v0x7f4112743240 = makeNative(1, clofun6, 0, 2, v0x7f4112743120, v0x7f4112743140);
-Obj v = v0x7f4112743120;
-Obj v0x7f41125fec60 = PRIM_ISCONS(v0x7f4112743140);
-if (True == v0x7f41125fec60) {
-Obj v0x7f41125fed80 = PRIM_CAR(v0x7f4112743140);
-Obj clo_45or_45cont = v0x7f41125fed80;
-Obj v0x7f41125fefe0 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125fb000 = PRIM_ISCONS(v0x7f41125fefe0);
-if (True == v0x7f41125fb000) {
-Obj v0x7f41125fb320 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125fb340 = PRIM_CAR(v0x7f41125fb320);
-Obj v0x7f41125fb3a0 = PRIM_ISCONS(v0x7f41125fb340);
-if (True == v0x7f41125fb3a0) {
-Obj v0x7f41125fb7a0 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125fb7c0 = PRIM_CAR(v0x7f41125fb7a0);
-Obj v0x7f41125fb7e0 = PRIM_CAR(v0x7f41125fb7c0);
-Obj v0x7f41125fb800 = PRIM_EQ(symlambda, v0x7f41125fb7e0);
-if (True == v0x7f41125fb800) {
-Obj v0x7f41125fbc00 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125fbc20 = PRIM_CAR(v0x7f41125fbc00);
-Obj v0x7f41125fbc60 = PRIM_CDR(v0x7f41125fbc20);
-Obj v0x7f41125fbc80 = PRIM_ISCONS(v0x7f41125fbc60);
-if (True == v0x7f41125fbc80) {
-Obj v0x7f41125ec0a0 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125ec160 = PRIM_CAR(v0x7f41125ec0a0);
-Obj v0x7f41125ec180 = PRIM_CDR(v0x7f41125ec160);
-Obj v0x7f41125ec1a0 = PRIM_CAR(v0x7f41125ec180);
-Obj params = v0x7f41125ec1a0;
-Obj v0x7f41125ec660 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125ec680 = PRIM_CAR(v0x7f41125ec660);
-Obj v0x7f41125ec6a0 = PRIM_CDR(v0x7f41125ec680);
-Obj v0x7f41125ec6c0 = PRIM_CDR(v0x7f41125ec6a0);
-Obj v0x7f41125ec6e0 = PRIM_ISCONS(v0x7f41125ec6c0);
-if (True == v0x7f41125ec6e0) {
-Obj v0x7f41125ecbe0 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125ecc20 = PRIM_CAR(v0x7f41125ecbe0);
-Obj v0x7f41125ecc40 = PRIM_CDR(v0x7f41125ecc20);
-Obj v0x7f41125ecc60 = PRIM_CDR(v0x7f41125ecc40);
-Obj v0x7f41125ecc80 = PRIM_CAR(v0x7f41125ecc60);
-Obj body = v0x7f41125ecc80;
-Obj v0x7f41125e7340 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125e7360 = PRIM_CAR(v0x7f41125e7340);
-Obj v0x7f41125e7380 = PRIM_CDR(v0x7f41125e7360);
-Obj v0x7f41125e73a0 = PRIM_CDR(v0x7f41125e7380);
-Obj v0x7f41125e73c0 = PRIM_CDR(v0x7f41125e73a0);
-Obj v0x7f41125e7400 = PRIM_EQ(Nil, v0x7f41125e73c0);
-if (True == v0x7f41125e7400) {
-Obj v0x7f41125e7720 = PRIM_CDR(v0x7f4112743140);
-Obj v0x7f41125e7740 = PRIM_CDR(v0x7f41125e7720);
-Obj fvs = v0x7f41125e7740;
-Obj v0x7f41125e7920 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == v0x7f41125e7920) {
+Obj x139973624890727 = __arg1;
+Obj x139973624890759 = __arg2;
+Obj x139973624891143 = makeNative(1, clofun6, 0, 2, x139973624890727, x139973624890759);
+Obj v = x139973624890727;
+Obj x139973624519015 = PRIM_ISCONS(x139973624890759);
+if (True == x139973624519015) {
+Obj x139973624519495 = PRIM_CAR(x139973624890759);
+Obj clo_45or_45cont = x139973624519495;
+Obj x139973624520263 = PRIM_CDR(x139973624890759);
+Obj x139973624520295 = PRIM_ISCONS(x139973624520263);
+if (True == x139973624520295) {
+Obj x139973624414727 = PRIM_CDR(x139973624890759);
+Obj x139973624414759 = PRIM_CAR(x139973624414727);
+Obj x139973624414791 = PRIM_ISCONS(x139973624414759);
+if (True == x139973624414791) {
+Obj x139973624415783 = PRIM_CDR(x139973624890759);
+Obj x139973624415815 = PRIM_CAR(x139973624415783);
+Obj x139973624415847 = PRIM_CAR(x139973624415815);
+Obj x139973624415975 = PRIM_EQ(symlambda, x139973624415847);
+if (True == x139973624415975) {
+Obj x139973624417511 = PRIM_CDR(x139973624890759);
+Obj x139973624417543 = PRIM_CAR(x139973624417511);
+Obj x139973624417607 = PRIM_CDR(x139973624417543);
+Obj x139973624417639 = PRIM_ISCONS(x139973624417607);
+if (True == x139973624417639) {
+Obj x139973624373543 = PRIM_CDR(x139973624890759);
+Obj x139973624373575 = PRIM_CAR(x139973624373543);
+Obj x139973624373607 = PRIM_CDR(x139973624373575);
+Obj x139973624373639 = PRIM_CAR(x139973624373607);
+Obj params = x139973624373639;
+Obj x139973624375239 = PRIM_CDR(x139973624890759);
+Obj x139973624375271 = PRIM_CAR(x139973624375239);
+Obj x139973624375303 = PRIM_CDR(x139973624375271);
+Obj x139973624375335 = PRIM_CDR(x139973624375303);
+Obj x139973624375367 = PRIM_ISCONS(x139973624375335);
+if (True == x139973624375367) {
+Obj x139973624376999 = PRIM_CDR(x139973624890759);
+Obj x139973624377159 = PRIM_CAR(x139973624376999);
+Obj x139973624377191 = PRIM_CDR(x139973624377159);
+Obj x139973624377223 = PRIM_CDR(x139973624377191);
+Obj x139973624377255 = PRIM_CAR(x139973624377223);
+Obj body = x139973624377255;
+Obj x139973624342055 = PRIM_CDR(x139973624890759);
+Obj x139973624342087 = PRIM_CAR(x139973624342055);
+Obj x139973624342119 = PRIM_CDR(x139973624342087);
+Obj x139973624342151 = PRIM_CDR(x139973624342119);
+Obj x139973624342183 = PRIM_CDR(x139973624342151);
+Obj x139973624342215 = PRIM_EQ(Nil, x139973624342183);
+if (True == x139973624342215) {
+Obj x139973624343015 = PRIM_CDR(x139973624890759);
+Obj x139973624343143 = PRIM_CDR(x139973624343015);
+Obj fvs = x139973624343143;
+Obj x139973624343623 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139973624343623) {
 if (True == True) {
 pushCont(co, 46, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7057,7 +7039,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7065,8 +7047,8 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj v0x7f41125d68c0 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
-if (True == v0x7f41125d68c0) {
+Obj x139973624224807 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
+if (True == x139973624224807) {
 if (True == True) {
 pushCont(co, 41, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7080,7 +7062,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7101,7 +7083,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7112,7 +7094,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7121,7 +7103,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7130,7 +7112,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7139,7 +7121,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7148,7 +7130,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7157,7 +7139,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7166,7 +7148,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743240;
+__arg0 = x139973624891143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7177,12 +7159,12 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41125cf7a0 = __arg1;
+Obj x139973624003399 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = v0x7f41125cf7a0;
+Obj body1 = x139973624003399;
 pushCont(co, 37, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7197,39 +7179,39 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41125cf8e0 = __arg1;
+Obj x139973624003911 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = v0x7f41125cf8e0;
-Obj v0x7f41125cfb00 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == v0x7f41125cfb00) {
-Obj v0x7f41125cd200 = makeCons(body1, Nil);
-Obj v0x7f41125cd220 = makeCons(Nil, v0x7f41125cd200);
-Obj v0x7f41125cd240 = makeCons(params, v0x7f41125cd220);
-Obj v0x7f41125cd260 = makeCons(symlambda, v0x7f41125cd240);
+Obj cur = x139973624003911;
+Obj x139973624004263 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139973624004263) {
+Obj x139973623731367 = makeCons(body1, Nil);
+Obj x139973623731399 = makeCons(Nil, x139973623731367);
+Obj x139973623731431 = makeCons(params, x139973623731399);
+Obj x139973623731463 = makeCons(symlambda, x139973623731431);
 pushCont(co, 39, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125cd260;
+__arg2 = x139973623731463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125cdd40 = makeCons(body1, Nil);
-Obj v0x7f41125cdd60 = makeCons(fvs, v0x7f41125cdd40);
-Obj v0x7f41125cddc0 = makeCons(params, v0x7f41125cdd60);
-Obj v0x7f41125cdde0 = makeCons(symlambda, v0x7f41125cddc0);
+Obj x139973623733895 = makeCons(body1, Nil);
+Obj x139973623733927 = makeCons(fvs, x139973623733895);
+Obj x139973623733959 = makeCons(params, x139973623733927);
+Obj x139973623733991 = makeCons(symlambda, x139973623733959);
 pushCont(co, 38, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125cdde0;
+__arg2 = x139973623733991;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7240,14 +7222,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41125cde00 = __arg1;
+Obj x139973623734023 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125c10e0 = makeCons(cur, fvs);
-Obj v0x7f41125c1100 = makeCons(clo_45or_45cont, v0x7f41125c10e0);
+Obj x139973623685543 = makeCons(cur, fvs);
+Obj x139973623685607 = makeCons(clo_45or_45cont, x139973623685543);
 __nargs = 2;
-__arg1 = v0x7f41125c1100;
+__arg1 = x139973623685607;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7255,7 +7237,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label39:
 {
-Obj v0x7f41125cd280 = __arg1;
+Obj x139973623731495 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7273,15 +7255,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f41125cd6c0 = __arg1;
+Obj x139973623732455 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125cd700 = makeCons(v0x7f41125cd6c0, fvs);
-Obj v0x7f41125cd720 = makeCons(cur, v0x7f41125cd700);
-Obj v0x7f41125cd7a0 = makeCons(clo_45or_45cont, v0x7f41125cd720);
+Obj x139973623732519 = makeCons(x139973623732455, fvs);
+Obj x139973623732551 = makeCons(cur, x139973623732519);
+Obj x139973623732583 = makeCons(clo_45or_45cont, x139973623732551);
 __nargs = 2;
-__arg1 = v0x7f41125cd7a0;
+__arg1 = x139973623732583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7289,12 +7271,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj v0x7f41125d6a80 = __arg1;
+Obj x139973624225095 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = v0x7f41125d6a80;
+Obj body1 = x139973624225095;
 pushCont(co, 42, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7309,39 +7291,39 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f41125d6c40 = __arg1;
+Obj x139973624225703 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = v0x7f41125d6c40;
-Obj v0x7f41125d6de0 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == v0x7f41125d6de0) {
-Obj v0x7f41125d23a0 = makeCons(body1, Nil);
-Obj v0x7f41125d23c0 = makeCons(Nil, v0x7f41125d23a0);
-Obj v0x7f41125d2440 = makeCons(params, v0x7f41125d23c0);
-Obj v0x7f41125d2480 = makeCons(symlambda, v0x7f41125d2440);
+Obj cur = x139973624225703;
+Obj x139973624078727 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139973624078727) {
+Obj x139973624080551 = makeCons(body1, Nil);
+Obj x139973624080743 = makeCons(Nil, x139973624080551);
+Obj x139973624080775 = makeCons(params, x139973624080743);
+Obj x139973624080807 = makeCons(symlambda, x139973624080775);
 pushCont(co, 44, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125d2480;
+__arg2 = x139973624080807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125cf0a0 = makeCons(body1, Nil);
-Obj v0x7f41125cf1e0 = makeCons(fvs, v0x7f41125cf0a0);
-Obj v0x7f41125cf200 = makeCons(params, v0x7f41125cf1e0);
-Obj v0x7f41125cf220 = makeCons(symlambda, v0x7f41125cf200);
+Obj x139973624001831 = makeCons(body1, Nil);
+Obj x139973624001927 = makeCons(fvs, x139973624001831);
+Obj x139973624001959 = makeCons(params, x139973624001927);
+Obj x139973624001991 = makeCons(symlambda, x139973624001959);
 pushCont(co, 43, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125cf220;
+__arg2 = x139973624001991;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7352,14 +7334,14 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41125cf240 = __arg1;
+Obj x139973624002023 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125cf400 = makeCons(cur, fvs);
-Obj v0x7f41125cf480 = makeCons(clo_45or_45cont, v0x7f41125cf400);
+Obj x139973624002631 = makeCons(cur, fvs);
+Obj x139973624002791 = makeCons(clo_45or_45cont, x139973624002631);
 __nargs = 2;
-__arg1 = v0x7f41125cf480;
+__arg1 = x139973624002791;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7367,7 +7349,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj v0x7f41125d2500 = __arg1;
+Obj x139973624080839 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7385,15 +7367,15 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f41125d29c0 = __arg1;
+Obj x139973624082055 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125d2a00 = makeCons(v0x7f41125d29c0, fvs);
-Obj v0x7f41125d2a20 = makeCons(cur, v0x7f41125d2a00);
-Obj v0x7f41125d2a40 = makeCons(clo_45or_45cont, v0x7f41125d2a20);
+Obj x139973624082151 = makeCons(x139973624082055, fvs);
+Obj x139973624082183 = makeCons(cur, x139973624082151);
+Obj x139973624082215 = makeCons(clo_45or_45cont, x139973624082183);
 __nargs = 2;
-__arg1 = v0x7f41125d2a40;
+__arg1 = x139973624082215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7401,12 +7383,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj v0x7f41125e7b20 = __arg1;
+Obj x139973624344231 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = v0x7f41125e7b20;
+Obj body1 = x139973624344231;
 pushCont(co, 47, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7421,39 +7403,39 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj v0x7f41125e7d80 = __arg1;
+Obj x139973624275047 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = v0x7f41125e7d80;
-Obj v0x7f41125e7f40 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == v0x7f41125e7f40) {
-Obj v0x7f41125e5620 = makeCons(body1, Nil);
-Obj v0x7f41125e5660 = makeCons(Nil, v0x7f41125e5620);
-Obj v0x7f41125e5680 = makeCons(params, v0x7f41125e5660);
-Obj v0x7f41125e56a0 = makeCons(symlambda, v0x7f41125e5680);
+Obj cur = x139973624275047;
+Obj x139973624275463 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139973624275463) {
+Obj x139973624277031 = makeCons(body1, Nil);
+Obj x139973624277159 = makeCons(Nil, x139973624277031);
+Obj x139973624277223 = makeCons(params, x139973624277159);
+Obj x139973624277255 = makeCons(symlambda, x139973624277223);
 pushCont(co, 49, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125e56a0;
+__arg2 = x139973624277255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41125d6220 = makeCons(body1, Nil);
-Obj v0x7f41125d62c0 = makeCons(fvs, v0x7f41125d6220);
-Obj v0x7f41125d6320 = makeCons(params, v0x7f41125d62c0);
-Obj v0x7f41125d6340 = makeCons(symlambda, v0x7f41125d6320);
+Obj x139973624222919 = makeCons(body1, Nil);
+Obj x139973624222951 = makeCons(fvs, x139973624222919);
+Obj x139973624222983 = makeCons(params, x139973624222951);
+Obj x139973624223015 = makeCons(symlambda, x139973624222983);
 pushCont(co, 48, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = v0x7f41125d6340;
+__arg2 = x139973624223015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7464,14 +7446,14 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f41125d63c0 = __arg1;
+Obj x139973624223047 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125d6680 = makeCons(cur, fvs);
-Obj v0x7f41125d66a0 = makeCons(clo_45or_45cont, v0x7f41125d6680);
+Obj x139973624223911 = makeCons(cur, fvs);
+Obj x139973624223943 = makeCons(clo_45or_45cont, x139973624223911);
 __nargs = 2;
-__arg1 = v0x7f41125d66a0;
+__arg1 = x139973624223943;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7479,7 +7461,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label49:
 {
-Obj v0x7f41125e56c0 = __arg1;
+Obj x139973624277287 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7517,15 +7499,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f41125e5c20 = __arg1;
+Obj x139973624278215 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125e5c60 = makeCons(v0x7f41125e5c20, fvs);
-Obj v0x7f41125e5c80 = makeCons(cur, v0x7f41125e5c60);
-Obj v0x7f41125e5ca0 = makeCons(clo_45or_45cont, v0x7f41125e5c80);
+Obj x139973624278375 = makeCons(x139973624278215, fvs);
+Obj x139973624278407 = makeCons(cur, x139973624278375);
+Obj x139973624278439 = makeCons(clo_45or_45cont, x139973624278407);
 __nargs = 2;
-__arg1 = v0x7f41125e5ca0;
+__arg1 = x139973624278439;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7533,11 +7515,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label1:
 {
-Obj v0x7f4112743760 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624892935 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj v0x7f41125fe6e0 = PRIM_ISCONS(f_45args);
-if (True == v0x7f41125fe6e0) {
+Obj x139973624517447 = PRIM_ISCONS(f_45args);
+if (True == x139973624517447) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = makeNative(2, clofun6, 1, 1, v);
@@ -7549,7 +7531,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743760;
+__arg0 = x139973624892935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7574,7 +7556,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f4112743920 = makeNative(4, clofun6, 0, 0);
+Obj x139973624844359 = makeNative(4, clofun6, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
@@ -7598,12 +7580,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f411272d1c0 = __arg1;
-Obj v0x7f411272d1e0 = __arg2;
-Obj v0x7f411272d2a0 = makeNative(7, clofun6, 0, 2, v0x7f411272d1c0, v0x7f411272d1e0);
-Obj __ = v0x7f411272d1c0;
-Obj x = v0x7f411272d1e0;
-pushCont(co, 6, clofun6, 2, x, v0x7f411272d2a0);
+Obj x139973625015431 = __arg1;
+Obj x139973625015463 = __arg2;
+Obj x139973625015847 = makeNative(7, clofun6, 0, 2, x139973625015431, x139973625015463);
+Obj __ = x139973625015431;
+Obj x = x139973625015463;
+pushCont(co, 6, clofun6, 2, x, x139973625015847);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -7616,10 +7598,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f4112603ec0 = __arg1;
+Obj x139973624531623 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272d2a0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f4112603ec0) {
+Obj x139973625015847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624531623) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7627,7 +7609,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d2a0;
+__arg0 = x139973625015847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7638,11 +7620,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f411272d400 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624914023 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj v0x7f4112603b80 = primIsSymbol(var);
-if (True == v0x7f4112603b80) {
+Obj x139973624530823 = primIsSymbol(var);
+if (True == x139973624530823) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7650,7 +7632,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d400;
+__arg0 = x139973624914023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7661,32 +7643,32 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f411272d620 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624914567 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj v0x7f4112669de0 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f4112669de0) {
-Obj v0x7f411261b000 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f411261b020 = PRIM_EQ(symlambda, v0x7f411261b000);
-if (True == v0x7f411261b020) {
-Obj v0x7f411261b200 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261b220 = PRIM_ISCONS(v0x7f411261b200);
-if (True == v0x7f411261b220) {
-Obj v0x7f411261b480 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261b4e0 = PRIM_CAR(v0x7f411261b480);
-Obj args = v0x7f411261b4e0;
-Obj v0x7f411261b7c0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261b7e0 = PRIM_CDR(v0x7f411261b7c0);
-Obj v0x7f411261b800 = PRIM_ISCONS(v0x7f411261b7e0);
-if (True == v0x7f411261b800) {
-Obj v0x7f411261baa0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261bac0 = PRIM_CDR(v0x7f411261baa0);
-Obj v0x7f411261bae0 = PRIM_CAR(v0x7f411261bac0);
-Obj body = v0x7f411261bae0;
-Obj v0x7f411261bfc0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f4112603020 = PRIM_CDR(v0x7f411261bfc0);
-Obj v0x7f4112603060 = PRIM_CDR(v0x7f4112603020);
-Obj v0x7f4112603080 = PRIM_EQ(Nil, v0x7f4112603060);
-if (True == v0x7f4112603080) {
+Obj x139973624686599 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973624686599) {
+Obj x139973624687079 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624687111 = PRIM_EQ(symlambda, x139973624687079);
+if (True == x139973624687111) {
+Obj x139973624687655 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624687719 = PRIM_ISCONS(x139973624687655);
+if (True == x139973624687719) {
+Obj x139973624688295 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624688327 = PRIM_CAR(x139973624688295);
+Obj args = x139973624688327;
+Obj x139973624640103 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624640135 = PRIM_CDR(x139973624640103);
+Obj x139973624640167 = PRIM_ISCONS(x139973624640135);
+if (True == x139973624640167) {
+Obj x139973624641159 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624641223 = PRIM_CDR(x139973624641159);
+Obj x139973624641255 = PRIM_CAR(x139973624641223);
+Obj body = x139973624641255;
+Obj x139973624642599 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624642631 = PRIM_CDR(x139973624642599);
+Obj x139973624642663 = PRIM_CDR(x139973624642631);
+Obj x139973624642695 = PRIM_EQ(Nil, x139973624642663);
+if (True == x139973624642695) {
 pushCont(co, 9, clofun6, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7699,7 +7681,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d620;
+__arg0 = x139973624914567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7708,7 +7690,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d620;
+__arg0 = x139973624914567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7717,7 +7699,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d620;
+__arg0 = x139973624914567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7726,7 +7708,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d620;
+__arg0 = x139973624914567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7735,7 +7717,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d620;
+__arg0 = x139973624914567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7746,13 +7728,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f41126034e0 = __arg1;
+Obj x139973624529191 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112603520 = makeCons(v0x7f41126034e0, Nil);
-Obj v0x7f4112603540 = makeCons(args, v0x7f4112603520);
-Obj v0x7f4112603560 = makeCons(symlambda, v0x7f4112603540);
+Obj x139973624529287 = makeCons(x139973624529191, Nil);
+Obj x139973624529319 = makeCons(args, x139973624529287);
+Obj x139973624529351 = makeCons(symlambda, x139973624529319);
 __nargs = 2;
-__arg1 = v0x7f4112603560;
+__arg1 = x139973624529351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7760,32 +7742,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label10:
 {
-Obj v0x7f411272d920 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624915847 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj v0x7f41126af960 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41126af960) {
-Obj v0x7f41126afc00 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41126afc20 = PRIM_EQ(symcontinuation, v0x7f41126afc00);
-if (True == v0x7f41126afc20) {
-Obj v0x7f41126afe20 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126afe40 = PRIM_ISCONS(v0x7f41126afe20);
-if (True == v0x7f41126afe40) {
-Obj v0x7f41126a7060 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a70c0 = PRIM_CAR(v0x7f41126a7060);
-Obj val = v0x7f41126a70c0;
-Obj v0x7f41126a73e0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7400 = PRIM_CDR(v0x7f41126a73e0);
-Obj v0x7f41126a7420 = PRIM_ISCONS(v0x7f41126a7400);
-if (True == v0x7f41126a7420) {
-Obj v0x7f41126a7700 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7720 = PRIM_CDR(v0x7f41126a7700);
-Obj v0x7f41126a7740 = PRIM_CAR(v0x7f41126a7720);
-Obj body = v0x7f41126a7740;
-Obj v0x7f41126a7c20 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7c60 = PRIM_CDR(v0x7f41126a7c20);
-Obj v0x7f41126a7c80 = PRIM_CDR(v0x7f41126a7c60);
-Obj v0x7f41126a7ca0 = PRIM_EQ(Nil, v0x7f41126a7c80);
-if (True == v0x7f41126a7ca0) {
+Obj x139973624916807 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973624916807) {
+Obj x139973624917479 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624917575 = PRIM_EQ(symcontinuation, x139973624917479);
+if (True == x139973624917575) {
+Obj x139973624889415 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624889447 = PRIM_ISCONS(x139973624889415);
+if (True == x139973624889447) {
+Obj x139973624890311 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624890343 = PRIM_CAR(x139973624890311);
+Obj val = x139973624890343;
+Obj x139973624891303 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624891463 = PRIM_CDR(x139973624891303);
+Obj x139973624891495 = PRIM_ISCONS(x139973624891463);
+if (True == x139973624891495) {
+Obj x139973624892391 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624892519 = PRIM_CDR(x139973624892391);
+Obj x139973624892551 = PRIM_CAR(x139973624892519);
+Obj body = x139973624892551;
+Obj x139973624844935 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624844967 = PRIM_CDR(x139973624844935);
+Obj x139973624844999 = PRIM_CDR(x139973624844967);
+Obj x139973624845031 = PRIM_EQ(Nil, x139973624844999);
+if (True == x139973624845031) {
 pushCont(co, 11, clofun6, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -7797,7 +7779,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d920;
+__arg0 = x139973624915847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7806,7 +7788,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d920;
+__arg0 = x139973624915847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7815,7 +7797,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d920;
+__arg0 = x139973624915847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7824,7 +7806,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d920;
+__arg0 = x139973624915847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7833,7 +7815,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d920;
+__arg0 = x139973624915847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7844,14 +7826,14 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f41126a7ee0 = __arg1;
+Obj x139973624845895 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 12, clofun6, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = v0x7f41126a7ee0;
+__arg1 = x139973624845895;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7862,11 +7844,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f41126a7f20 = __arg1;
+Obj x139973624845959 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = v0x7f41126a7f20;
+Obj fvs1 = x139973624845959;
 pushCont(co, 13, clofun6, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7880,14 +7862,14 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112669100 = __arg1;
+Obj x139973624846599 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 14, clofun6, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f4112669100;
+__arg1 = x139973624846599;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7898,11 +7880,11 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f4112669140 = __arg1;
+Obj x139973624846823 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs2 = v0x7f4112669140;
+Obj fvs2 = x139973624846823;
 pushCont(co, 15, clofun6, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7917,16 +7899,16 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f4112669700 = __arg1;
+Obj x139973624684647 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112669780 = makeCons(v0x7f4112669700, Nil);
-Obj v0x7f41126697a0 = makeCons(val, v0x7f4112669780);
-Obj v0x7f41126697c0 = makeCons(symlambda, v0x7f41126697a0);
-Obj v0x7f4112669800 = makeCons(v0x7f41126697c0, fvs2);
-Obj v0x7f4112669820 = makeCons(sym_37continuation, v0x7f4112669800);
+Obj x139973624684711 = makeCons(x139973624684647, Nil);
+Obj x139973624684775 = makeCons(val, x139973624684711);
+Obj x139973624684807 = makeCons(symlambda, x139973624684775);
+Obj x139973624684935 = makeCons(x139973624684807, fvs2);
+Obj x139973624684999 = makeCons(sym_37continuation, x139973624684935);
 __nargs = 2;
-__arg1 = v0x7f4112669820;
+__arg1 = x139973624684999;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7934,32 +7916,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj v0x7f411272dc40 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624917095 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj v0x7f41126cf5c0 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41126cf5c0) {
-Obj v0x7f41126cf980 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41126cf9a0 = PRIM_EQ(symcall, v0x7f41126cf980);
-if (True == v0x7f41126cf9a0) {
-Obj v0x7f41126cfec0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126cfee0 = PRIM_ISCONS(v0x7f41126cfec0);
-if (True == v0x7f41126cfee0) {
-Obj v0x7f41126b51a0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126b51c0 = PRIM_CAR(v0x7f41126b51a0);
-Obj exp = v0x7f41126b51c0;
-Obj v0x7f41126b5560 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126b55a0 = PRIM_CDR(v0x7f41126b5560);
-Obj v0x7f41126b55c0 = PRIM_ISCONS(v0x7f41126b55a0);
-if (True == v0x7f41126b55c0) {
-Obj v0x7f41126b58e0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126b5900 = PRIM_CDR(v0x7f41126b58e0);
-Obj v0x7f41126b5920 = PRIM_CAR(v0x7f41126b5900);
-Obj cont = v0x7f41126b5920;
-Obj v0x7f41126b5d20 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126b5d40 = PRIM_CDR(v0x7f41126b5d20);
-Obj v0x7f41126b5d60 = PRIM_CDR(v0x7f41126b5d40);
-Obj v0x7f41126b5d80 = PRIM_EQ(Nil, v0x7f41126b5d60);
-if (True == v0x7f41126b5d80) {
+Obj x139973625030471 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973625030471) {
+Obj x139973625031015 = PRIM_CAR(closureRef(co, 1));
+Obj x139973625031047 = PRIM_EQ(symcall, x139973625031015);
+if (True == x139973625031047) {
+Obj x139973625031943 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625031975 = PRIM_ISCONS(x139973625031943);
+if (True == x139973625031975) {
+Obj x139973625032583 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625032615 = PRIM_CAR(x139973625032583);
+Obj exp = x139973625032615;
+Obj x139973625013127 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625013159 = PRIM_CDR(x139973625013127);
+Obj x139973625013191 = PRIM_ISCONS(x139973625013159);
+if (True == x139973625013191) {
+Obj x139973625013991 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625014023 = PRIM_CDR(x139973625013991);
+Obj x139973625014055 = PRIM_CAR(x139973625014023);
+Obj cont = x139973625014055;
+Obj x139973625015399 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625015495 = PRIM_CDR(x139973625015399);
+Obj x139973625015655 = PRIM_CDR(x139973625015495);
+Obj x139973625015719 = PRIM_EQ(Nil, x139973625015655);
+if (True == x139973625015719) {
 pushCont(co, 17, clofun6, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7971,7 +7953,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dc40;
+__arg0 = x139973624917095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7980,7 +7962,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dc40;
+__arg0 = x139973624917095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7989,7 +7971,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dc40;
+__arg0 = x139973624917095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7998,7 +7980,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dc40;
+__arg0 = x139973624917095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8007,7 +7989,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dc40;
+__arg0 = x139973624917095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8018,14 +8000,14 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f41126af120 = __arg1;
+Obj x139973624914375 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 18, clofun6, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f41126af120;
+__arg1 = x139973624914375;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8036,10 +8018,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41126af160 = __arg1;
+Obj x139973624914439 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 19, clofun6, 1, v0x7f41126af160);
+pushCont(co, 19, clofun6, 1, x139973624914439);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
 __arg1 = fvs;
@@ -8053,13 +8035,13 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f41126af3a0 = __arg1;
-Obj v0x7f41126af160= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41126af400 = makeCons(v0x7f41126af3a0, Nil);
-Obj v0x7f41126af460 = makeCons(v0x7f41126af160, v0x7f41126af400);
-Obj v0x7f41126af480 = makeCons(symcall, v0x7f41126af460);
+Obj x139973624915015 = __arg1;
+Obj x139973624914439= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624915079 = makeCons(x139973624915015, Nil);
+Obj x139973624915175 = makeCons(x139973624914439, x139973624915079);
+Obj x139973624915207 = makeCons(symcall, x139973624915175);
 __nargs = 2;
-__arg1 = v0x7f41126af480;
+__arg1 = x139973624915207;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8067,14 +8049,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label20:
 {
-Obj v0x7f411272df40 = makeNative(22, clofun6, 0, 0);
+Obj x139973624889703 = makeNative(22, clofun6, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj v0x7f411272db80 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f411272db80) {
-Obj v0x7f411272dce0 = PRIM_CAR(closureRef(co, 1));
-Obj f = v0x7f411272dce0;
-Obj v0x7f411272de80 = PRIM_CDR(closureRef(co, 1));
-Obj args = v0x7f411272de80;
+Obj x139973625789767 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973625789767) {
+Obj x139973625790087 = PRIM_CAR(closureRef(co, 1));
+Obj f = x139973625790087;
+Obj x139973625028679 = PRIM_CDR(closureRef(co, 1));
+Obj args = x139973625028679;
 pushCont(co, 21, clofun6, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -8086,7 +8068,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272df40;
+__arg0 = x139973624889703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8097,14 +8079,14 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f41126cf120 = __arg1;
+Obj x139973625029415 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41126cf2e0 = makeCons(f, args);
+Obj x139973625029767 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f41126cf120;
-__arg2 = v0x7f41126cf2e0;
+__arg1 = x139973625029415;
+__arg2 = x139973625029767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8126,14 +8108,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f411273e9a0 = __arg1;
-Obj v0x7f411273e9c0 = __arg2;
-Obj v0x7f411273e9e0 = __arg3;
-Obj v0x7f411273eb20 = makeNative(30, clofun6, 0, 3, v0x7f411273e9a0, v0x7f411273e9c0, v0x7f411273e9e0);
-Obj v0x7f41125124a0 = PRIM_EQ(Nil, v0x7f411273e9a0);
-if (True == v0x7f41125124a0) {
-Obj ls = v0x7f411273e9c0;
-Obj next = v0x7f411273e9e0;
+Obj x139973625012423 = __arg1;
+Obj x139973625012455 = __arg2;
+Obj x139973625012487 = __arg3;
+Obj x139973625013063 = makeNative(30, clofun6, 0, 3, x139973625012423, x139973625012455, x139973625012487);
+Obj x139973623683815 = PRIM_EQ(Nil, x139973625012423);
+if (True == x139973623683815) {
+Obj ls = x139973625012455;
+Obj next = x139973625012487;
 pushCont(co, 24, clofun6, 1, next);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -8145,7 +8127,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273eb20;
+__arg0 = x139973625013063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8156,14 +8138,14 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f4112512620 = __arg1;
+Obj x139973623684199 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp = v0x7f4112512620;
-Obj v0x7f4112512800 = PRIM_CAR(exp);
+Obj exp = x139973623684199;
+Obj x139973623684679 = PRIM_CAR(exp);
 pushCont(co, 25, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = v0x7f4112512800;
+__arg1 = x139973623684679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8173,10 +8155,10 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f4112512820 = __arg1;
+Obj x139973623684711 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f4112512820) {
+if (True == x139973623684711) {
 pushCont(co, 27, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -8198,20 +8180,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f4112743400 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == v0x7f4112743400) {
-Obj v0x7f4112743840 = makeCons(exp, Nil);
-Obj v0x7f41127438c0 = makeCons(symtailcall, v0x7f4112743840);
+Obj x139973625853991 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139973625853991) {
+Obj x139973625854759 = makeCons(exp, Nil);
+Obj x139973625854791 = makeCons(symtailcall, x139973625854759);
 __nargs = 2;
-__arg1 = v0x7f41127438c0;
+__arg1 = x139973625854791;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f4112743aa0 = primGenSym();
-Obj val = v0x7f4112743aa0;
-Obj v0x7f411273e5e0 = makeCons(val, Nil);
-pushCont(co, 26, clofun6, 2, v0x7f411273e5e0, exp);
+Obj x139973625855047 = primGenSym();
+Obj val = x139973625855047;
+Obj x139973625823879 = makeCons(val, Nil);
+pushCont(co, 26, clofun6, 2, x139973625823879, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8227,17 +8209,17 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411273e920 = __arg1;
-Obj v0x7f411273e5e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973625824359 = __arg1;
+Obj x139973625823879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f411273e960 = makeCons(v0x7f411273e920, Nil);
-Obj v0x7f411273e980 = makeCons(v0x7f411273e5e0, v0x7f411273e960);
-Obj v0x7f411273eac0 = makeCons(symcontinuation, v0x7f411273e980);
-Obj v0x7f411273eba0 = makeCons(v0x7f411273eac0, Nil);
-Obj v0x7f411273ebc0 = makeCons(exp, v0x7f411273eba0);
-Obj v0x7f411273ec00 = makeCons(symcall, v0x7f411273ebc0);
+Obj x139973625824487 = makeCons(x139973625824359, Nil);
+Obj x139973625824519 = makeCons(x139973625823879, x139973625824487);
+Obj x139973625824647 = makeCons(symcontinuation, x139973625824519);
+Obj x139973625824743 = makeCons(x139973625824647, Nil);
+Obj x139973625824775 = makeCons(exp, x139973625824743);
+Obj x139973625824807 = makeCons(symcall, x139973625824775);
 __nargs = 2;
-__arg1 = v0x7f411273ec00;
+__arg1 = x139973625824807;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8245,11 +8227,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj v0x7f41125129c0 = __arg1;
+Obj x139973623672839 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112512a00 = PRIM_EQ(v0x7f41125129c0, sym_37builtin);
-if (True == v0x7f4112512a00) {
+Obj x139973623672903 = PRIM_EQ(x139973623672839, sym_37builtin);
+if (True == x139973623672903) {
 if (True == True) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
@@ -8261,20 +8243,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f4112512be0 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == v0x7f4112512be0) {
-Obj v0x7f4112512d80 = makeCons(exp, Nil);
-Obj v0x7f4112512da0 = makeCons(symtailcall, v0x7f4112512d80);
+Obj x139973623673383 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139973623673383) {
+Obj x139973623673799 = makeCons(exp, Nil);
+Obj x139973623673831 = makeCons(symtailcall, x139973623673799);
 __nargs = 2;
-__arg1 = v0x7f4112512da0;
+__arg1 = x139973623673831;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f4112512e80 = primGenSym();
-Obj val = v0x7f4112512e80;
-Obj v0x7f41124eb2e0 = makeCons(val, Nil);
-pushCont(co, 29, clofun6, 2, v0x7f41124eb2e0, exp);
+Obj x139973623674055 = primGenSym();
+Obj val = x139973623674055;
+Obj x139973623675175 = makeCons(val, Nil);
+pushCont(co, 29, clofun6, 2, x139973623675175, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8297,20 +8279,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f41124eb740 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == v0x7f41124eb740) {
-Obj v0x7f41124eb8e0 = makeCons(exp, Nil);
-Obj v0x7f41124eb900 = makeCons(symtailcall, v0x7f41124eb8e0);
+Obj x139973623676295 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139973623676295) {
+Obj x139973623676711 = makeCons(exp, Nil);
+Obj x139973623676743 = makeCons(symtailcall, x139973623676711);
 __nargs = 2;
-__arg1 = v0x7f41124eb900;
+__arg1 = x139973623676743;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f41124eb9e0 = primGenSym();
-Obj val = v0x7f41124eb9e0;
-Obj v0x7f41124ebe40 = makeCons(val, Nil);
-pushCont(co, 28, clofun6, 2, v0x7f41124ebe40, exp);
+Obj x139973623664679 = primGenSym();
+Obj val = x139973623664679;
+Obj x139973625852167 = makeCons(val, Nil);
+pushCont(co, 28, clofun6, 2, x139973625852167, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8326,17 +8308,17 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj v0x7f41124ebfc0 = __arg1;
-Obj v0x7f41124ebe40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973625852871 = __arg1;
+Obj x139973625852167= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124d9000 = makeCons(v0x7f41124ebfc0, Nil);
-Obj v0x7f41124d9020 = makeCons(v0x7f41124ebe40, v0x7f41124d9000);
-Obj v0x7f41124d9040 = makeCons(symcontinuation, v0x7f41124d9020);
-Obj v0x7f41124d9080 = makeCons(v0x7f41124d9040, Nil);
-Obj v0x7f41124d90a0 = makeCons(exp, v0x7f41124d9080);
-Obj v0x7f41124d90c0 = makeCons(symcall, v0x7f41124d90a0);
+Obj x139973625852935 = makeCons(x139973625852871, Nil);
+Obj x139973625852967 = makeCons(x139973625852167, x139973625852935);
+Obj x139973625853031 = makeCons(symcontinuation, x139973625852967);
+Obj x139973625853095 = makeCons(x139973625853031, Nil);
+Obj x139973625853127 = makeCons(exp, x139973625853095);
+Obj x139973625853255 = makeCons(symcall, x139973625853127);
 __nargs = 2;
-__arg1 = v0x7f41124d90c0;
+__arg1 = x139973625853255;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8344,17 +8326,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label29:
 {
-Obj v0x7f41124eb460 = __arg1;
-Obj v0x7f41124eb2e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973623675559 = __arg1;
+Obj x139973623675175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41124eb4a0 = makeCons(v0x7f41124eb460, Nil);
-Obj v0x7f41124eb4c0 = makeCons(v0x7f41124eb2e0, v0x7f41124eb4a0);
-Obj v0x7f41124eb4e0 = makeCons(symcontinuation, v0x7f41124eb4c0);
-Obj v0x7f41124eb520 = makeCons(v0x7f41124eb4e0, Nil);
-Obj v0x7f41124eb540 = makeCons(exp, v0x7f41124eb520);
-Obj v0x7f41124eb560 = makeCons(symcall, v0x7f41124eb540);
+Obj x139973623675623 = makeCons(x139973623675559, Nil);
+Obj x139973623675655 = makeCons(x139973623675175, x139973623675623);
+Obj x139973623675687 = makeCons(symcontinuation, x139973623675655);
+Obj x139973623675751 = makeCons(x139973623675687, Nil);
+Obj x139973623675783 = makeCons(exp, x139973623675751);
+Obj x139973623675815 = makeCons(symcall, x139973623675783);
 __nargs = 2;
-__arg1 = v0x7f41124eb560;
+__arg1 = x139973623675815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8362,13 +8344,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label30:
 {
-Obj v0x7f411273ed20 = makeNative(32, clofun6, 0, 0);
-Obj v0x7f4112529b00 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112529b00) {
-Obj v0x7f4112529ec0 = PRIM_CAR(closureRef(co, 0));
-Obj hd = v0x7f4112529ec0;
-Obj v0x7f4112529fc0 = PRIM_CDR(closureRef(co, 0));
-Obj tl = v0x7f4112529fc0;
+Obj x139973625013863 = makeNative(32, clofun6, 0, 0);
+Obj x139973623682055 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623682055) {
+Obj x139973623682311 = PRIM_CAR(closureRef(co, 0));
+Obj hd = x139973623682311;
+Obj x139973623682567 = PRIM_CDR(closureRef(co, 0));
+Obj tl = x139973623682567;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 __nargs = 3;
@@ -8382,7 +8364,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ed20;
+__arg0 = x139973625013863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8394,11 +8376,11 @@ goto *jumpTable[ps.label];
 label31:
 {
 Obj hd1 = __arg1;
-Obj v0x7f41125122e0 = makeCons(hd1, closureRef(co, 1));
+Obj x139973623683367 = makeCons(hd1, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
 __arg1 = closureRef(co, 0);
-__arg2 = v0x7f41125122e0;
+__arg2 = x139973623683367;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8421,13 +8403,13 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f4112743260 = __arg1;
-Obj v0x7f4112743280 = __arg2;
-Obj v0x7f4112743360 = makeNative(35, clofun6, 0, 2, v0x7f4112743260, v0x7f4112743280);
-Obj x = v0x7f4112743260;
-Obj next = v0x7f4112743280;
-Obj v0x7f41125292a0 = primIsSymbol(x);
-if (True == v0x7f41125292a0) {
+Obj x139973625824839 = __arg1;
+Obj x139973625824871 = __arg2;
+Obj x139973625825255 = makeNative(35, clofun6, 0, 2, x139973625824839, x139973625824871);
+Obj x = x139973625824839;
+Obj next = x139973625824871;
+Obj x139973623687079 = primIsSymbol(x);
+if (True == x139973623687079) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8439,7 +8421,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743360;
+__arg0 = x139973625825255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8447,7 +8429,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 34, clofun6, 3, next, x, v0x7f4112743360);
+pushCont(co, 34, clofun6, 3, next, x, x139973625825255);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8461,11 +8443,11 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f41125294c0 = __arg1;
+Obj x139973623687623 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112743360= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == v0x7f41125294c0) {
+Obj x139973625825255= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139973623687623) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8477,7 +8459,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743360;
+__arg0 = x139973625825255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8496,7 +8478,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743360;
+__arg0 = x139973625825255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8508,10 +8490,10 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41127434c0 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973625825799 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 36, clofun6, 2, x, v0x7f41127434c0);
+pushCont(co, 36, clofun6, 2, x, x139973625825799);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8524,10 +8506,10 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f4112529060 = __arg1;
+Obj x139973623686439 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41127434c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f4112529060) {
+Obj x139973625825799= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973623686439) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -8535,7 +8517,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127434c0;
+__arg0 = x139973625825799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8546,42 +8528,42 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41127436c0 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f41125c01c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125c01c0) {
-Obj v0x7f41125c03e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125c0400 = PRIM_EQ(symif, v0x7f41125c03e0);
-if (True == v0x7f41125c0400) {
-Obj v0x7f41125c0620 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0640 = PRIM_ISCONS(v0x7f41125c0620);
-if (True == v0x7f41125c0640) {
-Obj v0x7f41125c07e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0800 = PRIM_CAR(v0x7f41125c07e0);
-Obj a = v0x7f41125c0800;
-Obj v0x7f41125c0ac0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0ae0 = PRIM_CDR(v0x7f41125c0ac0);
-Obj v0x7f41125c0b00 = PRIM_ISCONS(v0x7f41125c0ae0);
-if (True == v0x7f41125c0b00) {
-Obj v0x7f41125c0de0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0e00 = PRIM_CDR(v0x7f41125c0de0);
-Obj v0x7f41125c0e20 = PRIM_CAR(v0x7f41125c0e00);
-Obj b = v0x7f41125c0e20;
-Obj v0x7f4112570180 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125701a0 = PRIM_CDR(v0x7f4112570180);
-Obj v0x7f41125701c0 = PRIM_CDR(v0x7f41125701a0);
-Obj v0x7f41125701e0 = PRIM_ISCONS(v0x7f41125701c0);
-if (True == v0x7f41125701e0) {
-Obj v0x7f411252c0e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411252c100 = PRIM_CDR(v0x7f411252c0e0);
-Obj v0x7f411252c120 = PRIM_CDR(v0x7f411252c100);
-Obj v0x7f411252c140 = PRIM_CAR(v0x7f411252c120);
-Obj c = v0x7f411252c140;
-Obj v0x7f411252c4e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411252c500 = PRIM_CDR(v0x7f411252c4e0);
-Obj v0x7f411252c520 = PRIM_CDR(v0x7f411252c500);
-Obj v0x7f411252c540 = PRIM_CDR(v0x7f411252c520);
-Obj v0x7f411252c560 = PRIM_EQ(Nil, v0x7f411252c540);
-if (True == v0x7f411252c560) {
+Obj x139973625826343 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624082087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624082087) {
+Obj x139973624000743 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624000775 = PRIM_EQ(symif, x139973624000743);
+if (True == x139973624000775) {
+Obj x139973624001319 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624001351 = PRIM_ISCONS(x139973624001319);
+if (True == x139973624001351) {
+Obj x139973624001863 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624001895 = PRIM_CAR(x139973624001863);
+Obj a = x139973624001895;
+Obj x139973624002663 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624002727 = PRIM_CDR(x139973624002663);
+Obj x139973624002759 = PRIM_ISCONS(x139973624002727);
+if (True == x139973624002759) {
+Obj x139973624003527 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624003655 = PRIM_CDR(x139973624003527);
+Obj x139973624003687 = PRIM_CAR(x139973624003655);
+Obj b = x139973624003687;
+Obj x139973623730183 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623730247 = PRIM_CDR(x139973623730183);
+Obj x139973623730279 = PRIM_CDR(x139973623730247);
+Obj x139973623730311 = PRIM_ISCONS(x139973623730279);
+if (True == x139973623730311) {
+Obj x139973623731111 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623731143 = PRIM_CDR(x139973623731111);
+Obj x139973623731175 = PRIM_CDR(x139973623731143);
+Obj x139973623731239 = PRIM_CAR(x139973623731175);
+Obj c = x139973623731239;
+Obj x139973623732199 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623732231 = PRIM_CDR(x139973623732199);
+Obj x139973623732263 = PRIM_CDR(x139973623732231);
+Obj x139973623732295 = PRIM_CDR(x139973623732263);
+Obj x139973623732327 = PRIM_EQ(Nil, x139973623732295);
+if (True == x139973623732327) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8594,7 +8576,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8603,7 +8585,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8612,7 +8594,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8621,7 +8603,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8630,7 +8612,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8639,7 +8621,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436c0;
+__arg0 = x139973625826343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8665,9 +8647,9 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj v0x7f411252c9a0 = __arg1;
+Obj x139973623733639 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 40, clofun6, 2, v0x7f411252c9a0, ra);
+pushCont(co, 40, clofun6, 2, x139973623733639, ra);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 1);
@@ -8681,15 +8663,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f411252cb40 = __arg1;
-Obj v0x7f411252c9a0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973623734119 = __arg1;
+Obj x139973623733639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f411252cb80 = makeCons(v0x7f411252cb40, Nil);
-Obj v0x7f411252cba0 = makeCons(v0x7f411252c9a0, v0x7f411252cb80);
-Obj v0x7f411252cbc0 = makeCons(ra, v0x7f411252cba0);
-Obj v0x7f411252cbe0 = makeCons(symif, v0x7f411252cbc0);
+Obj x139973623734183 = makeCons(x139973623734119, Nil);
+Obj x139973623734215 = makeCons(x139973623733639, x139973623734183);
+Obj x139973623734247 = makeCons(ra, x139973623734215);
+Obj x139973623685127 = makeCons(symif, x139973623734247);
 __nargs = 2;
-__arg1 = v0x7f411252cbe0;
+__arg1 = x139973623685127;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8697,31 +8679,31 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj v0x7f4112743a80 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f41125cd500 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cd500) {
-Obj v0x7f41125cd740 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cd780 = PRIM_EQ(symdo, v0x7f41125cd740);
-if (True == v0x7f41125cd780) {
-Obj v0x7f41125cd940 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd960 = PRIM_ISCONS(v0x7f41125cd940);
-if (True == v0x7f41125cd960) {
-Obj v0x7f41125cdb40 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cdc00 = PRIM_CAR(v0x7f41125cdb40);
-Obj a = v0x7f41125cdc00;
-Obj v0x7f41125cdec0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cdf40 = PRIM_CDR(v0x7f41125cdec0);
-Obj v0x7f41125cdf60 = PRIM_ISCONS(v0x7f41125cdf40);
-if (True == v0x7f41125cdf60) {
-Obj v0x7f41125c1200 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c1220 = PRIM_CDR(v0x7f41125c1200);
-Obj v0x7f41125c1240 = PRIM_CAR(v0x7f41125c1220);
-Obj b = v0x7f41125c1240;
-Obj v0x7f41125c1560 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c1580 = PRIM_CDR(v0x7f41125c1560);
-Obj v0x7f41125c15a0 = PRIM_CDR(v0x7f41125c1580);
-Obj v0x7f41125c1600 = PRIM_EQ(Nil, v0x7f41125c15a0);
-if (True == v0x7f41125c1600) {
+Obj x139973625789319 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624277735 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624277735) {
+Obj x139973624278247 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624278279 = PRIM_EQ(symdo, x139973624278247);
+if (True == x139973624278279) {
+Obj x139973624278951 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624278983 = PRIM_ISCONS(x139973624278951);
+if (True == x139973624278983) {
+Obj x139973624222215 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624222247 = PRIM_CAR(x139973624222215);
+Obj a = x139973624222247;
+Obj x139973624223079 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624223111 = PRIM_CDR(x139973624223079);
+Obj x139973624223143 = PRIM_ISCONS(x139973624223111);
+if (True == x139973624223143) {
+Obj x139973624224071 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624224103 = PRIM_CDR(x139973624224071);
+Obj x139973624224359 = PRIM_CAR(x139973624224103);
+Obj b = x139973624224359;
+Obj x139973624225415 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624225447 = PRIM_CDR(x139973624225415);
+Obj x139973624225479 = PRIM_CDR(x139973624225447);
+Obj x139973624225511 = PRIM_EQ(Nil, x139973624225479);
+if (True == x139973624225511) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8734,7 +8716,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743a80;
+__arg0 = x139973625789319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8743,7 +8725,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743a80;
+__arg0 = x139973625789319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8752,7 +8734,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743a80;
+__arg0 = x139973625789319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8761,7 +8743,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743a80;
+__arg0 = x139973625789319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8770,7 +8752,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743a80;
+__arg0 = x139973625789319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8782,8 +8764,8 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj ra = __arg1;
-Obj v0x7f41125c18c0 = primIsSymbol(ra);
-if (True == v0x7f41125c18c0) {
+Obj x139973624078983 = primIsSymbol(ra);
+if (True == x139973624078983) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 0);
@@ -8809,13 +8791,13 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f41125c1d20 = __arg1;
+Obj x139973624080519 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125c1d60 = makeCons(v0x7f41125c1d20, Nil);
-Obj v0x7f41125c1d80 = makeCons(ra, v0x7f41125c1d60);
-Obj v0x7f41125c1de0 = makeCons(symdo, v0x7f41125c1d80);
+Obj x139973624080647 = makeCons(x139973624080519, Nil);
+Obj x139973624080679 = makeCons(ra, x139973624080647);
+Obj x139973624080711 = makeCons(symdo, x139973624080679);
 __nargs = 2;
-__arg1 = v0x7f41125c1de0;
+__arg1 = x139973624080711;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8823,42 +8805,42 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj v0x7f4112743da0 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f41125d6aa0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d6aa0) {
-Obj v0x7f41125d6d20 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d6d40 = PRIM_EQ(symlet, v0x7f41125d6d20);
-if (True == v0x7f41125d6d40) {
-Obj v0x7f41125d6ee0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d6f40 = PRIM_ISCONS(v0x7f41125d6ee0);
-if (True == v0x7f41125d6f40) {
-Obj v0x7f41125d2160 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2180 = PRIM_CAR(v0x7f41125d2160);
-Obj a = v0x7f41125d2180;
-Obj v0x7f41125d24a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d24c0 = PRIM_CDR(v0x7f41125d24a0);
-Obj v0x7f41125d24e0 = PRIM_ISCONS(v0x7f41125d24c0);
-if (True == v0x7f41125d24e0) {
-Obj v0x7f41125d2800 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2820 = PRIM_CDR(v0x7f41125d2800);
-Obj v0x7f41125d2880 = PRIM_CAR(v0x7f41125d2820);
-Obj b = v0x7f41125d2880;
-Obj v0x7f41125d2c80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2ca0 = PRIM_CDR(v0x7f41125d2c80);
-Obj v0x7f41125d2cc0 = PRIM_CDR(v0x7f41125d2ca0);
-Obj v0x7f41125d2ce0 = PRIM_ISCONS(v0x7f41125d2cc0);
-if (True == v0x7f41125d2ce0) {
-Obj v0x7f41125cf0c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cf0e0 = PRIM_CDR(v0x7f41125cf0c0);
-Obj v0x7f41125cf100 = PRIM_CDR(v0x7f41125cf0e0);
-Obj v0x7f41125cf1a0 = PRIM_CAR(v0x7f41125cf100);
-Obj c = v0x7f41125cf1a0;
-Obj v0x7f41125cf6c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cf6e0 = PRIM_CDR(v0x7f41125cf6c0);
-Obj v0x7f41125cf700 = PRIM_CDR(v0x7f41125cf6e0);
-Obj v0x7f41125cf720 = PRIM_CDR(v0x7f41125cf700);
-Obj v0x7f41125cf740 = PRIM_EQ(Nil, v0x7f41125cf720);
-if (True == v0x7f41125cf740) {
+Obj x139973625028647 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624418119 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624418119) {
+Obj x139973624373703 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624373735 = PRIM_EQ(symlet, x139973624373703);
+if (True == x139973624373735) {
+Obj x139973624374343 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624374375 = PRIM_ISCONS(x139973624374343);
+if (True == x139973624374375) {
+Obj x139973624374983 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624375111 = PRIM_CAR(x139973624374983);
+Obj a = x139973624375111;
+Obj x139973624376039 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624376071 = PRIM_CDR(x139973624376039);
+Obj x139973624376135 = PRIM_ISCONS(x139973624376071);
+if (True == x139973624376135) {
+Obj x139973624376903 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624376935 = PRIM_CDR(x139973624376903);
+Obj x139973624376967 = PRIM_CAR(x139973624376935);
+Obj b = x139973624376967;
+Obj x139973624341063 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624341127 = PRIM_CDR(x139973624341063);
+Obj x139973624341159 = PRIM_CDR(x139973624341127);
+Obj x139973624341255 = PRIM_ISCONS(x139973624341159);
+if (True == x139973624341255) {
+Obj x139973624342247 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624342279 = PRIM_CDR(x139973624342247);
+Obj x139973624342343 = PRIM_CDR(x139973624342279);
+Obj x139973624342375 = PRIM_CAR(x139973624342343);
+Obj c = x139973624342375;
+Obj x139973624343751 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624343815 = PRIM_CDR(x139973624343751);
+Obj x139973624343975 = PRIM_CDR(x139973624343815);
+Obj x139973624344007 = PRIM_CDR(x139973624343975);
+Obj x139973624344039 = PRIM_EQ(Nil, x139973624344007);
+if (True == x139973624344039) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8871,7 +8853,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8880,7 +8862,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8889,7 +8871,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8898,7 +8880,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8907,7 +8889,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8916,7 +8898,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743da0;
+__arg0 = x139973625028647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8942,14 +8924,14 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj v0x7f41125cfea0 = __arg1;
+Obj x139973624276135 = __arg1;
 Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125cfee0 = makeCons(v0x7f41125cfea0, Nil);
-Obj v0x7f41125cff60 = makeCons(rb, v0x7f41125cfee0);
-Obj v0x7f41125cff80 = makeCons(closureRef(co, 0), v0x7f41125cff60);
-Obj v0x7f41125cffa0 = makeCons(symlet, v0x7f41125cff80);
+Obj x139973624276231 = makeCons(x139973624276135, Nil);
+Obj x139973624276263 = makeCons(rb, x139973624276231);
+Obj x139973624276295 = makeCons(closureRef(co, 0), x139973624276263);
+Obj x139973624276327 = makeCons(symlet, x139973624276295);
 __nargs = 2;
-__arg1 = v0x7f41125cffa0;
+__arg1 = x139973624276327;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8957,56 +8939,56 @@ goto *jumpTable[co->ctx.pc.label];
 
 label47:
 {
-Obj v0x7f411273e1a0 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f41125ec200 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125ec200) {
-Obj v0x7f41125ec400 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125ec420 = PRIM_EQ(sym_37closure, v0x7f41125ec400);
-if (True == v0x7f41125ec420) {
-Obj v0x7f41125ec620 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125ec640 = PRIM_ISCONS(v0x7f41125ec620);
-if (True == v0x7f41125ec640) {
-Obj v0x7f41125ec8c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125ec900 = PRIM_CAR(v0x7f41125ec8c0);
-Obj v0x7f41125ec920 = PRIM_ISCONS(v0x7f41125ec900);
-if (True == v0x7f41125ec920) {
-Obj v0x7f41125ecd00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125ecd60 = PRIM_CAR(v0x7f41125ecd00);
-Obj v0x7f41125ecd80 = PRIM_CAR(v0x7f41125ecd60);
-Obj v0x7f41125ecda0 = PRIM_EQ(symlambda, v0x7f41125ecd80);
-if (True == v0x7f41125ecda0) {
-Obj v0x7f41125e7100 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e7120 = PRIM_CAR(v0x7f41125e7100);
-Obj v0x7f41125e7140 = PRIM_CDR(v0x7f41125e7120);
-Obj v0x7f41125e7160 = PRIM_ISCONS(v0x7f41125e7140);
-if (True == v0x7f41125e7160) {
-Obj v0x7f41125e7560 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e7580 = PRIM_CAR(v0x7f41125e7560);
-Obj v0x7f41125e7620 = PRIM_CDR(v0x7f41125e7580);
-Obj v0x7f41125e7640 = PRIM_CAR(v0x7f41125e7620);
-Obj args = v0x7f41125e7640;
-Obj v0x7f41125e7b80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e7ba0 = PRIM_CAR(v0x7f41125e7b80);
-Obj v0x7f41125e7bc0 = PRIM_CDR(v0x7f41125e7ba0);
-Obj v0x7f41125e7be0 = PRIM_CDR(v0x7f41125e7bc0);
-Obj v0x7f41125e7c00 = PRIM_ISCONS(v0x7f41125e7be0);
-if (True == v0x7f41125e7c00) {
-Obj v0x7f41125e5120 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5140 = PRIM_CAR(v0x7f41125e5120);
-Obj v0x7f41125e51a0 = PRIM_CDR(v0x7f41125e5140);
-Obj v0x7f41125e51c0 = PRIM_CDR(v0x7f41125e51a0);
-Obj v0x7f41125e51e0 = PRIM_CAR(v0x7f41125e51c0);
-Obj body = v0x7f41125e51e0;
-Obj v0x7f41125e5820 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5840 = PRIM_CAR(v0x7f41125e5820);
-Obj v0x7f41125e5860 = PRIM_CDR(v0x7f41125e5840);
-Obj v0x7f41125e5880 = PRIM_CDR(v0x7f41125e5860);
-Obj v0x7f41125e58a0 = PRIM_CDR(v0x7f41125e5880);
-Obj v0x7f41125e58c0 = PRIM_EQ(Nil, v0x7f41125e58a0);
-if (True == v0x7f41125e58c0) {
-Obj v0x7f41125e5a80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5aa0 = PRIM_CDR(v0x7f41125e5a80);
-Obj frees = v0x7f41125e5aa0;
+Obj x139973625030151 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624641191 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624641191) {
+Obj x139973624641767 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624641799 = PRIM_EQ(sym_37closure, x139973624641767);
+if (True == x139973624641799) {
+Obj x139973624642375 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624642439 = PRIM_ISCONS(x139973624642375);
+if (True == x139973624642439) {
+Obj x139973624643207 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624643239 = PRIM_CAR(x139973624643207);
+Obj x139973624643271 = PRIM_ISCONS(x139973624643239);
+if (True == x139973624643271) {
+Obj x139973624529639 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624529671 = PRIM_CAR(x139973624529639);
+Obj x139973624529703 = PRIM_CAR(x139973624529671);
+Obj x139973624529735 = PRIM_EQ(symlambda, x139973624529703);
+if (True == x139973624529735) {
+Obj x139973624530663 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624530695 = PRIM_CAR(x139973624530663);
+Obj x139973624530727 = PRIM_CDR(x139973624530695);
+Obj x139973624530759 = PRIM_ISCONS(x139973624530727);
+if (True == x139973624530759) {
+Obj x139973624531783 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624531815 = PRIM_CAR(x139973624531783);
+Obj x139973624531847 = PRIM_CDR(x139973624531815);
+Obj x139973624531879 = PRIM_CAR(x139973624531847);
+Obj args = x139973624531879;
+Obj x139973624516615 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624516647 = PRIM_CAR(x139973624516615);
+Obj x139973624516679 = PRIM_CDR(x139973624516647);
+Obj x139973624516711 = PRIM_CDR(x139973624516679);
+Obj x139973624516871 = PRIM_ISCONS(x139973624516711);
+if (True == x139973624516871) {
+Obj x139973624517991 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624518023 = PRIM_CAR(x139973624517991);
+Obj x139973624518119 = PRIM_CDR(x139973624518023);
+Obj x139973624518151 = PRIM_CDR(x139973624518119);
+Obj x139973624518183 = PRIM_CAR(x139973624518151);
+Obj body = x139973624518183;
+Obj x139973624519815 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624519847 = PRIM_CAR(x139973624519815);
+Obj x139973624519879 = PRIM_CDR(x139973624519847);
+Obj x139973624519911 = PRIM_CDR(x139973624519879);
+Obj x139973624519943 = PRIM_CDR(x139973624519911);
+Obj x139973624519975 = PRIM_EQ(Nil, x139973624519943);
+if (True == x139973624519975) {
+Obj x139973624520519 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624520551 = PRIM_CDR(x139973624520519);
+Obj frees = x139973624520551;
 Obj next = closureRef(co, 1);
 pushCont(co, 48, clofun6, 3, args, frees, next);
 __nargs = 3;
@@ -9020,7 +9002,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9029,7 +9011,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9038,7 +9020,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9047,7 +9029,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9056,7 +9038,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9065,7 +9047,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9074,7 +9056,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9083,7 +9065,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e1a0;
+__arg0 = x139973625030151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9094,18 +9076,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f41125d6200 = __arg1;
+Obj x139973624415943 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f41125d6240 = makeCons(v0x7f41125d6200, Nil);
-Obj v0x7f41125d6260 = makeCons(args, v0x7f41125d6240);
-Obj v0x7f41125d6280 = makeCons(symlambda, v0x7f41125d6260);
-Obj v0x7f41125d62e0 = makeCons(v0x7f41125d6280, frees);
-Obj v0x7f41125d6300 = makeCons(sym_37closure, v0x7f41125d62e0);
+Obj x139973624416103 = makeCons(x139973624415943, Nil);
+Obj x139973624416135 = makeCons(args, x139973624416103);
+Obj x139973624416167 = makeCons(symlambda, x139973624416135);
+Obj x139973624416231 = makeCons(x139973624416167, frees);
+Obj x139973624416263 = makeCons(sym_37closure, x139973624416231);
 __nargs = 2;
 __arg0 = next;
-__arg1 = v0x7f41125d6300;
+__arg1 = x139973624416263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9115,18 +9097,18 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f411273e600 = makeNative(0, clofun7, 0, 0);
-Obj v0x7f41125fbac0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125fbac0) {
-Obj v0x7f41125fbbc0 = PRIM_CAR(closureRef(co, 0));
-Obj f = v0x7f41125fbbc0;
-Obj v0x7f41125fbd60 = PRIM_CDR(closureRef(co, 0));
-Obj args = v0x7f41125fbd60;
+Obj x139973625031815 = makeNative(0, clofun7, 0, 0);
+Obj x139973624688263 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624688263) {
+Obj x139973624639527 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139973624639527;
+Obj x139973624639847 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139973624639847;
 Obj next = closureRef(co, 1);
-Obj v0x7f41125fbf60 = makeCons(f, args);
+Obj x139973624640487 = makeCons(f, args);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = v0x7f41125fbf60;
+__arg1 = x139973624640487;
 __arg2 = Nil;
 __arg3 = next;
 co->ctx.frees = __arg0;
@@ -9136,7 +9118,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e600;
+__arg0 = x139973625031815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9180,10 +9162,10 @@ goto *jumpTable[ps.label];
 label1:
 {
 Obj x = __arg1;
-Obj v0x7f41125fb200 = makeCons(x, Nil);
-Obj v0x7f41125fb220 = makeCons(symreturn, v0x7f41125fb200);
+Obj x139973624686119 = makeCons(x, Nil);
+Obj x139973624686151 = makeCons(symreturn, x139973624686119);
 __nargs = 2;
-__arg1 = v0x7f41125fb220;
+__arg1 = x139973624686151;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9191,12 +9173,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label2:
 {
-Obj v0x7f41126cf700 = __arg1;
-Obj v0x7f41126cf720 = __arg2;
-Obj v0x7f41126cf800 = makeNative(4, clofun7, 0, 2, v0x7f41126cf700, v0x7f41126cf720);
-Obj __ = v0x7f41126cf700;
-Obj x = v0x7f41126cf720;
-pushCont(co, 3, clofun7, 2, x, v0x7f41126cf800);
+Obj x139973625852263 = __arg1;
+Obj x139973625852295 = __arg2;
+Obj x139973625852679 = makeNative(4, clofun7, 0, 2, x139973625852263, x139973625852295);
+Obj __ = x139973625852263;
+Obj x = x139973625852295;
+pushCont(co, 3, clofun7, 2, x, x139973625852679);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9209,10 +9191,10 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41125fed60 = __arg1;
+Obj x139973624684743 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41126cf800= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41125fed60) {
+Obj x139973625852679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624684743) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9220,7 +9202,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf800;
+__arg0 = x139973625852679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9231,11 +9213,11 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f41126cf960 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973625853223 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj v0x7f41125fe5e0 = primIsSymbol(var);
-if (True == v0x7f41125fe5e0) {
+Obj x139973624846471 = primIsSymbol(var);
+if (True == x139973624846471) {
 pushCont(co, 5, clofun7, 1, var);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -9248,7 +9230,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf960;
+__arg0 = x139973625853223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9259,21 +9241,21 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41125fe7c0 = __arg1;
+Obj x139973624846919 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pos = v0x7f41125fe7c0;
-Obj v0x7f41125fe8e0 = PRIM_EQ(MAKE_NUMBER(-1), pos);
-if (True == v0x7f41125fe8e0) {
+Obj pos = x139973624846919;
+Obj x139973624847271 = PRIM_EQ(MAKE_NUMBER(-1), pos);
+if (True == x139973624847271) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj v0x7f41125feac0 = makeCons(pos, Nil);
-Obj v0x7f41125feae0 = makeCons(sym_37closure_45ref, v0x7f41125feac0);
+Obj x139973624847719 = makeCons(pos, Nil);
+Obj x139973624847751 = makeCons(sym_37closure_45ref, x139973624847719);
 __nargs = 2;
-__arg1 = v0x7f41125feae0;
+__arg1 = x139973624847751;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9282,39 +9264,39 @@ goto *jumpTable[co->ctx.pc.label];
 
 label6:
 {
-Obj v0x7f41126cfac0 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973625853767 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj v0x7f411261b260 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f411261b260) {
-Obj v0x7f411261b4a0 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f411261b4c0 = PRIM_EQ(symlambda, v0x7f411261b4a0);
-if (True == v0x7f411261b4c0) {
-Obj v0x7f411261b680 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261b6a0 = PRIM_ISCONS(v0x7f411261b680);
-if (True == v0x7f411261b6a0) {
-Obj v0x7f411261b880 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261b8a0 = PRIM_CAR(v0x7f411261b880);
-Obj args = v0x7f411261b8a0;
-Obj v0x7f411261bb00 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261bb20 = PRIM_CDR(v0x7f411261bb00);
-Obj v0x7f411261bb40 = PRIM_ISCONS(v0x7f411261bb20);
-if (True == v0x7f411261bb40) {
-Obj v0x7f411261bea0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f411261bec0 = PRIM_CDR(v0x7f411261bea0);
-Obj v0x7f411261bee0 = PRIM_CAR(v0x7f411261bec0);
-Obj body = v0x7f411261bee0;
-Obj v0x7f4112603280 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126032a0 = PRIM_CDR(v0x7f4112603280);
-Obj v0x7f4112603320 = PRIM_CDR(v0x7f41126032a0);
-Obj v0x7f4112603340 = PRIM_EQ(Nil, v0x7f4112603320);
-if (True == v0x7f4112603340) {
-Obj v0x7f4112603720 = makeCons(body, Nil);
-Obj v0x7f4112603740 = makeCons(args, v0x7f4112603720);
-Obj v0x7f4112603760 = makeCons(symlambda, v0x7f4112603740);
+Obj x139973625016103 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973625016103) {
+Obj x139973624914311 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624914343 = PRIM_EQ(symlambda, x139973624914311);
+if (True == x139973624914343) {
+Obj x139973624914855 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624914887 = PRIM_ISCONS(x139973624914855);
+if (True == x139973624914887) {
+Obj x139973624915367 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624915399 = PRIM_CAR(x139973624915367);
+Obj args = x139973624915399;
+Obj x139973624916359 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624916391 = PRIM_CDR(x139973624916359);
+Obj x139973624916423 = PRIM_ISCONS(x139973624916391);
+if (True == x139973624916423) {
+Obj x139973624917191 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624917223 = PRIM_CDR(x139973624917191);
+Obj x139973624917287 = PRIM_CAR(x139973624917223);
+Obj body = x139973624917287;
+Obj x139973624889575 = PRIM_CDR(closureRef(co, 1));
+Obj x139973624889639 = PRIM_CDR(x139973624889575);
+Obj x139973624889863 = PRIM_CDR(x139973624889639);
+Obj x139973624889895 = PRIM_EQ(Nil, x139973624889863);
+if (True == x139973624889895) {
+Obj x139973624890983 = makeCons(body, Nil);
+Obj x139973624891047 = makeCons(args, x139973624890983);
+Obj x139973624891079 = makeCons(symlambda, x139973624891047);
 pushCont(co, 7, clofun7, 3, body, args, fvs);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = v0x7f4112603760;
+__arg1 = x139973624891079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9322,16 +9304,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfac0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126cfac0;
+__arg0 = x139973625853767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9340,7 +9313,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfac0;
+__arg0 = x139973625853767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9349,7 +9322,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfac0;
+__arg0 = x139973625853767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9358,7 +9331,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfac0;
+__arg0 = x139973625853767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973625853767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9369,11 +9351,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f4112603780 = __arg1;
+Obj x139973624891111 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = v0x7f4112603780;
+Obj fvs1 = x139973624891111;
 pushCont(co, 8, clofun7, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9388,14 +9370,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj v0x7f4112603d60 = __arg1;
+Obj x139973624892903 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj v0x7f4112603e20 = makeCons(v0x7f4112603d60, Nil);
-Obj v0x7f4112603e40 = makeCons(args, v0x7f4112603e20);
-Obj v0x7f4112603e60 = makeCons(symlambda, v0x7f4112603e40);
-pushCont(co, 9, clofun7, 2, fvs1, v0x7f4112603e60);
+Obj x139973624892999 = makeCons(x139973624892903, Nil);
+Obj x139973624893031 = makeCons(args, x139973624892999);
+Obj x139973624893063 = makeCons(symlambda, x139973624893031);
+pushCont(co, 9, clofun7, 2, fvs1, x139973624893063);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9408,13 +9390,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f41125fe080 = __arg1;
+Obj x139973624844487 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112603e60= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 10, clofun7, 1, v0x7f4112603e60);
+Obj x139973624893063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 10, clofun7, 1, x139973624893063);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f41125fe080;
+__arg1 = x139973624844487;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9425,12 +9407,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f41125fe0c0 = __arg1;
-Obj v0x7f4112603e60= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125fe0e0 = makeCons(v0x7f4112603e60, v0x7f41125fe0c0);
-Obj v0x7f41125fe100 = makeCons(sym_37closure, v0x7f41125fe0e0);
+Obj x139973624844647 = __arg1;
+Obj x139973624893063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624844775 = makeCons(x139973624893063, x139973624844647);
+Obj x139973624844807 = makeCons(sym_37closure, x139973624844775);
 __nargs = 2;
-__arg1 = v0x7f41125fe100;
+__arg1 = x139973624844807;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9438,43 +9420,43 @@ goto *jumpTable[co->ctx.pc.label];
 
 label11:
 {
-Obj v0x7f41126cfda0 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973625854951 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj v0x7f41126afe80 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41126afe80) {
-Obj v0x7f41126a7080 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41126a70a0 = PRIM_EQ(symlet, v0x7f41126a7080);
-if (True == v0x7f41126a70a0) {
-Obj v0x7f41126a7260 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7280 = PRIM_ISCONS(v0x7f41126a7260);
-if (True == v0x7f41126a7280) {
-Obj v0x7f41126a74e0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7500 = PRIM_CAR(v0x7f41126a74e0);
-Obj a = v0x7f41126a7500;
-Obj v0x7f41126a7760 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7820 = PRIM_CDR(v0x7f41126a7760);
-Obj v0x7f41126a7840 = PRIM_ISCONS(v0x7f41126a7820);
-if (True == v0x7f41126a7840) {
-Obj v0x7f41126a7ac0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7b00 = PRIM_CDR(v0x7f41126a7ac0);
-Obj v0x7f41126a7b20 = PRIM_CAR(v0x7f41126a7b00);
-Obj b = v0x7f41126a7b20;
-Obj v0x7f41126a7e60 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f41126a7e80 = PRIM_CDR(v0x7f41126a7e60);
-Obj v0x7f41126a7ea0 = PRIM_CDR(v0x7f41126a7e80);
-Obj v0x7f41126a7ec0 = PRIM_ISCONS(v0x7f41126a7ea0);
-if (True == v0x7f41126a7ec0) {
-Obj v0x7f41126691e0 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f4112669200 = PRIM_CDR(v0x7f41126691e0);
-Obj v0x7f4112669220 = PRIM_CDR(v0x7f4112669200);
-Obj v0x7f4112669240 = PRIM_CAR(v0x7f4112669220);
-Obj c = v0x7f4112669240;
-Obj v0x7f4112669600 = PRIM_CDR(closureRef(co, 1));
-Obj v0x7f4112669620 = PRIM_CDR(v0x7f4112669600);
-Obj v0x7f4112669660 = PRIM_CDR(v0x7f4112669620);
-Obj v0x7f4112669680 = PRIM_CDR(v0x7f4112669660);
-Obj v0x7f41126696a0 = PRIM_EQ(Nil, v0x7f4112669680);
-if (True == v0x7f41126696a0) {
+Obj x139973625825319 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973625825319) {
+Obj x139973625787463 = PRIM_CAR(closureRef(co, 1));
+Obj x139973625787495 = PRIM_EQ(symlet, x139973625787463);
+if (True == x139973625787495) {
+Obj x139973625787975 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625788007 = PRIM_ISCONS(x139973625787975);
+if (True == x139973625788007) {
+Obj x139973625789383 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625789415 = PRIM_CAR(x139973625789383);
+Obj a = x139973625789415;
+Obj x139973625790215 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625790247 = PRIM_CDR(x139973625790215);
+Obj x139973625790279 = PRIM_ISCONS(x139973625790247);
+if (True == x139973625790279) {
+Obj x139973625029287 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625029319 = PRIM_CDR(x139973625029287);
+Obj x139973625029383 = PRIM_CAR(x139973625029319);
+Obj b = x139973625029383;
+Obj x139973625030311 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625030343 = PRIM_CDR(x139973625030311);
+Obj x139973625030375 = PRIM_CDR(x139973625030343);
+Obj x139973625030407 = PRIM_ISCONS(x139973625030375);
+if (True == x139973625030407) {
+Obj x139973625031399 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625031463 = PRIM_CDR(x139973625031399);
+Obj x139973625031495 = PRIM_CDR(x139973625031463);
+Obj x139973625031559 = PRIM_CAR(x139973625031495);
+Obj c = x139973625031559;
+Obj x139973625012359 = PRIM_CDR(closureRef(co, 1));
+Obj x139973625012391 = PRIM_CDR(x139973625012359);
+Obj x139973625012519 = PRIM_CDR(x139973625012391);
+Obj x139973625012583 = PRIM_CDR(x139973625012519);
+Obj x139973625012615 = PRIM_EQ(Nil, x139973625012583);
+if (True == x139973625012615) {
 pushCont(co, 12, clofun7, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9487,7 +9469,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9496,7 +9478,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9505,7 +9487,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9514,7 +9496,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9523,7 +9505,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9532,7 +9514,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfda0;
+__arg0 = x139973625854951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9543,11 +9525,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f4112669a60 = __arg1;
+Obj x139973625013639 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 13, clofun7, 2, v0x7f4112669a60, a);
+pushCont(co, 13, clofun7, 2, x139973625013639, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9561,15 +9543,15 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f4112669c80 = __arg1;
-Obj v0x7f4112669a60= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973625014183 = __arg1;
+Obj x139973625013639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112669cc0 = makeCons(v0x7f4112669c80, Nil);
-Obj v0x7f4112669ce0 = makeCons(v0x7f4112669a60, v0x7f4112669cc0);
-Obj v0x7f4112669d00 = makeCons(a, v0x7f4112669ce0);
-Obj v0x7f4112669d20 = makeCons(symlet, v0x7f4112669d00);
+Obj x139973625014247 = makeCons(x139973625014183, Nil);
+Obj x139973625014279 = makeCons(x139973625013639, x139973625014247);
+Obj x139973625014311 = makeCons(a, x139973625014279);
+Obj x139973625014375 = makeCons(symlet, x139973625014311);
 __nargs = 2;
-__arg1 = v0x7f4112669d20;
+__arg1 = x139973625014375;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9577,14 +9559,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label14:
 {
-Obj v0x7f41126b5100 = makeNative(16, clofun7, 0, 0);
+Obj x139973625823591 = makeNative(16, clofun7, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj v0x7f41126af6c0 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41126af6c0) {
-Obj v0x7f41126af820 = PRIM_CAR(closureRef(co, 1));
-Obj f = v0x7f41126af820;
-Obj v0x7f41126af920 = PRIM_CDR(closureRef(co, 1));
-Obj args = v0x7f41126af920;
+Obj x139973625855879 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973625855879) {
+Obj x139973625823431 = PRIM_CAR(closureRef(co, 1));
+Obj f = x139973625823431;
+Obj x139973625823847 = PRIM_CDR(closureRef(co, 1));
+Obj args = x139973625823847;
 pushCont(co, 15, clofun7, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9596,7 +9578,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b5100;
+__arg0 = x139973625823591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9607,14 +9589,14 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj v0x7f41126afb20 = __arg1;
+Obj x139973625824263 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41126afc60 = makeCons(f, args);
+Obj x139973625824679 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f41126afb20;
-__arg2 = v0x7f41126afc60;
+__arg1 = x139973625824263;
+__arg2 = x139973625824679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9636,10 +9618,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f411273ed00 = __arg1;
-Obj v0x7f411273ed80 = makeNative(19, clofun7, 0, 1, v0x7f411273ed00);
-Obj x = v0x7f411273ed00;
-pushCont(co, 18, clofun7, 1, v0x7f411273ed80);
+Obj x139973624002151 = __arg1;
+Obj x139973624002375 = makeNative(19, clofun7, 0, 1, x139973624002151);
+Obj x = x139973624002151;
+pushCont(co, 18, clofun7, 1, x139973624002375);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9652,9 +9634,9 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj v0x7f41126b5ee0 = __arg1;
-Obj v0x7f411273ed80= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41126b5ee0) {
+Obj x139973625853639 = __arg1;
+Obj x139973624002375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139973625853639) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9662,7 +9644,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ed80;
+__arg0 = x139973624002375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9673,19 +9655,19 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj v0x7f411273ee60 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624002695 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj v0x7f41126b5c00 = primIsSymbol(x);
-if (True == v0x7f41126b5c00) {
-Obj v0x7f41126b5ce0 = makeCons(x, Nil);
+Obj x139973625852775 = primIsSymbol(x);
+if (True == x139973625852775) {
+Obj x139973625852999 = makeCons(x, Nil);
 __nargs = 2;
-__arg1 = v0x7f41126b5ce0;
+__arg1 = x139973625852999;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ee60;
+__arg0 = x139973624002695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9696,31 +9678,31 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj v0x7f411273ef40 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f411272de40 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411272de40) {
-Obj v0x7f41126cf140 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41126cf180 = PRIM_EQ(symlambda, v0x7f41126cf140);
-if (True == v0x7f41126cf180) {
-Obj v0x7f41126cf400 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126cf460 = PRIM_ISCONS(v0x7f41126cf400);
-if (True == v0x7f41126cf460) {
-Obj v0x7f41126cf660 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126cf6c0 = PRIM_CAR(v0x7f41126cf660);
-Obj args = v0x7f41126cf6c0;
-Obj v0x7f41126cfa60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126cfa80 = PRIM_CDR(v0x7f41126cfa60);
-Obj v0x7f41126cfaa0 = PRIM_ISCONS(v0x7f41126cfa80);
-if (True == v0x7f41126cfaa0) {
-Obj v0x7f41126b5020 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b5040 = PRIM_CDR(v0x7f41126b5020);
-Obj v0x7f41126b5060 = PRIM_CAR(v0x7f41126b5040);
-Obj body = v0x7f41126b5060;
-Obj v0x7f41126b54a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126b54c0 = PRIM_CDR(v0x7f41126b54a0);
-Obj v0x7f41126b54e0 = PRIM_CDR(v0x7f41126b54c0);
-Obj v0x7f41126b5520 = PRIM_EQ(Nil, v0x7f41126b54e0);
-if (True == v0x7f41126b5520) {
+Obj x139973624003015 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624001287 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624001287) {
+Obj x139973624001767 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624001799 = PRIM_EQ(symlambda, x139973624001767);
+if (True == x139973624001799) {
+Obj x139973624002279 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624002311 = PRIM_ISCONS(x139973624002279);
+if (True == x139973624002311) {
+Obj x139973624002855 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624002887 = PRIM_CAR(x139973624002855);
+Obj args = x139973624002887;
+Obj x139973624003559 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624003591 = PRIM_CDR(x139973624003559);
+Obj x139973624003623 = PRIM_ISCONS(x139973624003591);
+if (True == x139973624003623) {
+Obj x139973624004391 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624004423 = PRIM_CDR(x139973624004391);
+Obj x139973623688071 = PRIM_CAR(x139973624004423);
+Obj body = x139973623688071;
+Obj x139973623688839 = PRIM_CDR(closureRef(co, 0));
+Obj x139973623688871 = PRIM_CDR(x139973623688839);
+Obj x139973623688903 = PRIM_CDR(x139973623688871);
+Obj x139973623688935 = PRIM_EQ(Nil, x139973623688903);
+if (True == x139973623688935) {
 pushCont(co, 21, clofun7, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -9732,7 +9714,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef40;
+__arg0 = x139973624003015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9741,7 +9723,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef40;
+__arg0 = x139973624003015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9750,7 +9732,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef40;
+__arg0 = x139973624003015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9759,7 +9741,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef40;
+__arg0 = x139973624003015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9768,7 +9750,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273ef40;
+__arg0 = x139973624003015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9779,11 +9761,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj v0x7f41126b5740 = __arg1;
+Obj x139973623681095 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = v0x7f41126b5740;
+__arg1 = x139973623681095;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9794,50 +9776,50 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj v0x7f411272d180 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f4112563a20 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112563a20) {
-Obj v0x7f4112563be0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112563c00 = PRIM_EQ(symif, v0x7f4112563be0);
-if (True == v0x7f4112563c00) {
-Obj v0x7f4112563da0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563dc0 = PRIM_ISCONS(v0x7f4112563da0);
-if (True == v0x7f4112563dc0) {
-Obj v0x7f4112563f60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112563f80 = PRIM_CAR(v0x7f4112563f60);
-Obj x = v0x7f4112563f80;
-Obj v0x7f41127431a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112743200 = PRIM_CDR(v0x7f41127431a0);
-Obj v0x7f4112743220 = PRIM_ISCONS(v0x7f4112743200);
-if (True == v0x7f4112743220) {
-Obj v0x7f4112743780 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41127437a0 = PRIM_CDR(v0x7f4112743780);
-Obj v0x7f41127437c0 = PRIM_CAR(v0x7f41127437a0);
-Obj y = v0x7f41127437c0;
-Obj v0x7f4112743ea0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112743ee0 = PRIM_CDR(v0x7f4112743ea0);
-Obj v0x7f4112743f00 = PRIM_CDR(v0x7f4112743ee0);
-Obj v0x7f4112743f20 = PRIM_ISCONS(v0x7f4112743f00);
-if (True == v0x7f4112743f20) {
-Obj v0x7f411273e4a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411273e540 = PRIM_CDR(v0x7f411273e4a0);
-Obj v0x7f411273e560 = PRIM_CDR(v0x7f411273e540);
-Obj v0x7f411273e5a0 = PRIM_CAR(v0x7f411273e560);
-Obj z = v0x7f411273e5a0;
-Obj v0x7f411273ed60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411273eda0 = PRIM_CDR(v0x7f411273ed60);
-Obj v0x7f411273edc0 = PRIM_CDR(v0x7f411273eda0);
-Obj v0x7f411273ede0 = PRIM_CDR(v0x7f411273edc0);
-Obj v0x7f411273ee00 = PRIM_EQ(Nil, v0x7f411273ede0);
-if (True == v0x7f411273ee00) {
-Obj v0x7f411272d720 = makeCons(z, Nil);
-Obj v0x7f411272d760 = makeCons(y, v0x7f411272d720);
-Obj v0x7f411272d7a0 = makeCons(x, v0x7f411272d760);
+Obj x139973624003975 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624278183 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624278183) {
+Obj x139973624278663 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624278695 = PRIM_EQ(symif, x139973624278663);
+if (True == x139973624278695) {
+Obj x139973624221959 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624221991 = PRIM_ISCONS(x139973624221959);
+if (True == x139973624221991) {
+Obj x139973624222663 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624222695 = PRIM_CAR(x139973624222663);
+Obj x = x139973624222695;
+Obj x139973624223495 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624223527 = PRIM_CDR(x139973624223495);
+Obj x139973624223559 = PRIM_ISCONS(x139973624223527);
+if (True == x139973624223559) {
+Obj x139973624224391 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624224423 = PRIM_CDR(x139973624224391);
+Obj x139973624224455 = PRIM_CAR(x139973624224423);
+Obj y = x139973624224455;
+Obj x139973624225255 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624225287 = PRIM_CDR(x139973624225255);
+Obj x139973624225319 = PRIM_CDR(x139973624225287);
+Obj x139973624225351 = PRIM_ISCONS(x139973624225319);
+if (True == x139973624225351) {
+Obj x139973624078855 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624078887 = PRIM_CDR(x139973624078855);
+Obj x139973624078919 = PRIM_CDR(x139973624078887);
+Obj x139973624078951 = PRIM_CAR(x139973624078919);
+Obj z = x139973624078951;
+Obj x139973624080263 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624080295 = PRIM_CDR(x139973624080263);
+Obj x139973624080327 = PRIM_CDR(x139973624080295);
+Obj x139973624080359 = PRIM_CDR(x139973624080327);
+Obj x139973624080423 = PRIM_EQ(Nil, x139973624080359);
+if (True == x139973624080423) {
+Obj x139973624081735 = makeCons(z, Nil);
+Obj x139973624081767 = makeCons(y, x139973624081735);
+Obj x139973624081799 = makeCons(x, x139973624081767);
 PUSH_CONT_0(co, 23, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = v0x7f411272d7a0;
+__arg2 = x139973624081799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9845,16 +9827,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d180;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411272d180;
+__arg0 = x139973624003975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9863,7 +9836,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d180;
+__arg0 = x139973624003975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9872,7 +9845,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d180;
+__arg0 = x139973624003975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9881,7 +9854,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d180;
+__arg0 = x139973624003975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9890,7 +9863,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d180;
+__arg0 = x139973624003975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973624003975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9901,12 +9883,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj v0x7f411272d820 = __arg1;
+Obj x139973624081831 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = v0x7f411272d820;
+__arg3 = x139973624081831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9916,38 +9898,38 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj v0x7f411272d440 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f4112570560 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112570560) {
-Obj v0x7f4112570720 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f4112570740 = PRIM_EQ(symdo, v0x7f4112570720);
-if (True == v0x7f4112570740) {
-Obj v0x7f41125708e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112570900 = PRIM_ISCONS(v0x7f41125708e0);
-if (True == v0x7f4112570900) {
-Obj v0x7f4112570aa0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112570ac0 = PRIM_CAR(v0x7f4112570aa0);
-Obj x = v0x7f4112570ac0;
-Obj v0x7f4112570d00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112570d20 = PRIM_CDR(v0x7f4112570d00);
-Obj v0x7f4112570d40 = PRIM_ISCONS(v0x7f4112570d20);
-if (True == v0x7f4112570d40) {
-Obj v0x7f4112570f80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112570fa0 = PRIM_CDR(v0x7f4112570f80);
-Obj v0x7f4112570fc0 = PRIM_CAR(v0x7f4112570fa0);
-Obj y = v0x7f4112570fc0;
-Obj v0x7f41125632c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125632e0 = PRIM_CDR(v0x7f41125632c0);
-Obj v0x7f4112563300 = PRIM_CDR(v0x7f41125632e0);
-Obj v0x7f4112563320 = PRIM_EQ(Nil, v0x7f4112563300);
-if (True == v0x7f4112563320) {
-Obj v0x7f4112563660 = makeCons(y, Nil);
-Obj v0x7f4112563680 = makeCons(x, v0x7f4112563660);
+Obj x139973623730727 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624341383 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624341383) {
+Obj x139973624341959 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624341991 = PRIM_EQ(symdo, x139973624341959);
+if (True == x139973624341991) {
+Obj x139973624342439 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624342471 = PRIM_ISCONS(x139973624342439);
+if (True == x139973624342471) {
+Obj x139973624343047 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624343079 = PRIM_CAR(x139973624343047);
+Obj x = x139973624343079;
+Obj x139973624343847 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624343879 = PRIM_CDR(x139973624343847);
+Obj x139973624343911 = PRIM_ISCONS(x139973624343879);
+if (True == x139973624343911) {
+Obj x139973624344551 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624274983 = PRIM_CDR(x139973624344551);
+Obj x139973624275015 = PRIM_CAR(x139973624274983);
+Obj y = x139973624275015;
+Obj x139973624275911 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624275975 = PRIM_CDR(x139973624275911);
+Obj x139973624276007 = PRIM_CDR(x139973624275975);
+Obj x139973624276039 = PRIM_EQ(Nil, x139973624276007);
+if (True == x139973624276039) {
+Obj x139973624277063 = makeCons(y, Nil);
+Obj x139973624277095 = makeCons(x, x139973624277063);
 PUSH_CONT_0(co, 25, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = v0x7f4112563680;
+__arg2 = x139973624277095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9955,16 +9937,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d440;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411272d440;
+__arg0 = x139973623730727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9973,7 +9946,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d440;
+__arg0 = x139973623730727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9982,7 +9955,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d440;
+__arg0 = x139973623730727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9991,7 +9964,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d440;
+__arg0 = x139973623730727;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973623730727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10002,12 +9984,12 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj v0x7f41125636a0 = __arg1;
+Obj x139973624277127 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = v0x7f41125636a0;
+__arg3 = x139973624277127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10017,42 +9999,42 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj v0x7f411272d740 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125c1400 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125c1400) {
-Obj v0x7f41125c15c0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125c15e0 = PRIM_EQ(symlet, v0x7f41125c15c0);
-if (True == v0x7f41125c15e0) {
-Obj v0x7f41125c1820 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c1c00 = PRIM_ISCONS(v0x7f41125c1820);
-if (True == v0x7f41125c1c00) {
-Obj v0x7f41125c1da0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c1dc0 = PRIM_CAR(v0x7f41125c1da0);
-Obj a = v0x7f41125c1dc0;
-Obj v0x7f41125c0000 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0020 = PRIM_CDR(v0x7f41125c0000);
-Obj v0x7f41125c0040 = PRIM_ISCONS(v0x7f41125c0020);
-if (True == v0x7f41125c0040) {
-Obj v0x7f41125c0280 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c02a0 = PRIM_CDR(v0x7f41125c0280);
-Obj v0x7f41125c02c0 = PRIM_CAR(v0x7f41125c02a0);
-Obj b = v0x7f41125c02c0;
-Obj v0x7f41125c05a0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c05c0 = PRIM_CDR(v0x7f41125c05a0);
-Obj v0x7f41125c05e0 = PRIM_CDR(v0x7f41125c05c0);
-Obj v0x7f41125c0600 = PRIM_ISCONS(v0x7f41125c05e0);
-if (True == v0x7f41125c0600) {
-Obj v0x7f41125c08e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0900 = PRIM_CDR(v0x7f41125c08e0);
-Obj v0x7f41125c0920 = PRIM_CDR(v0x7f41125c0900);
-Obj v0x7f41125c0940 = PRIM_CAR(v0x7f41125c0920);
-Obj c = v0x7f41125c0940;
-Obj v0x7f41125c0ce0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c0d00 = PRIM_CDR(v0x7f41125c0ce0);
-Obj v0x7f41125c0d20 = PRIM_CDR(v0x7f41125c0d00);
-Obj v0x7f41125c0d40 = PRIM_CDR(v0x7f41125c0d20);
-Obj v0x7f41125c0d60 = PRIM_EQ(Nil, v0x7f41125c0d40);
-if (True == v0x7f41125c0d60) {
+Obj x139973623731687 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624520487 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624520487) {
+Obj x139973624414631 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624414663 = PRIM_EQ(symlet, x139973624414631);
+if (True == x139973624414663) {
+Obj x139973624415143 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624415175 = PRIM_ISCONS(x139973624415143);
+if (True == x139973624415175) {
+Obj x139973624415623 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624415655 = PRIM_CAR(x139973624415623);
+Obj a = x139973624415655;
+Obj x139973624416455 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624416487 = PRIM_CDR(x139973624416455);
+Obj x139973624416519 = PRIM_ISCONS(x139973624416487);
+if (True == x139973624416519) {
+Obj x139973624417383 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624417415 = PRIM_CDR(x139973624417383);
+Obj x139973624417447 = PRIM_CAR(x139973624417415);
+Obj b = x139973624417447;
+Obj x139973624418215 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624418247 = PRIM_CDR(x139973624418215);
+Obj x139973624418279 = PRIM_CDR(x139973624418247);
+Obj x139973624373287 = PRIM_ISCONS(x139973624418279);
+if (True == x139973624373287) {
+Obj x139973624374087 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624374119 = PRIM_CDR(x139973624374087);
+Obj x139973624374183 = PRIM_CDR(x139973624374119);
+Obj x139973624374215 = PRIM_CAR(x139973624374183);
+Obj c = x139973624374215;
+Obj x139973624375463 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624375495 = PRIM_CDR(x139973624375463);
+Obj x139973624375527 = PRIM_CDR(x139973624375495);
+Obj x139973624375559 = PRIM_CDR(x139973624375527);
+Obj x139973624375687 = PRIM_EQ(Nil, x139973624375559);
+if (True == x139973624375687) {
 pushCont(co, 27, clofun7, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10064,7 +10046,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10073,7 +10055,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10082,7 +10064,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10091,7 +10073,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10100,7 +10082,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10109,7 +10091,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d740;
+__arg0 = x139973623731687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10120,10 +10102,10 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj v0x7f41125c0ec0 = __arg1;
+Obj x139973624376103 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 28, clofun7, 2, a, v0x7f41125c0ec0);
+pushCont(co, 28, clofun7, 2, a, x139973624376103);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = c;
@@ -10136,15 +10118,15 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj v0x7f4112570040 = __arg1;
+Obj x139973624376551 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125c0ec0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112570140 = makeCons(a, Nil);
-pushCont(co, 29, clofun7, 1, v0x7f41125c0ec0);
+Obj x139973624376103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139973624376839 = makeCons(a, Nil);
+pushCont(co, 29, clofun7, 1, x139973624376103);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = v0x7f4112570040;
-__arg2 = v0x7f4112570140;
+__arg1 = x139973624376551;
+__arg2 = x139973624376839;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10154,12 +10136,12 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj v0x7f4112570160 = __arg1;
-Obj v0x7f41125c0ec0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624376871 = __arg1;
+Obj x139973624376103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = v0x7f41125c0ec0;
-__arg2 = v0x7f4112570160;
+__arg1 = x139973624376103;
+__arg2 = x139973624376871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10169,25 +10151,25 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj v0x7f411272da20 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125cd7e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cd7e0) {
-Obj v0x7f41125cd9a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cd9c0 = PRIM_EQ(sym_37closure, v0x7f41125cd9a0);
-if (True == v0x7f41125cd9c0) {
-Obj v0x7f41125cdb60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cdbe0 = PRIM_ISCONS(v0x7f41125cdb60);
-if (True == v0x7f41125cdbe0) {
-Obj v0x7f41125cdd80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cdda0 = PRIM_CAR(v0x7f41125cdd80);
-Obj lam = v0x7f41125cdda0;
-Obj v0x7f41125cdfe0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125c1000 = PRIM_CDR(v0x7f41125cdfe0);
-Obj more = v0x7f41125c1000;
-Obj v0x7f41125c1180 = makeCons(lam, more);
+Obj x139973623732871 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624517031 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624517031) {
+Obj x139973624517479 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624517511 = PRIM_EQ(sym_37closure, x139973624517479);
+if (True == x139973624517511) {
+Obj x139973624518055 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624518087 = PRIM_ISCONS(x139973624518055);
+if (True == x139973624518087) {
+Obj x139973624518503 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624518535 = PRIM_CAR(x139973624518503);
+Obj lam = x139973624518535;
+Obj x139973624519175 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624519207 = PRIM_CDR(x139973624519175);
+Obj more = x139973624519207;
+Obj x139973624519751 = makeCons(lam, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = v0x7f41125c1180;
+__arg1 = x139973624519751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10195,16 +10177,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da20;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411272da20;
+__arg0 = x139973623732871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10213,7 +10186,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272da20;
+__arg0 = x139973623732871;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973623732871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10224,22 +10206,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj v0x7f411272dbe0 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125cf8c0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125cf8c0) {
-Obj v0x7f41125cfb80 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125cfba0 = PRIM_EQ(symreturn, v0x7f41125cfb80);
-if (True == v0x7f41125cfba0) {
-Obj v0x7f41125cfe00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cfe20 = PRIM_ISCONS(v0x7f41125cfe00);
-if (True == v0x7f41125cfe20) {
-Obj v0x7f41125cd020 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd040 = PRIM_CAR(v0x7f41125cd020);
-Obj x = v0x7f41125cd040;
-Obj v0x7f41125cd300 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125cd320 = PRIM_CDR(v0x7f41125cd300);
-Obj v0x7f41125cd340 = PRIM_EQ(Nil, v0x7f41125cd320);
-if (True == v0x7f41125cd340) {
+Obj x139973623733607 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624529927 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624529927) {
+Obj x139973624530471 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624530503 = PRIM_EQ(symreturn, x139973624530471);
+if (True == x139973624530503) {
+Obj x139973624530983 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624531015 = PRIM_ISCONS(x139973624530983);
+if (True == x139973624531015) {
+Obj x139973624531431 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624531559 = PRIM_CAR(x139973624531431);
+Obj x = x139973624531559;
+Obj x139973624532167 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624532199 = PRIM_CDR(x139973624532167);
+Obj x139973624532231 = PRIM_EQ(Nil, x139973624532199);
+if (True == x139973624532231) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = x;
@@ -10250,7 +10232,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dbe0;
+__arg0 = x139973623733607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10259,7 +10241,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dbe0;
+__arg0 = x139973623733607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10268,7 +10250,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dbe0;
+__arg0 = x139973623733607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10277,7 +10259,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dbe0;
+__arg0 = x139973623733607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10288,38 +10270,38 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj v0x7f411272ddc0 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d2040 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d2040) {
-Obj v0x7f41125d2200 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d2220 = PRIM_EQ(symcall, v0x7f41125d2200);
-if (True == v0x7f41125d2220) {
-Obj v0x7f41125d23e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2400 = PRIM_ISCONS(v0x7f41125d23e0);
-if (True == v0x7f41125d2400) {
-Obj v0x7f41125d2600 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2620 = PRIM_CAR(v0x7f41125d2600);
-Obj exp = v0x7f41125d2620;
-Obj v0x7f41125d2920 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2940 = PRIM_CDR(v0x7f41125d2920);
-Obj v0x7f41125d2960 = PRIM_ISCONS(v0x7f41125d2940);
-if (True == v0x7f41125d2960) {
-Obj v0x7f41125d2c00 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2c20 = PRIM_CDR(v0x7f41125d2c00);
-Obj v0x7f41125d2c40 = PRIM_CAR(v0x7f41125d2c20);
-Obj cont = v0x7f41125d2c40;
-Obj v0x7f41125d2fc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d2fe0 = PRIM_CDR(v0x7f41125d2fc0);
-Obj v0x7f41125cf000 = PRIM_CDR(v0x7f41125d2fe0);
-Obj v0x7f41125cf020 = PRIM_EQ(Nil, v0x7f41125cf000);
-if (True == v0x7f41125cf020) {
-Obj v0x7f41125cf420 = makeCons(cont, Nil);
-Obj v0x7f41125cf440 = makeCons(exp, v0x7f41125cf420);
+Obj x139973623685191 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624687367 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624687367) {
+Obj x139973624687911 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624688007 = PRIM_EQ(symcall, x139973624687911);
+if (True == x139973624688007) {
+Obj x139973624688519 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624688551 = PRIM_ISCONS(x139973624688519);
+if (True == x139973624688551) {
+Obj x139973624639879 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624639911 = PRIM_CAR(x139973624639879);
+Obj exp = x139973624639911;
+Obj x139973624640647 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624640679 = PRIM_CDR(x139973624640647);
+Obj x139973624640711 = PRIM_ISCONS(x139973624640679);
+if (True == x139973624640711) {
+Obj x139973624641415 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624641447 = PRIM_CDR(x139973624641415);
+Obj x139973624641479 = PRIM_CAR(x139973624641447);
+Obj cont = x139973624641479;
+Obj x139973624642471 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624642503 = PRIM_CDR(x139973624642471);
+Obj x139973624642535 = PRIM_CDR(x139973624642503);
+Obj x139973624642567 = PRIM_EQ(Nil, x139973624642535);
+if (True == x139973624642567) {
+Obj x139973624528935 = makeCons(cont, Nil);
+Obj x139973624528967 = makeCons(exp, x139973624528935);
 PUSH_CONT_0(co, 33, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = v0x7f41125cf440;
+__arg2 = x139973624528967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10327,16 +10309,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272ddc0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f411272ddc0;
+__arg0 = x139973623685191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10345,7 +10318,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272ddc0;
+__arg0 = x139973623685191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10354,7 +10327,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272ddc0;
+__arg0 = x139973623685191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10363,7 +10336,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272ddc0;
+__arg0 = x139973623685191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973623685191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10374,12 +10356,12 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj v0x7f41125cf460 = __arg1;
+Obj x139973624528999 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = v0x7f41125cf460;
+__arg3 = x139973624528999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10389,22 +10371,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj v0x7f41126cf020 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125d6180 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125d6180) {
-Obj v0x7f41125d63e0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125d6400 = PRIM_EQ(symtailcall, v0x7f41125d63e0);
-if (True == v0x7f41125d6400) {
-Obj v0x7f41125d65c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d65e0 = PRIM_ISCONS(v0x7f41125d65c0);
-if (True == v0x7f41125d65e0) {
-Obj v0x7f41125d6820 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d6840 = PRIM_CAR(v0x7f41125d6820);
-Obj exp = v0x7f41125d6840;
-Obj v0x7f41125d6b60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125d6b80 = PRIM_CDR(v0x7f41125d6b60);
-Obj v0x7f41125d6ba0 = PRIM_EQ(Nil, v0x7f41125d6b80);
-if (True == v0x7f41125d6ba0) {
+Obj x139973623686151 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624847527 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624847527) {
+Obj x139973624848199 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624848231 = PRIM_EQ(symtailcall, x139973624848199);
+if (True == x139973624848231) {
+Obj x139973624684839 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624684871 = PRIM_ISCONS(x139973624684839);
+if (True == x139973624684871) {
+Obj x139973624685351 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624685383 = PRIM_CAR(x139973624685351);
+Obj exp = x139973624685383;
+Obj x139973624686311 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624686343 = PRIM_CDR(x139973624686311);
+Obj x139973624686375 = PRIM_EQ(Nil, x139973624686343);
+if (True == x139973624686375) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = exp;
@@ -10415,7 +10397,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf020;
+__arg0 = x139973623686151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10424,7 +10406,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf020;
+__arg0 = x139973623686151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10433,7 +10415,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf020;
+__arg0 = x139973623686151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10442,7 +10424,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf020;
+__arg0 = x139973623686151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10453,31 +10435,31 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj v0x7f41126cf1e0 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125e7ae0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125e7ae0) {
-Obj v0x7f41125e7ce0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125e7d00 = PRIM_EQ(symcontinuation, v0x7f41125e7ce0);
-if (True == v0x7f41125e7d00) {
-Obj v0x7f41125e7f60 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e7f80 = PRIM_ISCONS(v0x7f41125e7f60);
-if (True == v0x7f41125e7f80) {
-Obj v0x7f41125e5160 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5180 = PRIM_CAR(v0x7f41125e5160);
-Obj arg = v0x7f41125e5180;
-Obj v0x7f41125e53e0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5400 = PRIM_CDR(v0x7f41125e53e0);
-Obj v0x7f41125e5420 = PRIM_ISCONS(v0x7f41125e5400);
-if (True == v0x7f41125e5420) {
-Obj v0x7f41125e5780 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e57a0 = PRIM_CDR(v0x7f41125e5780);
-Obj v0x7f41125e57c0 = PRIM_CAR(v0x7f41125e57a0);
-Obj body = v0x7f41125e57c0;
-Obj v0x7f41125e5ae0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125e5b00 = PRIM_CDR(v0x7f41125e5ae0);
-Obj v0x7f41125e5b60 = PRIM_CDR(v0x7f41125e5b00);
-Obj v0x7f41125e5b80 = PRIM_EQ(Nil, v0x7f41125e5b60);
-if (True == v0x7f41125e5b80) {
+Obj x139973623686887 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973624890247 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624890247) {
+Obj x139973624890695 = PRIM_CAR(closureRef(co, 0));
+Obj x139973624890855 = PRIM_EQ(symcontinuation, x139973624890695);
+if (True == x139973624890855) {
+Obj x139973624891399 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624891431 = PRIM_ISCONS(x139973624891399);
+if (True == x139973624891431) {
+Obj x139973624891943 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624891975 = PRIM_CAR(x139973624891943);
+Obj arg = x139973624891975;
+Obj x139973624892807 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624892839 = PRIM_CDR(x139973624892807);
+Obj x139973624892871 = PRIM_ISCONS(x139973624892839);
+if (True == x139973624892871) {
+Obj x139973624844519 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624844551 = PRIM_CDR(x139973624844519);
+Obj x139973624844583 = PRIM_CAR(x139973624844551);
+Obj body = x139973624844583;
+Obj x139973624845639 = PRIM_CDR(closureRef(co, 0));
+Obj x139973624845799 = PRIM_CDR(x139973624845639);
+Obj x139973624845831 = PRIM_CDR(x139973624845799);
+Obj x139973624845863 = PRIM_EQ(Nil, x139973624845831);
+if (True == x139973624845863) {
 pushCont(co, 36, clofun7, 1, arg);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10489,7 +10471,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1e0;
+__arg0 = x139973623686887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10498,7 +10480,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1e0;
+__arg0 = x139973623686887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10507,7 +10489,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1e0;
+__arg0 = x139973623686887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10516,7 +10498,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1e0;
+__arg0 = x139973623686887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10525,7 +10507,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf1e0;
+__arg0 = x139973623686887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10536,11 +10518,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj v0x7f41125e5d00 = __arg1;
+Obj x139973624846375 = __arg1;
 Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = v0x7f41125e5d00;
+__arg1 = x139973624846375;
 __arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -10551,19 +10533,19 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj v0x7f41126cf440 = makeNative(39, clofun7, 0, 0);
-Obj v0x7f41125e72e0 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125e72e0) {
-Obj v0x7f41125e73e0 = PRIM_CAR(closureRef(co, 0));
-Obj f = v0x7f41125e73e0;
-Obj v0x7f41125e74e0 = PRIM_CDR(closureRef(co, 0));
-Obj args = v0x7f41125e74e0;
-Obj v0x7f41125e7840 = makeCons(f, args);
+Obj x139973623687847 = makeNative(39, clofun7, 0, 0);
+Obj x139973624916967 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624916967) {
+Obj x139973624917255 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139973624917255;
+Obj x139973624917543 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139973624917543;
+Obj x139973624889799 = makeCons(f, args);
 PUSH_CONT_0(co, 38, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = v0x7f41125e7840;
+__arg2 = x139973624889799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10571,7 +10553,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf440;
+__arg0 = x139973623687847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10582,12 +10564,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj v0x7f41125e7860 = __arg1;
+Obj x139973624889831 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = v0x7f41125e7860;
+__arg3 = x139973624889831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10609,23 +10591,23 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj v0x7f4112743fe0 = __arg1;
-Obj v0x7f411273e080 = makeNative(41, clofun7, 0, 1, v0x7f4112743fe0);
-Obj v0x7f41125fbc40 = PRIM_ISCONS(v0x7f4112743fe0);
-if (True == v0x7f41125fbc40) {
-Obj v0x7f41125fbe80 = PRIM_CAR(v0x7f4112743fe0);
-Obj v0x7f41125fbea0 = PRIM_EQ(sym_37const, v0x7f41125fbe80);
-if (True == v0x7f41125fbea0) {
-Obj v0x7f41125ec040 = PRIM_CDR(v0x7f4112743fe0);
-Obj v0x7f41125ec060 = PRIM_ISCONS(v0x7f41125ec040);
-if (True == v0x7f41125ec060) {
-Obj v0x7f41125ec2a0 = PRIM_CDR(v0x7f4112743fe0);
-Obj v0x7f41125ec2c0 = PRIM_CAR(v0x7f41125ec2a0);
-Obj x = v0x7f41125ec2c0;
-Obj v0x7f41125ec520 = PRIM_CDR(v0x7f4112743fe0);
-Obj v0x7f41125ec540 = PRIM_CDR(v0x7f41125ec520);
-Obj v0x7f41125ec560 = PRIM_EQ(Nil, v0x7f41125ec540);
-if (True == v0x7f41125ec560) {
+Obj x139973624079431 = __arg1;
+Obj x139973624079655 = makeNative(41, clofun7, 0, 1, x139973624079431);
+Obj x139973625013031 = PRIM_ISCONS(x139973624079431);
+if (True == x139973625013031) {
+Obj x139973625013575 = PRIM_CAR(x139973624079431);
+Obj x139973625013607 = PRIM_EQ(sym_37const, x139973625013575);
+if (True == x139973625013607) {
+Obj x139973625014087 = PRIM_CDR(x139973624079431);
+Obj x139973625014119 = PRIM_ISCONS(x139973625014087);
+if (True == x139973625014119) {
+Obj x139973625014567 = PRIM_CDR(x139973624079431);
+Obj x139973625014599 = PRIM_CAR(x139973625014567);
+Obj x = x139973625014599;
+Obj x139973625015527 = PRIM_CDR(x139973624079431);
+Obj x139973625015591 = PRIM_CDR(x139973625015527);
+Obj x139973625015623 = PRIM_EQ(Nil, x139973625015591);
+if (True == x139973625015623) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10633,7 +10615,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e080;
+__arg0 = x139973624079655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10642,7 +10624,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e080;
+__arg0 = x139973624079655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10651,7 +10633,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e080;
+__arg0 = x139973624079655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10660,7 +10642,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e080;
+__arg0 = x139973624079655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10671,22 +10653,22 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj v0x7f411273e240 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125fef60 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125fef60) {
-Obj v0x7f41125fb1a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125fb1c0 = PRIM_EQ(sym_37global, v0x7f41125fb1a0);
-if (True == v0x7f41125fb1c0) {
-Obj v0x7f41125fb360 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fb380 = PRIM_ISCONS(v0x7f41125fb360);
-if (True == v0x7f41125fb380) {
-Obj v0x7f41125fb580 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fb5a0 = PRIM_CAR(v0x7f41125fb580);
-Obj x = v0x7f41125fb5a0;
-Obj v0x7f41125fb880 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fb8a0 = PRIM_CDR(v0x7f41125fb880);
-Obj v0x7f41125fb8c0 = PRIM_EQ(Nil, v0x7f41125fb8a0);
-if (True == v0x7f41125fb8c0) {
+Obj x139973624080391 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973625030087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625030087) {
+Obj x139973625030599 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625030631 = PRIM_EQ(sym_37global, x139973625030599);
+if (True == x139973625030631) {
+Obj x139973625031079 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625031111 = PRIM_ISCONS(x139973625031079);
+if (True == x139973625031111) {
+Obj x139973625031655 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625031687 = PRIM_CAR(x139973625031655);
+Obj x = x139973625031687;
+Obj x139973625032391 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625032519 = PRIM_CDR(x139973625032391);
+Obj x139973625032551 = PRIM_EQ(Nil, x139973625032519);
+if (True == x139973625032551) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10694,7 +10676,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e240;
+__arg0 = x139973624080391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10703,7 +10685,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e240;
+__arg0 = x139973624080391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10712,7 +10694,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e240;
+__arg0 = x139973624080391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10721,7 +10703,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e240;
+__arg0 = x139973624080391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10732,22 +10714,22 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj v0x7f411273e460 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f41125fe340 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41125fe340) {
-Obj v0x7f41125fe540 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41125fe560 = PRIM_EQ(sym_37builtin, v0x7f41125fe540);
-if (True == v0x7f41125fe560) {
-Obj v0x7f41125fe700 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fe740 = PRIM_ISCONS(v0x7f41125fe700);
-if (True == v0x7f41125fe740) {
-Obj v0x7f41125fe940 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125fe960 = PRIM_CAR(v0x7f41125fe940);
-Obj op = v0x7f41125fe960;
-Obj v0x7f41125febc0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41125febe0 = PRIM_CDR(v0x7f41125febc0);
-Obj v0x7f41125fec00 = PRIM_EQ(Nil, v0x7f41125febe0);
-if (True == v0x7f41125fec00) {
+Obj x139973624081127 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973625787783 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625787783) {
+Obj x139973625788359 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625788391 = PRIM_EQ(sym_37builtin, x139973625788359);
+if (True == x139973625788391) {
+Obj x139973625789607 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625789639 = PRIM_ISCONS(x139973625789607);
+if (True == x139973625789639) {
+Obj x139973625790119 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625790151 = PRIM_CAR(x139973625790119);
+Obj op = x139973625790151;
+Obj x139973625029063 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625029095 = PRIM_CDR(x139973625029063);
+Obj x139973625029127 = PRIM_EQ(Nil, x139973625029095);
+if (True == x139973625029127) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10755,7 +10737,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e460;
+__arg0 = x139973624081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10764,7 +10746,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e460;
+__arg0 = x139973624081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10773,7 +10755,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e460;
+__arg0 = x139973624081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10782,7 +10764,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e460;
+__arg0 = x139973624081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10793,22 +10775,22 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj v0x7f411273e660 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f4112603680 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112603680) {
-Obj v0x7f41126038a0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f41126038c0 = PRIM_EQ(symquote, v0x7f41126038a0);
-if (True == v0x7f41126038c0) {
-Obj v0x7f4112603ac0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112603ae0 = PRIM_ISCONS(v0x7f4112603ac0);
-if (True == v0x7f4112603ae0) {
-Obj v0x7f4112603c80 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112603ca0 = PRIM_CAR(v0x7f4112603c80);
-Obj x = v0x7f4112603ca0;
-Obj v0x7f4112603fa0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112603fc0 = PRIM_CDR(v0x7f4112603fa0);
-Obj v0x7f4112603fe0 = PRIM_EQ(Nil, v0x7f4112603fc0);
-if (True == v0x7f4112603fe0) {
+Obj x139973624081863 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973625855655 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625855655) {
+Obj x139973625823335 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625823367 = PRIM_EQ(symquote, x139973625823335);
+if (True == x139973625823367) {
+Obj x139973625823943 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625823975 = PRIM_ISCONS(x139973625823943);
+if (True == x139973625823975) {
+Obj x139973625824391 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625824423 = PRIM_CAR(x139973625824391);
+Obj x = x139973625824423;
+Obj x139973625825191 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625825223 = PRIM_CDR(x139973625825191);
+Obj x139973625825287 = PRIM_EQ(Nil, x139973625825223);
+if (True == x139973625825287) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10816,7 +10798,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e660;
+__arg0 = x139973624081863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10825,7 +10807,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e660;
+__arg0 = x139973624081863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10834,7 +10816,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e660;
+__arg0 = x139973624081863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10843,7 +10825,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e660;
+__arg0 = x139973624081863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10854,22 +10836,22 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj v0x7f411273e8a0 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
-Obj v0x7f411261ba00 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f411261ba00) {
-Obj v0x7f411261bbc0 = PRIM_CAR(closureRef(co, 0));
-Obj v0x7f411261bc00 = PRIM_EQ(sym_37closure_45ref, v0x7f411261bbc0);
-if (True == v0x7f411261bc00) {
-Obj v0x7f411261be20 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f411261be40 = PRIM_ISCONS(v0x7f411261be20);
-if (True == v0x7f411261be40) {
-Obj v0x7f411261bfe0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f4112603000 = PRIM_CAR(v0x7f411261bfe0);
-Obj __ = v0x7f4112603000;
-Obj v0x7f41126032c0 = PRIM_CDR(closureRef(co, 0));
-Obj v0x7f41126032e0 = PRIM_CDR(v0x7f41126032c0);
-Obj v0x7f4112603300 = PRIM_EQ(Nil, v0x7f41126032e0);
-if (True == v0x7f4112603300) {
+Obj x139973624000679 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
+Obj x139973625852039 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973625852039) {
+Obj x139973625852583 = PRIM_CAR(closureRef(co, 0));
+Obj x139973625852743 = PRIM_EQ(sym_37closure_45ref, x139973625852583);
+if (True == x139973625852743) {
+Obj x139973625853159 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625853191 = PRIM_ISCONS(x139973625853159);
+if (True == x139973625853191) {
+Obj x139973625853735 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625853799 = PRIM_CAR(x139973625853735);
+Obj __ = x139973625853799;
+Obj x139973625854567 = PRIM_CDR(closureRef(co, 0));
+Obj x139973625854695 = PRIM_CDR(x139973625854567);
+Obj x139973625854727 = PRIM_EQ(Nil, x139973625854695);
+if (True == x139973625854727) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10877,7 +10859,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e8a0;
+__arg0 = x139973624000679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10886,7 +10868,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e8a0;
+__arg0 = x139973624000679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10895,7 +10877,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e8a0;
+__arg0 = x139973624000679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10904,7 +10886,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e8a0;
+__arg0 = x139973624000679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10915,7 +10897,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj v0x7f411273ea80 = makeNative(46, clofun7, 0, 0);
+Obj x139973624001415 = makeNative(46, clofun7, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = False;
@@ -10938,12 +10920,12 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj v0x7f4112743860 = __arg1;
-Obj v0x7f41127438a0 = __arg2;
-Obj v0x7f4112743960 = makeNative(48, clofun7, 0, 2, v0x7f4112743860, v0x7f41127438a0);
-Obj v0x7f411261b240 = PRIM_EQ(Nil, v0x7f4112743860);
-if (True == v0x7f411261b240) {
-Obj __ = v0x7f41127438a0;
+Obj x139973624224167 = __arg1;
+Obj x139973624224199 = __arg2;
+Obj x139973624224583 = makeNative(48, clofun7, 0, 2, x139973624224167, x139973624224199);
+Obj x139973623686343 = PRIM_EQ(Nil, x139973624224167);
+if (True == x139973623686343) {
+Obj __ = x139973624224199;
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10951,7 +10933,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743960;
+__arg0 = x139973624224583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10962,15 +10944,15 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj v0x7f4112743ac0 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f4112669b20 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112669b20) {
-Obj v0x7f4112669c60 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f4112669c60;
-Obj v0x7f4112669d80 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f4112669d80;
+Obj x139973624225127 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973623733831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623733831) {
+Obj x139973623734087 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139973623734087;
+Obj x139973623685223 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139973623685223;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 49, clofun7, 3, y, s2, v0x7f4112743ac0);
+pushCont(co, 49, clofun7, 3, y, s2, x139973624225127);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -10982,7 +10964,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743ac0;
+__arg0 = x139973624225127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10993,11 +10975,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj v0x7f4112669f00 = __arg1;
+Obj x139973623685575 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112743ac0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == v0x7f4112669f00) {
+Obj x139973624225127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139973623685575) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
 __arg1 = y;
@@ -11009,7 +10991,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743ac0;
+__arg0 = x139973624225127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11040,13 +11022,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f4112743cc0 = makeNative(2, clofun8, 0, 0);
-Obj v0x7f4112669540 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f4112669540) {
-Obj v0x7f4112669640 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f4112669640;
-Obj v0x7f4112669760 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f4112669760;
+Obj x139973624078439 = makeNative(2, clofun8, 0, 0);
+Obj x139973623732359 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973623732359) {
+Obj x139973623732615 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139973623732615;
+Obj x139973623732903 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139973623732903;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 1, clofun8, 1, x);
 __nargs = 3;
@@ -11060,7 +11042,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743cc0;
+__arg0 = x139973624078439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11071,11 +11053,11 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj v0x7f4112669960 = __arg1;
+Obj x139973623733383 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f4112669980 = makeCons(x, v0x7f4112669960);
+Obj x139973623733415 = makeCons(x, x139973623733383);
 __nargs = 2;
-__arg1 = v0x7f4112669980;
+__arg1 = x139973623733415;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11095,12 +11077,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj v0x7f41127430e0 = __arg1;
-Obj v0x7f4112743100 = __arg2;
-Obj v0x7f41127431e0 = makeNative(4, clofun8, 0, 2, v0x7f41127430e0, v0x7f4112743100);
-Obj v0x7f4112669000 = PRIM_EQ(Nil, v0x7f41127430e0);
-if (True == v0x7f4112669000) {
-Obj s2 = v0x7f4112743100;
+Obj x139973624377095 = __arg1;
+Obj x139973624377127 = __arg2;
+Obj x139973624221863 = makeNative(4, clofun8, 0, 2, x139973624377095, x139973624377127);
+Obj x139973623730983 = PRIM_EQ(Nil, x139973624377095);
+if (True == x139973623730983) {
+Obj s2 = x139973624377127;
 __nargs = 2;
 __arg1 = s2;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -11108,7 +11090,7 @@ if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127431e0;
+__arg0 = x139973624221863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11119,15 +11101,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj v0x7f4112743340 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v0x7f41126a7980 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41126a7980) {
-Obj v0x7f41126a7a80 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f41126a7a80;
-Obj v0x7f41126a7ba0 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f41126a7ba0;
+Obj x139973624222407 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973624003751 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624003751) {
+Obj x139973624004039 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139973624004039;
+Obj x139973624004295 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139973624004295;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 5, clofun8, 3, y, s2, v0x7f4112743340);
+pushCont(co, 5, clofun8, 3, y, s2, x139973624222407);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -11139,7 +11121,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743340;
+__arg0 = x139973624222407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11150,11 +11132,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj v0x7f41126a7d20 = __arg1;
+Obj x139973623730215 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f4112743340= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == v0x7f41126a7d20) {
+Obj x139973624222407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139973623730215) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
 __arg1 = y;
@@ -11166,7 +11148,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743340;
+__arg0 = x139973624222407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11177,13 +11159,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj v0x7f4112743520 = makeNative(8, clofun8, 0, 0);
-Obj v0x7f41126a7320 = PRIM_ISCONS(closureRef(co, 0));
-if (True == v0x7f41126a7320) {
-Obj v0x7f41126a7480 = PRIM_CAR(closureRef(co, 0));
-Obj x = v0x7f41126a7480;
-Obj v0x7f41126a75a0 = PRIM_CDR(closureRef(co, 0));
-Obj y = v0x7f41126a75a0;
+Obj x139973624223175 = makeNative(8, clofun8, 0, 0);
+Obj x139973624002247 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139973624002247) {
+Obj x139973624002535 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139973624002535;
+Obj x139973624002823 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139973624002823;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 7, clofun8, 1, x);
 __nargs = 3;
@@ -11197,7 +11179,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743520;
+__arg0 = x139973624223175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11208,11 +11190,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj v0x7f41126a7780 = __arg1;
+Obj x139973624003335 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41126a7800 = makeCons(x, v0x7f41126a7780);
+Obj x139973624003367 = makeCons(x, x139973624003335);
 __nargs = 2;
-__arg1 = v0x7f41126a7800;
+__arg1 = x139973624003367;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11232,18 +11214,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj v0x7f411272d460 = __arg1;
-Obj v0x7f411272d480 = __arg2;
-Obj v0x7f411272d4a0 = __arg3;
-Obj v0x7f411272d4c0 = co->args[4];
-Obj v0x7f411272d4e0 = co->args[5];
-Obj v0x7f411272d660 = makeNative(13, clofun8, 0, 5, v0x7f411272d460, v0x7f411272d480, v0x7f411272d4a0, v0x7f411272d4c0, v0x7f411272d4e0);
-Obj __ = v0x7f411272d460;
-__ = v0x7f411272d480;
-__ = v0x7f411272d4a0;
-Obj globals = v0x7f411272d4c0;
-Obj x = v0x7f411272d4e0;
-pushCont(co, 10, clofun8, 2, x, v0x7f411272d660);
+Obj x139973624892103 = __arg1;
+Obj x139973624892135 = __arg2;
+Obj x139973624892167 = __arg3;
+Obj x139973624892199 = co->args[4];
+Obj x139973624892231 = co->args[5];
+Obj x139973624893095 = makeNative(13, clofun8, 0, 5, x139973624892103, x139973624892135, x139973624892167, x139973624892199, x139973624892231);
+Obj __ = x139973624892103;
+__ = x139973624892135;
+__ = x139973624892167;
+Obj globals = x139973624892199;
+Obj x = x139973624892231;
+pushCont(co, 10, clofun8, 2, x, x139973624893095);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35number_63);
 __arg1 = x;
@@ -11256,21 +11238,21 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj v0x7f41126b5e60 = __arg1;
+Obj x139973624225543 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272d660= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41126b5e60) {
+Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624225543) {
 if (True == True) {
-Obj v0x7f41126af040 = makeCons(x, Nil);
-Obj v0x7f41126af060 = makeCons(sym_37const, v0x7f41126af040);
+Obj x139973624078631 = makeCons(x, Nil);
+Obj x139973624078663 = makeCons(sym_37const, x139973624078631);
 __nargs = 2;
-__arg1 = v0x7f41126af060;
+__arg1 = x139973624078663;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d660;
+__arg0 = x139973624893095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11278,19 +11260,19 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj v0x7f41126af240 = primIsString(x);
-if (True == v0x7f41126af240) {
+Obj x139973624079047 = primIsString(x);
+if (True == x139973624079047) {
 if (True == True) {
-Obj v0x7f41126af420 = makeCons(x, Nil);
-Obj v0x7f41126af440 = makeCons(sym_37const, v0x7f41126af420);
+Obj x139973624079591 = makeCons(x, Nil);
+Obj x139973624079623 = makeCons(sym_37const, x139973624079591);
 __nargs = 2;
-__arg1 = v0x7f41126af440;
+__arg1 = x139973624079623;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d660;
+__arg0 = x139973624893095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11298,7 +11280,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 11, clofun8, 2, x, v0x7f411272d660);
+pushCont(co, 11, clofun8, 2, x, x139973624893095);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35boolean_63);
 __arg1 = x;
@@ -11313,21 +11295,21 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj v0x7f41126af5c0 = __arg1;
+Obj x139973624080039 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272d660= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41126af5c0) {
+Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624080039) {
 if (True == True) {
-Obj v0x7f41126af7a0 = makeCons(x, Nil);
-Obj v0x7f41126af7c0 = makeCons(sym_37const, v0x7f41126af7a0);
+Obj x139973624080583 = makeCons(x, Nil);
+Obj x139973624080615 = makeCons(sym_37const, x139973624080583);
 __nargs = 2;
-__arg1 = v0x7f41126af7c0;
+__arg1 = x139973624080615;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d660;
+__arg0 = x139973624893095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11335,7 +11317,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 12, clofun8, 2, x, v0x7f411272d660);
+pushCont(co, 12, clofun8, 2, x, x139973624893095);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = x;
@@ -11349,21 +11331,21 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj v0x7f41126af940 = __arg1;
+Obj x139973624081095 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272d660= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41126af940) {
+Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624081095) {
 if (True == True) {
-Obj v0x7f41126afb60 = makeCons(x, Nil);
-Obj v0x7f41126afb80 = makeCons(sym_37const, v0x7f41126afb60);
+Obj x139973624081543 = makeCons(x, Nil);
+Obj x139973624081575 = makeCons(sym_37const, x139973624081543);
 __nargs = 2;
-__arg1 = v0x7f41126afb80;
+__arg1 = x139973624081575;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d660;
+__arg0 = x139973624893095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11372,16 +11354,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj v0x7f41126afda0 = makeCons(x, Nil);
-Obj v0x7f41126afdc0 = makeCons(sym_37const, v0x7f41126afda0);
+Obj x139973624082247 = makeCons(x, Nil);
+Obj x139973624082279 = makeCons(sym_37const, x139973624082247);
 __nargs = 2;
-__arg1 = v0x7f41126afdc0;
+__arg1 = x139973624082279;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d660;
+__arg0 = x139973624893095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11393,26 +11375,26 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj v0x7f411272d940 = makeNative(15, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624845159 = makeNative(15, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41126cfa40 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41126cfa40) {
-Obj v0x7f41126cff00 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41126cff20 = PRIM_EQ(symquote, v0x7f41126cff00);
-if (True == v0x7f41126cff20) {
-Obj v0x7f41126b50e0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41126b5120 = PRIM_ISCONS(v0x7f41126b50e0);
-if (True == v0x7f41126b5120) {
-Obj v0x7f41126b5340 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41126b5360 = PRIM_CAR(v0x7f41126b5340);
-Obj x = v0x7f41126b5360;
-Obj v0x7f41126b5600 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41126b5640 = PRIM_CDR(v0x7f41126b5600);
-Obj v0x7f41126b5660 = PRIM_EQ(Nil, v0x7f41126b5640);
-if (True == v0x7f41126b5660) {
+Obj x139973624278343 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624278343) {
+Obj x139973624278791 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624278919 = PRIM_EQ(symquote, x139973624278791);
+if (True == x139973624278919) {
+Obj x139973624222023 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624222055 = PRIM_ISCONS(x139973624222023);
+if (True == x139973624222055) {
+Obj x139973624222599 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624222631 = PRIM_CAR(x139973624222599);
+Obj x = x139973624222631;
+Obj x139973624223271 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624223399 = PRIM_CDR(x139973624223271);
+Obj x139973624223431 = PRIM_EQ(Nil, x139973624223399);
+if (True == x139973624223431) {
 pushCont(co, 14, clofun8, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
@@ -11425,7 +11407,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d940;
+__arg0 = x139973624845159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11434,7 +11416,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d940;
+__arg0 = x139973624845159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11443,7 +11425,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d940;
+__arg0 = x139973624845159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11452,7 +11434,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272d940;
+__arg0 = x139973624845159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11463,12 +11445,12 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj v0x7f41126b57a0 = __arg1;
+Obj x139973624223719 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41126b5960 = makeCons(x, Nil);
-Obj v0x7f41126b5980 = makeCons(sym_37const, v0x7f41126b5960);
+Obj x139973624224135 = makeCons(x, Nil);
+Obj x139973624224327 = makeCons(sym_37const, x139973624224135);
 __nargs = 2;
-__arg1 = v0x7f41126b5980;
+__arg1 = x139973624224327;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11476,15 +11458,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj v0x7f411272dd00 = makeNative(19, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624846791 = makeNative(18, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
 Obj x = closureRef(co, 4);
-Obj v0x7f411272dee0 = primIsSymbol(x);
-if (True == v0x7f411272dee0) {
-pushCont(co, 16, clofun8, 4, x, ns, import, globals);
+Obj x139973624276551 = primIsSymbol(x);
+if (True == x139973624276551) {
+pushCont(co, 16, clofun8, 2, globals, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -11496,7 +11478,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dd00;
+__arg0 = x139973624846791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11507,24 +11489,21 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj v0x7f41126cf100 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == v0x7f41126cf100) {
+Obj x139973624276839 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139973624276839) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 17, clofun8, 1, globals);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35lookup_45var);
+pushCont(co, 17, clofun8, 1, x);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
 __arg1 = x;
-__arg2 = ns;
-__arg3 = import;
+__arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11535,66 +11514,49 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj v0x7f41126cf2a0 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = v0x7f41126cf2a0;
-pushCont(co, 18, clofun8, 1, v);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = v;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj v0x7f41126cf480 = __arg1;
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41126cf620 = makeCons(v, Nil);
-Obj v0x7f41126cf640 = makeCons(sym_37global, v0x7f41126cf620);
+Obj x139973624277191 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624277607 = makeCons(x, Nil);
+Obj x139973624277671 = makeCons(sym_37global, x139973624277607);
 __nargs = 2;
-__arg1 = v0x7f41126cf640;
+__arg1 = x139973624277671;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label19:
+label18:
 {
-Obj v0x7f411272dfe0 = makeNative(22, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624848007 = makeNative(21, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41127435e0 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41127435e0) {
-Obj v0x7f4112743900 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f4112743940 = PRIM_EQ(symlambda, v0x7f4112743900);
-if (True == v0x7f4112743940) {
-Obj v0x7f4112743d20 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f4112743d40 = PRIM_ISCONS(v0x7f4112743d20);
-if (True == v0x7f4112743d40) {
-Obj v0x7f4112743fa0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f411273e060 = PRIM_CAR(v0x7f4112743fa0);
-Obj args = v0x7f411273e060;
-Obj v0x7f411273e3c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f411273e3e0 = PRIM_CDR(v0x7f411273e3c0);
-Obj v0x7f411273e400 = PRIM_ISCONS(v0x7f411273e3e0);
-if (True == v0x7f411273e400) {
-Obj v0x7f411273e800 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f411273e820 = PRIM_CDR(v0x7f411273e800);
-Obj v0x7f411273e840 = PRIM_CAR(v0x7f411273e820);
-Obj body = v0x7f411273e840;
-Obj v0x7f411273ee40 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f411273ee80 = PRIM_CDR(v0x7f411273ee40);
-Obj v0x7f411273eea0 = PRIM_CDR(v0x7f411273ee80);
-Obj v0x7f411273eec0 = PRIM_EQ(Nil, v0x7f411273eea0);
-if (True == v0x7f411273eec0) {
-pushCont(co, 20, clofun8, 5, ns, import, globals, body, args);
+Obj x139973624376583 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624376583) {
+Obj x139973624377031 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624377063 = PRIM_EQ(symlambda, x139973624377031);
+if (True == x139973624377063) {
+Obj x139973624340679 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624340711 = PRIM_ISCONS(x139973624340679);
+if (True == x139973624340711) {
+Obj x139973624341191 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624341223 = PRIM_CAR(x139973624341191);
+Obj args = x139973624341223;
+Obj x139973624341863 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624341895 = PRIM_CDR(x139973624341863);
+Obj x139973624341927 = PRIM_ISCONS(x139973624341895);
+if (True == x139973624341927) {
+Obj x139973624342535 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624342599 = PRIM_CDR(x139973624342535);
+Obj x139973624342631 = PRIM_CAR(x139973624342599);
+Obj body = x139973624342631;
+Obj x139973624343463 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624343495 = PRIM_CDR(x139973624343463);
+Obj x139973624343527 = PRIM_CDR(x139973624343495);
+Obj x139973624343559 = PRIM_EQ(Nil, x139973624343527);
+if (True == x139973624343559) {
+pushCont(co, 19, clofun8, 5, ns, import, globals, body, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
 __arg1 = args;
@@ -11606,7 +11568,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dfe0;
+__arg0 = x139973624848007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11615,7 +11577,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dfe0;
+__arg0 = x139973624848007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11624,7 +11586,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dfe0;
+__arg0 = x139973624848007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11633,7 +11595,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dfe0;
+__arg0 = x139973624848007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11642,7 +11604,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f411272dfe0;
+__arg0 = x139973624848007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11651,18 +11613,18 @@ goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label19:
 {
-Obj v0x7f411272d6c0 = __arg1;
+Obj x139973624274951 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 21, clofun8, 1, args);
+pushCont(co, 20, clofun8, 1, args);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = v0x7f411272d6c0;
+__arg1 = x139973624274951;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
@@ -11674,35 +11636,35 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label20:
 {
-Obj v0x7f411272d780 = __arg1;
+Obj x139973624275111 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411272d7c0 = makeCons(v0x7f411272d780, Nil);
-Obj v0x7f411272d7e0 = makeCons(args, v0x7f411272d7c0);
-Obj v0x7f411272d800 = makeCons(symlambda, v0x7f411272d7e0);
+Obj x139973624275175 = makeCons(x139973624275111, Nil);
+Obj x139973624275207 = makeCons(args, x139973624275175);
+Obj x139973624275239 = makeCons(symlambda, x139973624275207);
 __nargs = 2;
-__arg1 = v0x7f411272d800;
+__arg1 = x139973624275239;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label22:
+label21:
 {
-Obj v0x7f41126cf420 = makeNative(25, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624686023 = makeNative(24, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41125c1620 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125c1620) {
-Obj v0x7f41125c17e0 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41125c1800 = PRIM_EQ(symif, v0x7f41125c17e0);
-if (True == v0x7f41125c1800) {
-Obj v0x7f41125c1900 = PRIM_CDR(closureRef(co, 4));
-Obj args = v0x7f41125c1900;
-pushCont(co, 23, clofun8, 1, args);
+Obj x139973624373959 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624373959) {
+Obj x139973624374439 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624374471 = PRIM_EQ(symif, x139973624374439);
+if (True == x139973624374471) {
+Obj x139973624374791 = PRIM_CDR(closureRef(co, 4));
+Obj args = x139973624374791;
+pushCont(co, 22, clofun8, 1, args);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -11716,7 +11678,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf420;
+__arg0 = x139973624686023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11725,7 +11687,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf420;
+__arg0 = x139973624686023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11734,14 +11696,14 @@ goto *jumpTable[ps.label];
 }
 }
 
-label23:
+label22:
 {
-Obj v0x7f41125c1b80 = __arg1;
+Obj x139973624375623 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 24, clofun8);
+PUSH_CONT_0(co, 23, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f41125c1b80;
+__arg1 = x139973624375623;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -11750,82 +11712,82 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label24:
+label23:
 {
-Obj v0x7f41125c1bc0 = __arg1;
-Obj v0x7f41125c1be0 = makeCons(symif, v0x7f41125c1bc0);
+Obj x139973624375719 = __arg1;
+Obj x139973624375751 = makeCons(symif, x139973624375719);
 __nargs = 2;
-__arg1 = v0x7f41125c1be0;
+__arg1 = x139973624375751;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label25:
+label24:
 {
-Obj v0x7f41126cf760 = makeNative(28, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624687431 = makeNative(27, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41125d2460 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125d2460) {
-Obj v0x7f41125d2640 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41125d2660 = PRIM_EQ(symdo, v0x7f41125d2640);
-if (True == v0x7f41125d2660) {
-Obj v0x7f41125d2840 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d2860 = PRIM_ISCONS(v0x7f41125d2840);
-if (True == v0x7f41125d2860) {
-Obj v0x7f41125d2aa0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d2ac0 = PRIM_CAR(v0x7f41125d2aa0);
-Obj v0x7f41125d2ae0 = PRIM_ISCONS(v0x7f41125d2ac0);
-if (True == v0x7f41125d2ae0) {
-Obj v0x7f41125d2de0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d2e00 = PRIM_CAR(v0x7f41125d2de0);
-Obj v0x7f41125d2e20 = PRIM_CAR(v0x7f41125d2e00);
-Obj v0x7f41125d2e40 = PRIM_EQ(symimport, v0x7f41125d2e20);
-if (True == v0x7f41125d2e40) {
-Obj v0x7f41125cf120 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cf140 = PRIM_CAR(v0x7f41125cf120);
-Obj v0x7f41125cf160 = PRIM_CDR(v0x7f41125cf140);
-Obj v0x7f41125cf180 = PRIM_ISCONS(v0x7f41125cf160);
-if (True == v0x7f41125cf180) {
-Obj v0x7f41125cf4a0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cf4c0 = PRIM_CAR(v0x7f41125cf4a0);
-Obj v0x7f41125cf4e0 = PRIM_CDR(v0x7f41125cf4c0);
-Obj v0x7f41125cf500 = PRIM_CAR(v0x7f41125cf4e0);
-Obj pkg = v0x7f41125cf500;
-Obj v0x7f41125cf900 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cf920 = PRIM_CAR(v0x7f41125cf900);
-Obj v0x7f41125cf940 = PRIM_CDR(v0x7f41125cf920);
-Obj v0x7f41125cf960 = PRIM_CDR(v0x7f41125cf940);
-Obj v0x7f41125cf980 = PRIM_EQ(Nil, v0x7f41125cf960);
-if (True == v0x7f41125cf980) {
-Obj v0x7f41125cfc20 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cfc40 = PRIM_CDR(v0x7f41125cfc20);
-Obj v0x7f41125cfc60 = PRIM_ISCONS(v0x7f41125cfc40);
-if (True == v0x7f41125cfc60) {
-Obj v0x7f41125cff00 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cff20 = PRIM_CDR(v0x7f41125cff00);
-Obj v0x7f41125cff40 = PRIM_CAR(v0x7f41125cff20);
-Obj y = v0x7f41125cff40;
-Obj v0x7f41125cd600 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125cd620 = PRIM_CDR(v0x7f41125cd600);
-Obj v0x7f41125cd640 = PRIM_CDR(v0x7f41125cd620);
-Obj v0x7f41125cd660 = PRIM_EQ(Nil, v0x7f41125cd640);
-if (True == v0x7f41125cd660) {
-Obj v0x7f41125cd760 = primIsString(pkg);
-if (True == v0x7f41125cd760) {
-Obj v0x7f41125cdb80 = makeCons(pkg, Nil);
-Obj v0x7f41125cdba0 = makeCons(symimport, v0x7f41125cdb80);
-pushCont(co, 26, clofun8, 6, pkg, import, env, ns, globals, y);
+Obj x139973624529959 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624529959) {
+Obj x139973624530407 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624530439 = PRIM_EQ(symdo, x139973624530407);
+if (True == x139973624530439) {
+Obj x139973624530855 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624530887 = PRIM_ISCONS(x139973624530855);
+if (True == x139973624530887) {
+Obj x139973624531463 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624531495 = PRIM_CAR(x139973624531463);
+Obj x139973624531527 = PRIM_ISCONS(x139973624531495);
+if (True == x139973624531527) {
+Obj x139973624532295 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624532327 = PRIM_CAR(x139973624532295);
+Obj x139973624532359 = PRIM_CAR(x139973624532327);
+Obj x139973624532391 = PRIM_EQ(symimport, x139973624532359);
+if (True == x139973624532391) {
+Obj x139973624516743 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624516775 = PRIM_CAR(x139973624516743);
+Obj x139973624516807 = PRIM_CDR(x139973624516775);
+Obj x139973624516839 = PRIM_ISCONS(x139973624516807);
+if (True == x139973624516839) {
+Obj x139973624517575 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624517607 = PRIM_CAR(x139973624517575);
+Obj x139973624517639 = PRIM_CDR(x139973624517607);
+Obj x139973624517671 = PRIM_CAR(x139973624517639);
+Obj pkg = x139973624517671;
+Obj x139973624518599 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624518631 = PRIM_CAR(x139973624518599);
+Obj x139973624518663 = PRIM_CDR(x139973624518631);
+Obj x139973624518695 = PRIM_CDR(x139973624518663);
+Obj x139973624518727 = PRIM_EQ(Nil, x139973624518695);
+if (True == x139973624518727) {
+Obj x139973624519399 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624519431 = PRIM_CDR(x139973624519399);
+Obj x139973624519463 = PRIM_ISCONS(x139973624519431);
+if (True == x139973624519463) {
+Obj x139973624520071 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624520103 = PRIM_CDR(x139973624520071);
+Obj x139973624520135 = PRIM_CAR(x139973624520103);
+Obj y = x139973624520135;
+Obj x139973624414439 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624414471 = PRIM_CDR(x139973624414439);
+Obj x139973624414503 = PRIM_CDR(x139973624414471);
+Obj x139973624414535 = PRIM_EQ(Nil, x139973624414503);
+if (True == x139973624414535) {
+Obj x139973624414855 = primIsString(pkg);
+if (True == x139973624414855) {
+Obj x139973624416007 = makeCons(pkg, Nil);
+Obj x139973624416039 = makeCons(symimport, x139973624416007);
+pushCont(co, 25, clofun8, 6, pkg, import, env, ns, globals, y);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
-co->args[5] = v0x7f41125cdba0;
+co->args[5] = x139973624416039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11833,16 +11795,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11851,7 +11804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11860,7 +11813,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11869,7 +11822,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11878,7 +11831,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11887,7 +11840,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11896,7 +11849,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11905,7 +11858,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11914,7 +11867,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cf760;
+__arg0 = x139973624687431;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139973624687431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11923,22 +11885,22 @@ goto *jumpTable[ps.label];
 }
 }
 
-label26:
+label25:
 {
-Obj v0x7f41125cdbc0 = __arg1;
+Obj x139973624416071 = __arg1;
 Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj v0x7f41125cde40 = makeCons(pkg, import);
-pushCont(co, 27, clofun8, 1, v0x7f41125cdbc0);
+Obj x139973624416839 = makeCons(pkg, import);
+pushCont(co, 26, clofun8, 1, x139973624416071);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
 __arg2 = ns;
-__arg3 = v0x7f41125cde40;
+__arg3 = x139973624416839;
 co->args[4] = globals;
 co->args[5] = y;
 co->ctx.frees = __arg0;
@@ -11948,52 +11910,52 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label27:
+label26:
 {
-Obj v0x7f41125cdea0 = __arg1;
-Obj v0x7f41125cdbc0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125cdee0 = makeCons(v0x7f41125cdea0, Nil);
-Obj v0x7f41125cdf00 = makeCons(v0x7f41125cdbc0, v0x7f41125cdee0);
-Obj v0x7f41125cdf20 = makeCons(symdo, v0x7f41125cdf00);
+Obj x139973624416935 = __arg1;
+Obj x139973624416071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624416999 = makeCons(x139973624416935, Nil);
+Obj x139973624417031 = makeCons(x139973624416071, x139973624416999);
+Obj x139973624417095 = makeCons(symdo, x139973624417031);
 __nargs = 2;
-__arg1 = v0x7f41125cdf20;
+__arg1 = x139973624417095;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label28:
+label27:
 {
-Obj v0x7f41126cfc80 = makeNative(31, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624640551 = makeNative(30, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41125e5b40 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125e5b40) {
-Obj v0x7f41125e5d20 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41125e5d40 = PRIM_EQ(symdo, v0x7f41125e5d20);
-if (True == v0x7f41125e5d40) {
-Obj v0x7f41125e5ee0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125e5f00 = PRIM_ISCONS(v0x7f41125e5ee0);
-if (True == v0x7f41125e5f00) {
-Obj v0x7f41125d60c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d60e0 = PRIM_CAR(v0x7f41125d60c0);
-Obj x = v0x7f41125d60e0;
-Obj v0x7f41125d6360 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d6380 = PRIM_CDR(v0x7f41125d6360);
-Obj v0x7f41125d63a0 = PRIM_ISCONS(v0x7f41125d6380);
-if (True == v0x7f41125d63a0) {
-Obj v0x7f41125d6600 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d6620 = PRIM_CDR(v0x7f41125d6600);
-Obj v0x7f41125d6640 = PRIM_CAR(v0x7f41125d6620);
-Obj y = v0x7f41125d6640;
-Obj v0x7f41125d69c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125d69e0 = PRIM_CDR(v0x7f41125d69c0);
-Obj v0x7f41125d6a00 = PRIM_CDR(v0x7f41125d69e0);
-Obj v0x7f41125d6a20 = PRIM_EQ(Nil, v0x7f41125d6a00);
-if (True == v0x7f41125d6a20) {
-pushCont(co, 29, clofun8, 5, env, ns, import, globals, y);
+Obj x139973624687463 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624687463) {
+Obj x139973624687943 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624687975 = PRIM_EQ(symdo, x139973624687943);
+if (True == x139973624687975) {
+Obj x139973624688391 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624688455 = PRIM_ISCONS(x139973624688391);
+if (True == x139973624688455) {
+Obj x139973624639719 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624639751 = PRIM_CAR(x139973624639719);
+Obj x = x139973624639751;
+Obj x139973624640359 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624640391 = PRIM_CDR(x139973624640359);
+Obj x139973624640423 = PRIM_ISCONS(x139973624640391);
+if (True == x139973624640423) {
+Obj x139973624641063 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624641095 = PRIM_CDR(x139973624641063);
+Obj x139973624641127 = PRIM_CAR(x139973624641095);
+Obj y = x139973624641127;
+Obj x139973624641927 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624641959 = PRIM_CDR(x139973624641927);
+Obj x139973624641991 = PRIM_CDR(x139973624641959);
+Obj x139973624642023 = PRIM_EQ(Nil, x139973624641991);
+if (True == x139973624642023) {
+pushCont(co, 28, clofun8, 5, env, ns, import, globals, y);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12008,7 +11970,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfc80;
+__arg0 = x139973624640551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12017,7 +11979,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfc80;
+__arg0 = x139973624640551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12026,7 +11988,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfc80;
+__arg0 = x139973624640551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12035,7 +11997,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfc80;
+__arg0 = x139973624640551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12044,7 +12006,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126cfc80;
+__arg0 = x139973624640551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12053,15 +12015,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label29:
+label28:
 {
-Obj v0x7f41125d6d00 = __arg1;
+Obj x139973624642759 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 30, clofun8, 1, v0x7f41125d6d00);
+pushCont(co, 29, clofun8, 1, x139973624642759);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12076,63 +12038,63 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label29:
 {
-Obj v0x7f41125d6f20 = __arg1;
-Obj v0x7f41125d6d00= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125d6f60 = makeCons(v0x7f41125d6f20, Nil);
-Obj v0x7f41125d6f80 = makeCons(v0x7f41125d6d00, v0x7f41125d6f60);
-Obj v0x7f41125d6fa0 = makeCons(symdo, v0x7f41125d6f80);
+Obj x139973624643303 = __arg1;
+Obj x139973624642759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624643367 = makeCons(x139973624643303, Nil);
+Obj x139973624643399 = makeCons(x139973624642759, x139973624643367);
+Obj x139973624643431 = makeCons(symdo, x139973624643399);
 __nargs = 2;
-__arg1 = v0x7f41125d6fa0;
+__arg1 = x139973624643431;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label31:
+label30:
 {
-Obj v0x7f41126b50c0 = makeNative(34, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624642407 = makeNative(33, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f41125ec760 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125ec760) {
-Obj v0x7f41125ec940 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41125ec960 = PRIM_EQ(symlet, v0x7f41125ec940);
-if (True == v0x7f41125ec960) {
-Obj v0x7f41125ecb40 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125ecb60 = PRIM_ISCONS(v0x7f41125ecb40);
-if (True == v0x7f41125ecb60) {
-Obj v0x7f41125ecd20 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125ecd40 = PRIM_CAR(v0x7f41125ecd20);
-Obj a = v0x7f41125ecd40;
-Obj v0x7f41125ecf80 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125ecfa0 = PRIM_CDR(v0x7f41125ecf80);
-Obj v0x7f41125ecfc0 = PRIM_ISCONS(v0x7f41125ecfa0);
-if (True == v0x7f41125ecfc0) {
-Obj v0x7f41125e7240 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125e7260 = PRIM_CDR(v0x7f41125e7240);
-Obj v0x7f41125e7280 = PRIM_CAR(v0x7f41125e7260);
-Obj b = v0x7f41125e7280;
-Obj v0x7f41125e75a0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125e75c0 = PRIM_CDR(v0x7f41125e75a0);
-Obj v0x7f41125e75e0 = PRIM_CDR(v0x7f41125e75c0);
-Obj v0x7f41125e7600 = PRIM_ISCONS(v0x7f41125e75e0);
-if (True == v0x7f41125e7600) {
-Obj v0x7f41125e7960 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125e7980 = PRIM_CDR(v0x7f41125e7960);
-Obj v0x7f41125e79a0 = PRIM_CDR(v0x7f41125e7980);
-Obj v0x7f41125e79c0 = PRIM_CAR(v0x7f41125e79a0);
-Obj c = v0x7f41125e79c0;
-Obj v0x7f41125e7e00 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125e7e20 = PRIM_CDR(v0x7f41125e7e00);
-Obj v0x7f41125e7e40 = PRIM_CDR(v0x7f41125e7e20);
-Obj v0x7f41125e7e60 = PRIM_CDR(v0x7f41125e7e40);
-Obj v0x7f41125e7e80 = PRIM_EQ(Nil, v0x7f41125e7e60);
-if (True == v0x7f41125e7e80) {
-pushCont(co, 32, clofun8, 6, env, ns, import, globals, c, a);
+Obj x139973624890823 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973624890823) {
+Obj x139973624891335 = PRIM_CAR(closureRef(co, 4));
+Obj x139973624891367 = PRIM_EQ(symlet, x139973624891335);
+if (True == x139973624891367) {
+Obj x139973624891815 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624891847 = PRIM_ISCONS(x139973624891815);
+if (True == x139973624891847) {
+Obj x139973624892423 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624892487 = PRIM_CAR(x139973624892423);
+Obj a = x139973624892487;
+Obj x139973624893127 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624893159 = PRIM_CDR(x139973624893127);
+Obj x139973624893191 = PRIM_ISCONS(x139973624893159);
+if (True == x139973624893191) {
+Obj x139973624844679 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624844711 = PRIM_CDR(x139973624844679);
+Obj x139973624844743 = PRIM_CAR(x139973624844711);
+Obj b = x139973624844743;
+Obj x139973624845671 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624845703 = PRIM_CDR(x139973624845671);
+Obj x139973624845735 = PRIM_CDR(x139973624845703);
+Obj x139973624845767 = PRIM_ISCONS(x139973624845735);
+if (True == x139973624845767) {
+Obj x139973624846663 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624846695 = PRIM_CDR(x139973624846663);
+Obj x139973624846727 = PRIM_CDR(x139973624846695);
+Obj x139973624846759 = PRIM_CAR(x139973624846727);
+Obj c = x139973624846759;
+Obj x139973624847783 = PRIM_CDR(closureRef(co, 4));
+Obj x139973624847815 = PRIM_CDR(x139973624847783);
+Obj x139973624847847 = PRIM_CDR(x139973624847815);
+Obj x139973624847879 = PRIM_CDR(x139973624847847);
+Obj x139973624847911 = PRIM_EQ(Nil, x139973624847879);
+if (True == x139973624847911) {
+pushCont(co, 31, clofun8, 6, env, ns, import, globals, c, a);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12147,7 +12109,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12156,7 +12118,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12165,7 +12127,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12174,7 +12136,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12183,7 +12145,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12192,7 +12154,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b50c0;
+__arg0 = x139973624642407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12201,20 +12163,20 @@ goto *jumpTable[ps.label];
 }
 }
 
-label32:
+label31:
 {
-Obj v0x7f41125e5220 = __arg1;
+Obj x139973624685031 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj v0x7f41125e5460 = makeCons(a, env);
-pushCont(co, 33, clofun8, 2, v0x7f41125e5220, a);
+Obj x139973624685671 = makeCons(a, env);
+pushCont(co, 32, clofun8, 2, x139973624685031, a);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = v0x7f41125e5460;
+__arg1 = x139973624685671;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
@@ -12226,298 +12188,36 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label32:
+{
+Obj x139973624685863 = __arg1;
+Obj x139973624685031= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139973624685927 = makeCons(x139973624685863, Nil);
+Obj x139973624685959 = makeCons(x139973624685031, x139973624685927);
+Obj x139973624685991 = makeCons(a, x139973624685959);
+Obj x139973624686055 = makeCons(symlet, x139973624685991);
+__nargs = 2;
+__arg1 = x139973624686055;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
 label33:
 {
-Obj v0x7f41125e5500 = __arg1;
-Obj v0x7f41125e5220= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125e5560 = makeCons(v0x7f41125e5500, Nil);
-Obj v0x7f41125e5580 = makeCons(v0x7f41125e5220, v0x7f41125e5560);
-Obj v0x7f41125e55a0 = makeCons(a, v0x7f41125e5580);
-Obj v0x7f41125e55c0 = makeCons(symlet, v0x7f41125e55a0);
-__nargs = 2;
-__arg1 = v0x7f41125e55c0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label34:
-{
-Obj v0x7f41126b5580 = makeNative(35, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
-Obj env = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj v0x7f41125fec20 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f41125fec20) {
-Obj v0x7f41125fede0 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f41125fee00 = PRIM_EQ(symns, v0x7f41125fede0);
-if (True == v0x7f41125fee00) {
-Obj v0x7f41125fefa0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fefc0 = PRIM_ISCONS(v0x7f41125fefa0);
-if (True == v0x7f41125fefc0) {
-Obj v0x7f41125fb160 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fb180 = PRIM_CAR(v0x7f41125fb160);
-Obj path = v0x7f41125fb180;
-Obj v0x7f41125fb3c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fb3e0 = PRIM_CDR(v0x7f41125fb3c0);
-Obj v0x7f41125fb400 = PRIM_ISCONS(v0x7f41125fb3e0);
-if (True == v0x7f41125fb400) {
-Obj v0x7f41125fb640 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fb660 = PRIM_CDR(v0x7f41125fb640);
-Obj v0x7f41125fb680 = PRIM_CAR(v0x7f41125fb660);
-Obj import = v0x7f41125fb680;
-Obj v0x7f41125fb980 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fb9a0 = PRIM_CDR(v0x7f41125fb980);
-Obj v0x7f41125fb9c0 = PRIM_CDR(v0x7f41125fb9a0);
-Obj v0x7f41125fb9e0 = PRIM_ISCONS(v0x7f41125fb9c0);
-if (True == v0x7f41125fb9e0) {
-Obj v0x7f41125fbcc0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125fbce0 = PRIM_CDR(v0x7f41125fbcc0);
-Obj v0x7f41125fbd00 = PRIM_CDR(v0x7f41125fbce0);
-Obj v0x7f41125fbd20 = PRIM_CAR(v0x7f41125fbd00);
-Obj body = v0x7f41125fbd20;
-Obj v0x7f41125ec0c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41125ec0e0 = PRIM_CDR(v0x7f41125ec0c0);
-Obj v0x7f41125ec100 = PRIM_CDR(v0x7f41125ec0e0);
-Obj v0x7f41125ec120 = PRIM_CDR(v0x7f41125ec100);
-Obj v0x7f41125ec140 = PRIM_EQ(Nil, v0x7f41125ec120);
-if (True == v0x7f41125ec140) {
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = path;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5580;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label35:
-{
-Obj v0x7f41126b5a40 = makeNative(39, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139973624374151 = makeNative(41, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj v0x7f4112603040 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f4112603040) {
-Obj v0x7f4112603200 = PRIM_CAR(closureRef(co, 4));
-Obj v0x7f4112603220 = PRIM_EQ(symdef, v0x7f4112603200);
-if (True == v0x7f4112603220) {
-Obj v0x7f41126033c0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41126033e0 = PRIM_ISCONS(v0x7f41126033c0);
-if (True == v0x7f41126033e0) {
-Obj v0x7f4112603580 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f41126035a0 = PRIM_CAR(v0x7f4112603580);
-Obj var = v0x7f41126035a0;
-Obj v0x7f41126037e0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f4112603800 = PRIM_CDR(v0x7f41126037e0);
-Obj v0x7f4112603820 = PRIM_ISCONS(v0x7f4112603800);
-if (True == v0x7f4112603820) {
-Obj v0x7f4112603a60 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f4112603a80 = PRIM_CDR(v0x7f4112603a60);
-Obj v0x7f4112603aa0 = PRIM_CAR(v0x7f4112603a80);
-Obj val = v0x7f4112603aa0;
-Obj v0x7f4112603da0 = PRIM_CDR(closureRef(co, 4));
-Obj v0x7f4112603dc0 = PRIM_CDR(v0x7f4112603da0);
-Obj v0x7f4112603de0 = PRIM_CDR(v0x7f4112603dc0);
-Obj v0x7f4112603e00 = PRIM_EQ(Nil, v0x7f4112603de0);
-if (True == v0x7f4112603e00) {
-pushCont(co, 36, clofun8, 5, env, ns, import, globals, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35var_45with_45ns);
-__arg1 = var;
-__arg2 = ns;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5a40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5a40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5a40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5a40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = v0x7f41126b5a40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label36:
-{
-Obj v0x7f4112603f20 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj var1 = v0x7f4112603f20;
-pushCont(co, 37, clofun8, 6, var1, env, ns, import, globals, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = var1;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label37:
-{
-Obj v0x7f41125fe040 = __arg1;
-Obj var1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj v0x7f41125fe280 = makeCons(symset, Nil);
-Obj v0x7f41125fe2a0 = makeCons(sym_37builtin, v0x7f41125fe280);
-Obj v0x7f41125fe500 = makeCons(var1, Nil);
-Obj v0x7f41125fe520 = makeCons(sym_37const, v0x7f41125fe500);
-pushCont(co, 38, clofun8, 2, v0x7f41125fe520, v0x7f41125fe2a0);
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label38:
-{
-Obj v0x7f41125fe720 = __arg1;
-Obj v0x7f41125fe520= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f41125fe2a0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125fe760 = makeCons(v0x7f41125fe720, Nil);
-Obj v0x7f41125fe780 = makeCons(v0x7f41125fe520, v0x7f41125fe760);
-Obj v0x7f41125fe7a0 = makeCons(v0x7f41125fe2a0, v0x7f41125fe780);
-__nargs = 2;
-__arg1 = v0x7f41125fe7a0;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label39:
-{
-Obj v0x7f41126b5e80 = makeNative(47, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj v0x7f4112669940 = PRIM_ISCONS(closureRef(co, 4));
-if (True == v0x7f4112669940) {
-Obj v0x7f4112669a40 = PRIM_CAR(closureRef(co, 4));
-Obj op = v0x7f4112669a40;
-Obj v0x7f4112669b40 = PRIM_CDR(closureRef(co, 4));
-Obj args = v0x7f4112669b40;
-pushCont(co, 40, clofun8, 7, op, args, env, ns, import, globals, v0x7f41126b5e80);
+Obj x139973625014983 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139973625014983) {
+Obj x139973625015335 = PRIM_CAR(closureRef(co, 4));
+Obj op = x139973625015335;
+Obj x139973625015687 = PRIM_CDR(closureRef(co, 4));
+Obj args = x139973625015687;
+pushCont(co, 34, clofun8, 7, op, args, env, ns, import, globals, x139973624374151);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
 __arg1 = op;
@@ -12528,7 +12228,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b5e80;
+__arg0 = x139973624374151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12537,18 +12237,18 @@ goto *jumpTable[ps.label];
 }
 }
 
-label40:
+label34:
 {
-Obj v0x7f4112669c40 = __arg1;
+Obj x139973625015975 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj v0x7f41126b5e80= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-if (True == v0x7f4112669c40) {
-pushCont(co, 41, clofun8, 6, op, args, env, ns, import, globals);
+Obj x139973624374151= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+if (True == x139973625015975) {
+pushCont(co, 35, clofun8, 6, op, args, env, ns, import, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
 __arg1 = op;
@@ -12559,7 +12259,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41126b5e80;
+__arg0 = x139973624374151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12568,17 +12268,17 @@ goto *jumpTable[ps.label];
 }
 }
 
-label41:
+label35:
 {
-Obj v0x7f4112669d40 = __arg1;
+Obj x139973625016295 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj required = v0x7f4112669d40;
-pushCont(co, 42, clofun8, 7, required, op, args, env, ns, import, globals);
+Obj required = x139973625016295;
+pushCont(co, 36, clofun8, 7, required, op, args, env, ns, import, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = args;
@@ -12589,9 +12289,9 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label36:
 {
-Obj v0x7f4112669e40 = __arg1;
+Obj x139973624914183 = __arg1;
 Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -12599,12 +12299,12 @@ Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-Obj provided = v0x7f4112669e40;
-Obj v0x7f4112669f60 = PRIM_EQ(required, provided);
-if (True == v0x7f4112669f60) {
-Obj v0x7f411261b1a0 = makeCons(op, Nil);
-Obj v0x7f411261b1c0 = makeCons(sym_37builtin, v0x7f411261b1a0);
-pushCont(co, 45, clofun8, 2, args, v0x7f411261b1c0);
+Obj provided = x139973624914183;
+Obj x139973624914471 = PRIM_EQ(required, provided);
+if (True == x139973624914471) {
+Obj x139973624915111 = makeCons(op, Nil);
+Obj x139973624915143 = makeCons(sym_37builtin, x139973624915111);
+pushCont(co, 39, clofun8, 2, args, x139973624915143);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12617,13 +12317,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj v0x7f411261b520 = PRIM_GT(required, provided);
-if (True == v0x7f411261b520) {
-Obj v0x7f411261b6e0 = PRIM_SUB(required, provided);
-pushCont(co, 43, clofun8, 6, op, args, env, ns, import, globals);
+Obj x139973624916263 = PRIM_GT(required, provided);
+if (True == x139973624916263) {
+Obj x139973624916775 = PRIM_SUB(required, provided);
+pushCont(co, 37, clofun8, 6, op, args, env, ns, import, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = v0x7f411261b6e0;
+__arg1 = x139973624916775;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12643,21 +12343,21 @@ goto *jumpTable[ps.label];
 }
 }
 
-label43:
+label37:
 {
-Obj v0x7f411261b720 = __arg1;
+Obj x139973624916839 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj tmp = v0x7f411261b720;
-Obj v0x7f411261bbe0 = makeCons(op, args);
-pushCont(co, 44, clofun8, 5, tmp, env, ns, import, globals);
+Obj tmp = x139973624916839;
+Obj x139973624889543 = makeCons(op, args);
+pushCont(co, 38, clofun8, 5, tmp, env, ns, import, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
-__arg1 = v0x7f411261bbe0;
+__arg1 = x139973624889543;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12666,24 +12366,24 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label44:
+label38:
 {
-Obj v0x7f411261bc20 = __arg1;
+Obj x139973624889607 = __arg1;
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj v0x7f411261bc60 = makeCons(v0x7f411261bc20, Nil);
-Obj v0x7f411261bc80 = makeCons(tmp, v0x7f411261bc60);
-Obj v0x7f411261bca0 = makeCons(symlambda, v0x7f411261bc80);
+Obj x139973624889671 = makeCons(x139973624889607, Nil);
+Obj x139973624889735 = makeCons(tmp, x139973624889671);
+Obj x139973624889767 = makeCons(symlambda, x139973624889735);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
-co->args[5] = v0x7f411261bca0;
+co->args[5] = x139973624889767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12691,15 +12391,15 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label39:
 {
-Obj v0x7f411261b3a0 = __arg1;
+Obj x139973624915815 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411261b1c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun8, 1, v0x7f411261b1c0);
+Obj x139973624915143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 40, clofun8, 1, x139973624915143);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f411261b3a0;
+__arg1 = x139973624915815;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12708,27 +12408,27 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label40:
 {
-Obj v0x7f411261b3e0 = __arg1;
-Obj v0x7f411261b1c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v0x7f411261b400 = makeCons(v0x7f411261b1c0, v0x7f411261b3e0);
+Obj x139973624915911 = __arg1;
+Obj x139973624915143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139973624915943 = makeCons(x139973624915143, x139973624915911);
 __nargs = 2;
-__arg1 = v0x7f411261b400;
+__arg1 = x139973624915943;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label47:
+label41:
 {
-Obj v0x7f41126af1e0 = makeNative(49, clofun8, 0, 0);
+Obj x139973624375591 = makeNative(43, clofun8, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
 Obj ls = closureRef(co, 4);
-pushCont(co, 48, clofun8, 1, ls);
+pushCont(co, 42, clofun8, 1, ls);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12742,13 +12442,13 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label48:
+label42:
 {
-Obj v0x7f4112669720 = __arg1;
+Obj x139973625014343 = __arg1;
 Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = v0x7f4112669720;
+__arg1 = x139973625014343;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12757,7 +12457,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label49:
+label43:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -12767,6 +12467,113 @@ struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139973624917639 = __arg1;
+Obj x139973624917671 = __arg2;
+Obj x139973624889383 = makeNative(45, clofun8, 0, 2, x139973624917639, x139973624917671);
+Obj x139973625031527 = PRIM_EQ(MAKE_NUMBER(0), x139973624917639);
+if (True == x139973625031527) {
+Obj res = x139973624917671;
+__nargs = 2;
+__arg1 = res;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139973624889383;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label45:
+{
+Obj x139973624889927 = makeNative(46, clofun8, 0, 0);
+Obj n = closureRef(co, 0);
+Obj res = closureRef(co, 1);
+Obj x139973625030791 = PRIM_SUB(n, MAKE_NUMBER(1));
+Obj x139973625031143 = primGenSym();
+Obj x139973625031207 = makeCons(x139973625031143, res);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
+__arg1 = x139973625030791;
+__arg2 = x139973625031207;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x = __arg1;
+PUSH_CONT_0(co, 48, clofun8);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35assq);
+__arg1 = x;
+__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x139973625028807 = __arg1;
+Obj find = x139973625028807;
+pushCont(co, 49, clofun8, 1, find);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35null_63);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label49:
+{
+Obj x139973625029159 = __arg1;
+Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139973625029159) {
+__nargs = 2;
+__arg1 = makeCString("ERROR");
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35cadr);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -12785,452 +12592,45 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj v0x7f411273e740 = __arg1;
-Obj v0x7f411273e760 = __arg2;
-Obj v0x7f411273e780 = __arg3;
-Obj v0x7f411273e880 = makeNative(1, clofun9, 0, 3, v0x7f411273e740, v0x7f411273e760, v0x7f411273e780);
-Obj s = v0x7f411273e740;
-Obj ns = v0x7f411273e760;
-Obj v0x7f41126a7ae0 = PRIM_EQ(Nil, v0x7f411273e780);
-if (True == v0x7f41126a7ae0) {
+Obj x = __arg1;
+PUSH_CONT_0(co, 1, clofun9);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35var_45with_45ns);
-__arg1 = s;
-__arg2 = ns;
+__arg0 = globalRef(symcora_47lib_47toc_35assq);
+__arg1 = x;
+__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411273e880;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj v0x7f411273ea60 = makeNative(9, clofun9, 0, 0);
-Obj s = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj v0x7f41126afee0 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41126afee0) {
-Obj v0x7f41126affe0 = PRIM_CAR(closureRef(co, 2));
-Obj import = v0x7f41126affe0;
-Obj v0x7f41126a70e0 = PRIM_CDR(closureRef(co, 2));
-Obj more = v0x7f41126a70e0;
-pushCont(co, 2, clofun9, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35string_45append);
-__arg1 = import;
-__arg2 = makeCString("#*ns-export*");
+Obj x139973625789575 = __arg1;
+Obj find = x139973625789575;
+pushCont(co, 2, clofun9, 1, find);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35null_63);
+__arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411273ea60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label2:
 {
-Obj v0x7f41126a7340 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 3, clofun9, 4, import, s, ns, more);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35intern);
-__arg1 = v0x7f41126a7340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj v0x7f41126a7360 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 4, clofun9, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35value_45or);
-__arg1 = v0x7f41126a7360;
-__arg2 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj v0x7f41126a73a0 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = v0x7f41126a73a0;
-pushCont(co, 5, clofun9, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = s;
-__arg2 = export;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj v0x7f41126a74c0 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == v0x7f41126a74c0) {
-pushCont(co, 6, clofun9, 1, import);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35symbol_45_62string);
-__arg1 = s;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35lookup_45var);
-__arg1 = s;
-__arg2 = ns;
-__arg3 = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj v0x7f41126a77a0 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 7, clofun9, 1, import);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35string_45append);
-__arg1 = makeCString("#");
-__arg2 = v0x7f41126a77a0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj v0x7f41126a77c0 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 8, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35string_45append);
-__arg1 = import;
-__arg2 = v0x7f41126a77c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj v0x7f41126a77e0 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35intern);
-__arg1 = v0x7f41126a77e0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj var = __arg1;
-Obj ns = __arg2;
-Obj v0x7f41126af640 = PRIM_EQ(ns, makeCString(""));
-if (True == v0x7f41126af640) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 11, clofun9, 2, var, ns);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35symbol_45cooked_63);
-__arg1 = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj v0x7f41126af740 = __arg1;
-Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == v0x7f41126af740) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 12, clofun9, 1, ns);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35symbol_45_62string);
-__arg1 = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj v0x7f41126afa20 = __arg1;
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 13, clofun9, 1, ns);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35string_45append);
-__arg1 = makeCString("#");
-__arg2 = v0x7f41126afa20;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj v0x7f41126afa40 = __arg1;
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 14, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35string_45append);
-__arg1 = ns;
-__arg2 = v0x7f41126afa40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj v0x7f41126afa60 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35intern);
-__arg1 = v0x7f41126afa60;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj v0x7f411273e2a0 = __arg1;
-Obj v0x7f411273e2c0 = __arg2;
-Obj v0x7f411273e380 = makeNative(16, clofun9, 0, 2, v0x7f411273e2a0, v0x7f411273e2c0);
-Obj v0x7f41126af300 = PRIM_EQ(MAKE_NUMBER(0), v0x7f411273e2a0);
-if (True == v0x7f41126af300) {
-Obj res = v0x7f411273e2c0;
-__nargs = 2;
-__arg1 = res;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = v0x7f411273e380;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj v0x7f411273e4e0 = makeNative(17, clofun9, 0, 0);
-Obj n = closureRef(co, 0);
-Obj res = closureRef(co, 1);
-Obj v0x7f41126af020 = PRIM_SUB(n, MAKE_NUMBER(1));
-Obj v0x7f41126af180 = primGenSym();
-Obj v0x7f41126af1c0 = makeCons(v0x7f41126af180, res);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = v0x7f41126af020;
-__arg2 = v0x7f41126af1c0;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj x = __arg1;
-PUSH_CONT_0(co, 19, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj v0x7f41126b5940 = __arg1;
-Obj find = v0x7f41126b5940;
-pushCont(co, 20, clofun9, 1, find);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = find;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj v0x7f41126b5a60 = __arg1;
+Obj x139973625789831 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41126b5a60) {
-__nargs = 2;
-__arg1 = makeCString("ERROR");
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35cadr);
-__arg1 = find;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label21:
-{
-Obj x = __arg1;
-PUSH_CONT_0(co, 22, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label22:
-{
-Obj v0x7f41126b5500 = __arg1;
-Obj find = v0x7f41126b5500;
-pushCont(co, 23, clofun9, 1, find);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = find;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label23:
-{
-Obj v0x7f41126b5620 = __arg1;
-Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == v0x7f41126b5620) {
+if (True == x139973625789831) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13248,10 +12648,10 @@ goto *jumpTable[ps.label];
 }
 }
 
-label24:
+label3:
 {
 Obj x = __arg1;
-PUSH_CONT_0(co, 25, clofun9);
+PUSH_CONT_0(co, 4, clofun9);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = x;
@@ -13263,13 +12663,13 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label4:
 {
-Obj v0x7f41126b5240 = __arg1;
-PUSH_CONT_0(co, 26, clofun9);
+Obj x139973625788103 = __arg1;
+PUSH_CONT_0(co, 5, clofun9);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = v0x7f41126b5240;
+__arg1 = x139973625788103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13277,25 +12677,25 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label5:
 {
-Obj v0x7f41126b5260 = __arg1;
-Obj v0x7f41126b5280 = primNot(v0x7f41126b5260);
+Obj x139973625788135 = __arg1;
+Obj x139973625788167 = primNot(x139973625788135);
 __nargs = 2;
-__arg1 = v0x7f41126b5280;
+__arg1 = x139973625788167;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label27:
+label6:
 {
-Obj v0x7f4112743de0 = __arg1;
-Obj v0x7f4112743e00 = __arg2;
-Obj v0x7f4112743ec0 = makeNative(28, clofun9, 0, 2, v0x7f4112743de0, v0x7f4112743e00);
-Obj x = v0x7f4112743de0;
-Obj v0x7f41125cf1c0 = PRIM_EQ(Nil, v0x7f4112743e00);
-if (True == v0x7f41125cf1c0) {
+Obj x139973624915751 = __arg1;
+Obj x139973624915783 = __arg2;
+Obj x139973624916167 = makeNative(7, clofun9, 0, 2, x139973624915751, x139973624915783);
+Obj x = x139973624915751;
+Obj x139973624277639 = PRIM_EQ(Nil, x139973624915783);
+if (True == x139973624277639) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13303,7 +12703,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743ec0;
+__arg0 = x139973624916167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13312,17 +12712,17 @@ goto *jumpTable[ps.label];
 }
 }
 
-label28:
+label7:
 {
-Obj v0x7f411273e020 = makeNative(30, clofun9, 0, 0);
+Obj x139973624916711 = makeNative(9, clofun9, 0, 0);
 Obj x = closureRef(co, 0);
-Obj v0x7f41125d2320 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41125d2320) {
-Obj v0x7f41125d2420 = PRIM_CAR(closureRef(co, 1));
-Obj hd = v0x7f41125d2420;
-Obj v0x7f41125d2520 = PRIM_CDR(closureRef(co, 1));
-Obj tl = v0x7f41125d2520;
-pushCont(co, 29, clofun9, 2, x, tl);
+Obj x139973624275943 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973624275943) {
+Obj x139973624276199 = PRIM_CAR(closureRef(co, 1));
+Obj hd = x139973624276199;
+Obj x139973624276455 = PRIM_CDR(closureRef(co, 1));
+Obj tl = x139973624276455;
+pushCont(co, 8, clofun9, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
 __arg1 = x;
@@ -13334,7 +12734,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411273e020;
+__arg0 = x139973624916711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13343,13 +12743,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label29:
+label8:
 {
-Obj v0x7f41125d26e0 = __arg1;
+Obj x139973624276903 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v0x7f41125d2720 = PRIM_LT(v0x7f41125d26e0, MAKE_NUMBER(0));
-if (True == v0x7f41125d2720) {
+Obj x139973624276967 = PRIM_LT(x139973624276903, MAKE_NUMBER(0));
+if (True == x139973624276967) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
 __arg1 = x;
@@ -13368,7 +12768,7 @@ goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label30:
+label9:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -13380,7 +12780,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
+label10:
 {
 Obj x = __arg1;
 Obj l = __arg2;
@@ -13396,16 +12796,16 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label32:
+label11:
 {
-Obj v0x7f4112743560 = __arg1;
-Obj v0x7f4112743580 = __arg2;
-Obj v0x7f41127435a0 = __arg3;
-Obj v0x7f41127436a0 = makeNative(33, clofun9, 0, 3, v0x7f4112743560, v0x7f4112743580, v0x7f41127435a0);
-Obj __ = v0x7f4112743560;
-Obj x = v0x7f4112743580;
-Obj v0x7f41125d6c20 = PRIM_EQ(Nil, v0x7f41127435a0);
-if (True == v0x7f41125d6c20) {
+Obj x139973625014631 = __arg1;
+Obj x139973625014663 = __arg2;
+Obj x139973625014695 = __arg3;
+Obj x139973625015239 = makeNative(12, clofun9, 0, 3, x139973625014631, x139973625014663, x139973625014695);
+Obj __ = x139973625014631;
+Obj x = x139973625014663;
+Obj x139973624343783 = PRIM_EQ(Nil, x139973625014695);
+if (True == x139973624343783) {
 __nargs = 2;
 __arg1 = MAKE_NUMBER(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13413,7 +12813,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127436a0;
+__arg0 = x139973625015239;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13422,19 +12822,19 @@ goto *jumpTable[ps.label];
 }
 }
 
-label33:
+label12:
 {
-Obj v0x7f4112743880 = makeNative(34, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139973625016007 = makeNative(13, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj v0x7f41125d6660 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125d6660) {
-Obj v0x7f41125d6760 = PRIM_CAR(closureRef(co, 2));
-Obj a = v0x7f41125d6760;
-Obj v0x7f41125d6860 = PRIM_CDR(closureRef(co, 2));
-Obj b = v0x7f41125d6860;
-Obj v0x7f41125d6980 = PRIM_EQ(x, a);
-if (True == v0x7f41125d6980) {
+Obj x139973624342311 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973624342311) {
+Obj x139973624342567 = PRIM_CAR(closureRef(co, 2));
+Obj a = x139973624342567;
+Obj x139973624342823 = PRIM_CDR(closureRef(co, 2));
+Obj b = x139973624342823;
+Obj x139973624343111 = PRIM_EQ(x, a);
+if (True == x139973624343111) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13442,7 +12842,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743880;
+__arg0 = x139973625016007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13451,7 +12851,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743880;
+__arg0 = x139973625016007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13460,21 +12860,21 @@ goto *jumpTable[ps.label];
 }
 }
 
-label34:
+label13:
 {
-Obj v0x7f4112743ae0 = makeNative(35, clofun9, 0, 0);
+Obj x139973624914599 = makeNative(14, clofun9, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj v0x7f41125d60a0 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125d60a0) {
-Obj v0x7f41125d61a0 = PRIM_CAR(closureRef(co, 2));
-Obj a = v0x7f41125d61a0;
-Obj v0x7f41125d62a0 = PRIM_CDR(closureRef(co, 2));
-Obj b = v0x7f41125d62a0;
-Obj v0x7f41125d6420 = PRIM_ADD(pos, MAKE_NUMBER(1));
+Obj x139973624340839 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973624340839) {
+Obj x139973624341095 = PRIM_CAR(closureRef(co, 2));
+Obj a = x139973624341095;
+Obj x139973624341351 = PRIM_CDR(closureRef(co, 2));
+Obj b = x139973624341351;
+Obj x139973624341735 = PRIM_ADD(pos, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = v0x7f41125d6420;
+__arg1 = x139973624341735;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
@@ -13484,7 +12884,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f4112743ae0;
+__arg0 = x139973624914599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13493,7 +12893,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label35:
+label14:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -13505,16 +12905,16 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label36:
+label15:
 {
-Obj v0x7f41124adea0 = __arg1;
-Obj v0x7f41124adec0 = __arg2;
-Obj v0x7f41124adf00 = __arg3;
-Obj v0x7f411248c160 = makeNative(37, clofun9, 0, 3, v0x7f41124adea0, v0x7f41124adec0, v0x7f41124adf00);
-Obj f = v0x7f41124adea0;
-Obj acc = v0x7f41124adec0;
-Obj v0x7f41125e5b20 = PRIM_EQ(Nil, v0x7f41124adf00);
-if (True == v0x7f41125e5b20) {
+Obj x139973625032423 = __arg1;
+Obj x139973625032455 = __arg2;
+Obj x139973625032487 = __arg3;
+Obj x139973625012551 = makeNative(16, clofun9, 0, 3, x139973625032423, x139973625032455, x139973625032487);
+Obj f = x139973625032423;
+Obj acc = x139973625032455;
+Obj x139973624376231 = PRIM_EQ(Nil, x139973625032487);
+if (True == x139973624376231) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13522,7 +12922,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f411248c160;
+__arg0 = x139973625012551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13531,18 +12931,18 @@ goto *jumpTable[ps.label];
 }
 }
 
-label37:
+label16:
 {
-Obj v0x7f41127431c0 = makeNative(39, clofun9, 0, 0);
+Obj x139973625013319 = makeNative(18, clofun9, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj v0x7f41125e5540 = PRIM_ISCONS(closureRef(co, 2));
-if (True == v0x7f41125e5540) {
-Obj v0x7f41125e5640 = PRIM_CAR(closureRef(co, 2));
-Obj x = v0x7f41125e5640;
-Obj v0x7f41125e5740 = PRIM_CDR(closureRef(co, 2));
-Obj y = v0x7f41125e5740;
-pushCont(co, 38, clofun9, 2, f, y);
+Obj x139973624374567 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139973624374567) {
+Obj x139973624374855 = PRIM_CAR(closureRef(co, 2));
+Obj x = x139973624374855;
+Obj x139973624375207 = PRIM_CDR(closureRef(co, 2));
+Obj y = x139973624375207;
+pushCont(co, 17, clofun9, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -13554,7 +12954,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41127431c0;
+__arg0 = x139973625013319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13563,15 +12963,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label38:
+label17:
 {
-Obj v0x7f41125e58e0 = __arg1;
+Obj x139973624375655 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = f;
-__arg2 = v0x7f41125e58e0;
+__arg2 = x139973624375655;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -13580,7 +12980,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label18:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -13592,14 +12992,14 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label19:
 {
-Obj v0x7f41124c4f20 = __arg1;
-Obj v0x7f41124c4f40 = __arg2;
-Obj v0x7f41124ad020 = makeNative(41, clofun9, 0, 2, v0x7f41124c4f20, v0x7f41124c4f40);
-Obj var = v0x7f41124c4f20;
-Obj v0x7f41125e5040 = PRIM_EQ(Nil, v0x7f41124c4f40);
-if (True == v0x7f41125e5040) {
+Obj x139973625029479 = __arg1;
+Obj x139973625029511 = __arg2;
+Obj x139973625029895 = makeNative(20, clofun9, 0, 2, x139973625029479, x139973625029511);
+Obj var = x139973625029479;
+Obj x139973624373255 = PRIM_EQ(Nil, x139973625029511);
+if (True == x139973624373255) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13607,7 +13007,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41124ad020;
+__arg0 = x139973625029895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13616,34 +13016,34 @@ goto *jumpTable[ps.label];
 }
 }
 
-label41:
+label20:
 {
-Obj v0x7f41124ad320 = makeNative(42, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139973625030439 = makeNative(21, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj v0x7f41125e7520 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41125e7520) {
-Obj v0x7f41125e76c0 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41125e76e0 = PRIM_ISCONS(v0x7f41125e76c0);
-if (True == v0x7f41125e76e0) {
-Obj v0x7f41125e7880 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41125e78a0 = PRIM_CAR(v0x7f41125e7880);
-Obj x = v0x7f41125e78a0;
-Obj v0x7f41125e7a40 = PRIM_CAR(closureRef(co, 1));
-Obj v0x7f41125e7a60 = PRIM_CDR(v0x7f41125e7a40);
-Obj y = v0x7f41125e7a60;
-Obj v0x7f41125e7b60 = PRIM_CDR(closureRef(co, 1));
-Obj __ = v0x7f41125e7b60;
-Obj v0x7f41125e7c80 = PRIM_EQ(var, x);
-if (True == v0x7f41125e7c80) {
-Obj v0x7f41125e7d60 = makeCons(x, y);
+Obj x139973624415463 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973624415463) {
+Obj x139973624415879 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624415911 = PRIM_ISCONS(x139973624415879);
+if (True == x139973624415911) {
+Obj x139973624416327 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624416359 = PRIM_CAR(x139973624416327);
+Obj x = x139973624416359;
+Obj x139973624416775 = PRIM_CAR(closureRef(co, 1));
+Obj x139973624416807 = PRIM_CDR(x139973624416775);
+Obj y = x139973624416807;
+Obj x139973624417063 = PRIM_CDR(closureRef(co, 1));
+Obj __ = x139973624417063;
+Obj x139973624417351 = PRIM_EQ(var, x);
+if (True == x139973624417351) {
+Obj x139973624417575 = makeCons(x, y);
 __nargs = 2;
-__arg1 = v0x7f41125e7d60;
+__arg1 = x139973624417575;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41124ad320;
+__arg0 = x139973625030439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13652,7 +13052,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41124ad320;
+__arg0 = x139973625030439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13661,7 +13061,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = v0x7f41124ad320;
+__arg0 = x139973625030439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13670,16 +13070,16 @@ goto *jumpTable[ps.label];
 }
 }
 
-label42:
+label21:
 {
-Obj v0x7f41124ad7e0 = makeNative(43, clofun9, 0, 0);
+Obj x139973625031431 = makeNative(22, clofun9, 0, 0);
 Obj var = closureRef(co, 0);
-Obj v0x7f41125e70a0 = PRIM_ISCONS(closureRef(co, 1));
-if (True == v0x7f41125e70a0) {
-Obj v0x7f41125e71a0 = PRIM_CAR(closureRef(co, 1));
-Obj __ = v0x7f41125e71a0;
-Obj v0x7f41125e72a0 = PRIM_CDR(closureRef(co, 1));
-Obj y = v0x7f41125e72a0;
+Obj x139973624414311 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139973624414311) {
+Obj x139973624414567 = PRIM_CAR(closureRef(co, 1));
+Obj __ = x139973624414567;
+Obj x139973624414823 = PRIM_CDR(closureRef(co, 1));
+Obj y = x139973624414823;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = var;
@@ -13691,7 +13091,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = v0x7f41124ad7e0;
+__arg0 = x139973625031431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13700,7 +13100,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label43:
+label22:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -31,6 +31,7 @@ static Obj symcora_47lib_47toc_35split_45type_45and_45code;
 static Obj symdefine_45library;
 static Obj symbegin;
 static Obj symexport;
+static Obj symimport;
 static Obj symcora_47lib_47toc_35handle_45import_45eagerly;
 static Obj symcora_47lib_47toc_35generate_45c;
 static Obj symcora_47init_35symbol_45_62string;
@@ -103,7 +104,6 @@ static Obj sym_37global;
 static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
 static Obj symcora_47init_35elem_63;
 static Obj symif;
-static Obj symimport;
 static Obj symdo;
 static Obj symlet;
 static Obj symcora_47init_35append;
@@ -164,6 +164,7 @@ symcora_47lib_47toc_35split_45type_45and_45code = intern("cora/lib/toc#split-typ
 symdefine_45library = intern("define-library");
 symbegin = intern("begin");
 symexport = intern("export");
+symimport = intern("import");
 symcora_47lib_47toc_35handle_45import_45eagerly = intern("cora/lib/toc#handle-import-eagerly");
 symcora_47lib_47toc_35generate_45c = intern("cora/lib/toc#generate-c");
 symcora_47init_35symbol_45_62string = intern("cora/init#symbol->string");
@@ -236,7 +237,6 @@ sym_37global = intern("%global");
 symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
 symcora_47init_35elem_63 = intern("cora/init#elem?");
 symif = intern("if");
-symimport = intern("import");
 symdo = intern("do");
 symlet = intern("let");
 symcora_47init_35append = intern("cora/init#append");
@@ -306,7 +306,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973624518823 = __arg1;
+Obj x139731068888551 = __arg1;
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -320,7 +320,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139973624519079 = __arg1;
+Obj x139731068888839 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -334,118 +334,118 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973624519335 = __arg1;
-Obj x139973624519623 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
-Obj x139973624373415 = primSet(co, symcora_47lib_47toc_35assq, makeNative(19, clofun9, 2, 0));
-Obj x139973624376391 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(15, clofun9, 3, 0));
-Obj x139973624343943 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(11, clofun9, 3, 0));
-Obj x139973624344519 = primSet(co, symcora_47lib_47toc_35index, makeNative(10, clofun9, 2, 0));
-Obj x139973624277799 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(6, clofun9, 2, 0));
-Obj x139973624278823 = makeCons(makeCString("primSet"), Nil);
-Obj x139973624278855 = makeCons(MAKE_NUMBER(2), x139973624278823);
-Obj x139973624278887 = makeCons(symset, x139973624278855);
-Obj x139973624222375 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x139973624222439 = makeCons(MAKE_NUMBER(1), x139973624222375);
-Obj x139973624222471 = makeCons(symcar, x139973624222439);
-Obj x139973624223303 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x139973624223335 = makeCons(MAKE_NUMBER(1), x139973624223303);
-Obj x139973624223367 = makeCons(symcdr, x139973624223335);
-Obj x139973624224231 = makeCons(makeCString("makeCons"), Nil);
-Obj x139973624224263 = makeCons(MAKE_NUMBER(2), x139973624224231);
-Obj x139973624224295 = makeCons(symcons, x139973624224263);
-Obj x139973624225735 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x139973624225767 = makeCons(MAKE_NUMBER(1), x139973624225735);
-Obj x139973624078343 = makeCons(symcons_63, x139973624225767);
-Obj x139973624079175 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x139973624079207 = makeCons(MAKE_NUMBER(2), x139973624079175);
-Obj x139973624079239 = makeCons(sym_43, x139973624079207);
-Obj x139973624080103 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x139973624080135 = makeCons(MAKE_NUMBER(2), x139973624080103);
-Obj x139973624080167 = makeCons(sym_45, x139973624080135);
-Obj x139973624080999 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x139973624081031 = makeCons(MAKE_NUMBER(2), x139973624080999);
-Obj x139973624081063 = makeCons(sym_42, x139973624081031);
-Obj x139973624081927 = makeCons(makeCString("primDiv"), Nil);
-Obj x139973624081959 = makeCons(MAKE_NUMBER(2), x139973624081927);
-Obj x139973624081991 = makeCons(sym_47, x139973624081959);
-Obj x139973624000903 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x139973624000935 = makeCons(MAKE_NUMBER(2), x139973624000903);
-Obj x139973624000967 = makeCons(sym_61, x139973624000935);
-Obj x139973625852615 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x139973625852647 = makeCons(MAKE_NUMBER(2), x139973625852615);
-Obj x139973625852711 = makeCons(sym_62, x139973625852647);
-Obj x139973625853543 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x139973625853575 = makeCons(MAKE_NUMBER(2), x139973625853543);
-Obj x139973625853607 = makeCons(sym_60, x139973625853575);
-Obj x139973625854599 = makeCons(makeCString("primGenSym"), Nil);
-Obj x139973625854631 = makeCons(MAKE_NUMBER(0), x139973625854599);
-Obj x139973625854663 = makeCons(symgensym, x139973625854631);
-Obj x139973625855527 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x139973625855559 = makeCons(MAKE_NUMBER(1), x139973625855527);
-Obj x139973625855591 = makeCons(symsymbol_63, x139973625855559);
-Obj x139973625823655 = makeCons(makeCString("primNot"), Nil);
-Obj x139973625823687 = makeCons(MAKE_NUMBER(1), x139973625823655);
-Obj x139973625823719 = makeCons(symnot, x139973625823687);
-Obj x139973625824551 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x139973625824583 = makeCons(MAKE_NUMBER(1), x139973625824551);
-Obj x139973625824615 = makeCons(syminteger_63, x139973625824583);
-Obj x139973625825511 = makeCons(makeCString("primIsString"), Nil);
-Obj x139973625825543 = makeCons(MAKE_NUMBER(1), x139973625825511);
-Obj x139973625825575 = makeCons(symstring_63, x139973625825543);
-Obj x139973625825639 = makeCons(x139973625825575, Nil);
-Obj x139973625825671 = makeCons(x139973625824615, x139973625825639);
-Obj x139973625825703 = makeCons(x139973625823719, x139973625825671);
-Obj x139973625825735 = makeCons(x139973625855591, x139973625825703);
-Obj x139973625825767 = makeCons(x139973625854663, x139973625825735);
-Obj x139973625825831 = makeCons(x139973625853607, x139973625825767);
-Obj x139973625825863 = makeCons(x139973625852711, x139973625825831);
-Obj x139973625825895 = makeCons(x139973624000967, x139973625825863);
-Obj x139973625826055 = makeCons(x139973624081991, x139973625825895);
-Obj x139973625826087 = makeCons(x139973624081063, x139973625826055);
-Obj x139973625826119 = makeCons(x139973624080167, x139973625826087);
-Obj x139973625826151 = makeCons(x139973624079239, x139973625826119);
-Obj x139973625826183 = makeCons(x139973624078343, x139973625826151);
-Obj x139973625826215 = makeCons(x139973624224295, x139973625826183);
-Obj x139973625826247 = makeCons(x139973624223367, x139973625826215);
-Obj x139973625826279 = makeCons(x139973624222471, x139973625826247);
-Obj x139973625826311 = makeCons(x139973624278887, x139973625826279);
-Obj x139973625826375 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139973625826311);
-Obj x139973625788199 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(3, clofun9, 1, 0));
-Obj x139973625790023 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(0, clofun9, 1, 0));
-Obj x139973625029351 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(47, clofun8, 1, 0));
-Obj x139973625031751 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(44, clofun8, 2, 0));
-Obj x139973624000519 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 5, 0));
-Obj x139973623731207 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
-Obj x139973623686567 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
-Obj x139973624913959 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
-Obj x139973625853895 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
-Obj x139973624684967 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
-Obj x139973624686215 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
-Obj x139973623688295 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
-Obj x139973625825031 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
-Obj x139973624531911 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
-Obj x139973623686791 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
-Obj x139973623681383 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
-Obj x139973623683143 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
-Obj x139973623668359 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
-Obj x139973623649223 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
-Obj x139973623473447 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
-Obj x139973625853863 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
-Obj x139973625029671 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
-Obj x139973625030887 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
-Obj x139973625031591 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
-Obj x139973625013767 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
-Obj x139973624914407 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
-Obj x139973624891655 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
-Obj x139973624846631 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
-Obj x139973624640039 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
-Obj x139973624080007 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
-Obj x139973624081607 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
-Obj x139973624000999 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
-Obj x139973624001671 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
-Obj x139973624003047 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
-Obj x139973623733703 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
-Obj x139973623689031 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
+Obj x139731068889095 = __arg1;
+Obj x139731068889383 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
+Obj x139731068854087 = primSet(co, symcora_47lib_47toc_35assq, makeNative(16, clofun9, 2, 0));
+Obj x139731068836551 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(12, clofun9, 3, 0));
+Obj x139731068828775 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(8, clofun9, 3, 0));
+Obj x139731068829383 = primSet(co, symcora_47lib_47toc_35index, makeNative(7, clofun9, 2, 0));
+Obj x139731068820071 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(3, clofun9, 2, 0));
+Obj x139731068821095 = makeCons(makeCString("primSet"), Nil);
+Obj x139731068821127 = makeCons(MAKE_NUMBER(2), x139731068821095);
+Obj x139731068821159 = makeCons(symset, x139731068821127);
+Obj x139731068748487 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x139731068748519 = makeCons(MAKE_NUMBER(1), x139731068748487);
+Obj x139731068748551 = makeCons(symcar, x139731068748519);
+Obj x139731068749351 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x139731068749383 = makeCons(MAKE_NUMBER(1), x139731068749351);
+Obj x139731068749415 = makeCons(symcdr, x139731068749383);
+Obj x139731068750215 = makeCons(makeCString("makeCons"), Nil);
+Obj x139731068750247 = makeCons(MAKE_NUMBER(2), x139731068750215);
+Obj x139731068750279 = makeCons(symcons, x139731068750247);
+Obj x139731068751079 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x139731068751111 = makeCons(MAKE_NUMBER(1), x139731068751079);
+Obj x139731068751143 = makeCons(symcons_63, x139731068751111);
+Obj x139731068735559 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x139731068735591 = makeCons(MAKE_NUMBER(2), x139731068735559);
+Obj x139731068735623 = makeCons(sym_43, x139731068735591);
+Obj x139731068736423 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x139731068736455 = makeCons(MAKE_NUMBER(2), x139731068736423);
+Obj x139731068736487 = makeCons(sym_45, x139731068736455);
+Obj x139731068737287 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x139731068737319 = makeCons(MAKE_NUMBER(2), x139731068737287);
+Obj x139731068737351 = makeCons(sym_42, x139731068737319);
+Obj x139731068738151 = makeCons(makeCString("primDiv"), Nil);
+Obj x139731068738183 = makeCons(MAKE_NUMBER(2), x139731068738151);
+Obj x139731068738215 = makeCons(sym_47, x139731068738183);
+Obj x139731068739015 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x139731068739047 = makeCons(MAKE_NUMBER(2), x139731068739015);
+Obj x139731068739079 = makeCons(sym_61, x139731068739047);
+Obj x139731068686631 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x139731068686663 = makeCons(MAKE_NUMBER(2), x139731068686631);
+Obj x139731068686695 = makeCons(sym_62, x139731068686663);
+Obj x139731070513767 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x139731070513991 = makeCons(MAKE_NUMBER(2), x139731070513767);
+Obj x139731070514023 = makeCons(sym_60, x139731070513991);
+Obj x139731070515047 = makeCons(makeCString("primGenSym"), Nil);
+Obj x139731070515079 = makeCons(MAKE_NUMBER(0), x139731070515047);
+Obj x139731070515143 = makeCons(symgensym, x139731070515079);
+Obj x139731070516071 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x139731070516167 = makeCons(MAKE_NUMBER(1), x139731070516071);
+Obj x139731070516199 = makeCons(symsymbol_63, x139731070516167);
+Obj x139731070517191 = makeCons(makeCString("primNot"), Nil);
+Obj x139731070517223 = makeCons(MAKE_NUMBER(1), x139731070517191);
+Obj x139731070373895 = makeCons(symnot, x139731070517223);
+Obj x139731070374855 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x139731070374887 = makeCons(MAKE_NUMBER(1), x139731070374855);
+Obj x139731070374919 = makeCons(syminteger_63, x139731070374887);
+Obj x139731070376103 = makeCons(makeCString("primIsString"), Nil);
+Obj x139731070376135 = makeCons(MAKE_NUMBER(1), x139731070376103);
+Obj x139731070376231 = makeCons(symstring_63, x139731070376135);
+Obj x139731070376295 = makeCons(x139731070376231, Nil);
+Obj x139731070376327 = makeCons(x139731070374919, x139731070376295);
+Obj x139731070376359 = makeCons(x139731070373895, x139731070376327);
+Obj x139731070376391 = makeCons(x139731070516199, x139731070376359);
+Obj x139731070376455 = makeCons(x139731070515143, x139731070376391);
+Obj x139731070376487 = makeCons(x139731070514023, x139731070376455);
+Obj x139731070376519 = makeCons(x139731068686695, x139731070376487);
+Obj x139731070376583 = makeCons(x139731068739079, x139731070376519);
+Obj x139731070376615 = makeCons(x139731068738215, x139731070376583);
+Obj x139731070376647 = makeCons(x139731068737351, x139731070376615);
+Obj x139731070376679 = makeCons(x139731068736487, x139731070376647);
+Obj x139731070376711 = makeCons(x139731068735623, x139731070376679);
+Obj x139731070376743 = makeCons(x139731068751143, x139731070376711);
+Obj x139731070376775 = makeCons(x139731068750279, x139731070376743);
+Obj x139731070376807 = makeCons(x139731068749415, x139731070376775);
+Obj x139731070376839 = makeCons(x139731068748551, x139731070376807);
+Obj x139731070376871 = makeCons(x139731068821159, x139731070376839);
+Obj x139731070376903 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139731070376871);
+Obj x139731070361703 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(0, clofun9, 1, 0));
+Obj x139731070363079 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(47, clofun8, 1, 0));
+Obj x139731070364391 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(44, clofun8, 1, 0));
+Obj x139731070035175 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(41, clofun8, 2, 0));
+Obj x139731068836999 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 3, 0));
+Obj x139731068829543 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
+Obj x139731068748263 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
+Obj x139731069963911 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
+Obj x139731070515207 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
+Obj x139731069388935 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
+Obj x139731069389959 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
+Obj x139731068551911 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
+Obj x139731070037895 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
+Obj x139731068851431 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
+Obj x139731067954151 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
+Obj x139731067956583 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
+Obj x139731067933671 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
+Obj x139731067932615 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
+Obj x139731067905287 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
+Obj x139731070036775 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
+Obj x139731068897671 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
+Obj x139731068890119 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
+Obj x139731068850471 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
+Obj x139731068850951 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
+Obj x139731068853671 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
+Obj x139731068836487 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
+Obj x139731068817735 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
+Obj x139731068821063 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
+Obj x139731068737383 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
+Obj x139731067929319 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
+Obj x139731067930023 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
+Obj x139731067930695 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
+Obj x139731067931399 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
+Obj x139731067932007 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
+Obj x139731067906535 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
+Obj x139731067860583 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -460,21 +460,21 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973623682183 = __arg1;
-Obj x139973623684135 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
-Obj x139973623675399 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
-Obj x139973623666343 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
-Obj x139973623579751 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
-Obj x139973623521063 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
-Obj x139973623476199 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
-Obj x139973623427303 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
-Obj x139973622169959 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
-Obj x139973625789703 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
-Obj x139973625790343 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
-Obj x139973625030247 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
-Obj x139973625015271 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
+Obj x139731067861735 = __arg1;
+Obj x139731067834695 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
+Obj x139731067837543 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
+Obj x139731067804519 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
+Obj x139731067614375 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
+Obj x139731067595175 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
+Obj x139731067582631 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
+Obj x139731070515687 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
+Obj x139731069390375 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
+Obj x139731068817671 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
+Obj x139731068818247 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
+Obj x139731068820199 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
+Obj x139731068751207 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
 __nargs = 2;
-__arg1 = x139973625015271;
+__arg1 = x139731068751207;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -484,9 +484,9 @@ label5:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-Obj x139973625031367 = primGenSym();
-Obj globals = x139973625031367;
-Obj x139973625032135 = primSet(co, globals, Nil);
+Obj x139731068821031 = primGenSym();
+Obj globals = x139731068821031;
+Obj x139731068748103 = primSet(co, globals, Nil);
 pushCont(co, 6, clofun0, 3, from, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35compile);
@@ -500,11 +500,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973625012327 = __arg1;
+Obj x139731068748903 = __arg1;
 Obj from= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun0, 3, x139973625012327, to, globals);
+pushCont(co, 7, clofun0, 3, x139731068748903, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35preprocess);
 __arg1 = from;
@@ -517,14 +517,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973625013447 = __arg1;
-Obj x139973625012327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068749639 = __arg1;
+Obj x139731068748903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun0, 3, x139973625012327, to, globals);
+pushCont(co, 8, clofun0, 3, x139731068748903, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand);
-__arg1 = x139973625013447;
+__arg1 = x139731068749639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -534,14 +534,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973625013479 = __arg1;
-Obj x139973625012327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068749671 = __arg1;
+Obj x139731068748903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 9, clofun0, 2, to, globals);
 __nargs = 2;
-__arg0 = x139973625012327;
-__arg1 = x139973625013479;
+__arg0 = x139731068748903;
+__arg1 = x139731068749671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -551,10 +551,10 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973625013511 = __arg1;
+Obj x139731068749703 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj bc = x139973625013511;
+Obj bc = x139731068749703;
 pushCont(co, 10, clofun0, 2, bc, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35open_45output_45file);
@@ -568,10 +568,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973625014151 = __arg1;
+Obj x139731068750311 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stream = x139973625014151;
+Obj stream = x139731068750311;
 pushCont(co, 11, clofun0, 1, stream);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45c);
@@ -587,7 +587,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139973625014855 = __arg1;
+Obj x139731068750791 = __arg1;
 Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35close_45output_45file);
@@ -615,8 +615,8 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973625029863 = __arg1;
-Obj sexp = x139973625029863;
+Obj x139731068819399 = __arg1;
+Obj sexp = x139731068819399;
 pushCont(co, 14, clofun0, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -630,7 +630,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973625030215 = __arg1;
+Obj x139731068820167 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
@@ -641,16 +641,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj x139973624846183 = __arg1;
-Obj x139973624846215 = __arg2;
-Obj x139973624846247 = __arg3;
-Obj x139973624846279 = co->args[4];
-Obj x139973624847015 = makeNative(18, clofun0, 0, 4, x139973624846183, x139973624846215, x139973624846247, x139973624846279);
-Obj x139973625787335 = PRIM_EQ(Nil, x139973624846183);
-if (True == x139973625787335) {
-Obj type = x139973624846215;
-Obj code = x139973624846247;
-Obj k = x139973624846279;
+Obj x139731070375591 = __arg1;
+Obj x139731070375623 = __arg2;
+Obj x139731070375655 = __arg3;
+Obj x139731070375719 = co->args[4];
+Obj x139731070376551 = makeNative(18, clofun0, 0, 4, x139731070375591, x139731070375623, x139731070375655, x139731070375719);
+Obj x139731068827975 = PRIM_EQ(Nil, x139731070375591);
+if (True == x139731068827975) {
+Obj type = x139731070375623;
+Obj code = x139731070375655;
+Obj k = x139731070375719;
 pushCont(co, 16, clofun0, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -662,7 +662,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624847015;
+__arg0 = x139731070376551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -673,10 +673,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973625788295 = __arg1;
+Obj x139731068829095 = __arg1;
 Obj code= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 17, clofun0, 2, k, x139973625788295);
+pushCont(co, 17, clofun0, 2, k, x139731068829095);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
 __arg1 = code;
@@ -689,13 +689,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973625789447 = __arg1;
+Obj x139731068829639 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973625788295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731068829095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = k;
-__arg1 = x139973625788295;
-__arg2 = x139973625789447;
+__arg1 = x139731068829095;
+__arg2 = x139731068829639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -705,30 +705,30 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973624848071 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973622145831 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973622145831) {
-Obj x139973625852135 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625852231 = PRIM_ISCONS(x139973625852135);
-if (True == x139973625852231) {
-Obj x139973625853671 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625853703 = PRIM_CAR(x139973625853671);
-Obj x139973625853831 = PRIM_EQ(sym_58type, x139973625853703);
-if (True == x139973625853831) {
-Obj x139973625854535 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625854823 = PRIM_CDR(x139973625854535);
-Obj exp = x139973625854823;
-Obj x139973625855143 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139973625855143;
+Obj x139731070377639 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731068852647 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068852647) {
+Obj x139731068853575 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068853607 = PRIM_ISCONS(x139731068853575);
+if (True == x139731068853607) {
+Obj x139731068834375 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068834535 = PRIM_CAR(x139731068834375);
+Obj x139731068834567 = PRIM_EQ(sym_58type, x139731068834535);
+if (True == x139731068834567) {
+Obj x139731068835687 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068835719 = PRIM_CDR(x139731068835687);
+Obj exp = x139731068835719;
+Obj x139731068836519 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139731068836519;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj x139973625823751 = makeCons(symbegin, exp);
-Obj x139973625824039 = makeCons(x139973625823751, type);
+Obj x139731068837831 = makeCons(symbegin, exp);
+Obj x139731068825671 = makeCons(x139731068837831, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = x139973625824039;
+__arg2 = x139731068825671;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -738,7 +738,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624848071;
+__arg0 = x139731070377639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -747,7 +747,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848071;
+__arg0 = x139731070377639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -756,7 +756,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848071;
+__arg0 = x139731070377639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -767,30 +767,30 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624685735 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973622162951 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973622162951) {
-Obj x139973622163367 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622163399 = PRIM_ISCONS(x139973622163367);
-if (True == x139973622163399) {
-Obj x139973622164007 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622164039 = PRIM_CAR(x139973622164007);
-Obj x139973622164071 = PRIM_EQ(sym_58declare, x139973622164039);
-if (True == x139973622164071) {
-Obj x139973622164487 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622164519 = PRIM_CDR(x139973622164487);
-Obj exp = x139973622164519;
-Obj x139973622164775 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139973622164775;
+Obj x139731070363047 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731068894279 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068894279) {
+Obj x139731068887239 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068887303 = PRIM_ISCONS(x139731068887239);
+if (True == x139731068887303) {
+Obj x139731068888807 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068888871 = PRIM_CAR(x139731068888807);
+Obj x139731068888903 = PRIM_EQ(sym_58declare, x139731068888871);
+if (True == x139731068888903) {
+Obj x139731068889767 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068889831 = PRIM_CDR(x139731068889767);
+Obj exp = x139731068889831;
+Obj x139731068890183 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139731068890183;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj x139973622145063 = makeCons(symdeclare, exp);
-Obj x139973622145127 = makeCons(x139973622145063, type);
+Obj x139731068850855 = makeCons(symdeclare, exp);
+Obj x139731068850983 = makeCons(x139731068850855, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = x139973622145127;
+__arg2 = x139731068850983;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -800,7 +800,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624685735;
+__arg0 = x139731070363047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -809,7 +809,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685735;
+__arg0 = x139731070363047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -818,7 +818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685735;
+__arg0 = x139731070363047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -829,33 +829,33 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973624687239 = makeNative(21, clofun0, 0, 0);
-Obj x139973622171207 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973622171207) {
-Obj x139973622171463 = PRIM_CAR(closureRef(co, 0));
-Obj exp = x139973622171463;
-Obj x139973622171719 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139973622171719;
+Obj x139731070364775 = makeNative(21, clofun0, 0, 0);
+Obj x139731069044487 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069044487) {
+Obj x139731069045191 = PRIM_CAR(closureRef(co, 0));
+Obj exp = x139731069045191;
+Obj x139731069045767 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139731069045767;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj x139973622173383 = makeCons(exp, Nil);
-Obj x139973622173415 = makeCons(symbackquote, x139973622173383);
-Obj x139973622173479 = makeCons(x139973622173415, Nil);
-Obj x139973622173511 = makeCons(symmacroexpand, x139973622173479);
-Obj x139973622161639 = makeCons(symtvar, Nil);
-Obj x139973622162087 = makeCons(Nil, Nil);
-Obj x139973622162119 = makeCons(Nil, x139973622162087);
-Obj x139973622162151 = makeCons(x139973622161639, x139973622162119);
-Obj x139973622162183 = makeCons(x139973622173511, x139973622162151);
-Obj x139973622162215 = makeCons(symcora_47lib_47infer_35check_45type, x139973622162183);
-Obj x139973622162279 = makeCons(x139973622162215, type);
-Obj x139973622162535 = makeCons(exp, code);
+Obj x139731068898279 = makeCons(exp, Nil);
+Obj x139731068898343 = makeCons(symbackquote, x139731068898279);
+Obj x139731068898407 = makeCons(x139731068898343, Nil);
+Obj x139731068898439 = makeCons(symmacroexpand, x139731068898407);
+Obj x139731068891175 = makeCons(symtvar, Nil);
+Obj x139731068892295 = makeCons(Nil, Nil);
+Obj x139731068892327 = makeCons(Nil, x139731068892295);
+Obj x139731068892359 = makeCons(x139731068891175, x139731068892327);
+Obj x139731068892391 = makeCons(x139731068898439, x139731068892359);
+Obj x139731068892455 = makeCons(symcora_47lib_47infer_35check_45type, x139731068892391);
+Obj x139731068892679 = makeCons(x139731068892455, type);
+Obj x139731068893127 = makeCons(exp, code);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = x139973622162279;
-__arg3 = x139973622162535;
+__arg2 = x139731068892679;
+__arg3 = x139731068893127;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -864,7 +864,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624687239;
+__arg0 = x139731070364775;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -887,22 +887,22 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973624890791 = __arg1;
-Obj x139973624891015 = makeNative(23, clofun0, 0, 1, x139973624890791);
-Obj x139973622208519 = PRIM_ISCONS(x139973624890791);
-if (True == x139973622208519) {
-Obj x139973622208967 = PRIM_CAR(x139973624890791);
-Obj x139973622208999 = PRIM_EQ(symdefine_45library, x139973622208967);
-if (True == x139973622208999) {
-Obj x139973622209415 = PRIM_CDR(x139973624890791);
-Obj x139973622209447 = PRIM_ISCONS(x139973622209415);
-if (True == x139973622209447) {
-Obj x139973622209863 = PRIM_CDR(x139973624890791);
-Obj x139973622209895 = PRIM_CAR(x139973622209863);
-Obj __ = x139973622209895;
-Obj x139973622210311 = PRIM_CDR(x139973624890791);
-Obj x139973622210343 = PRIM_CDR(x139973622210311);
-Obj remain = x139973622210343;
+Obj x139731070514119 = __arg1;
+Obj x139731070514407 = makeNative(23, clofun0, 0, 1, x139731070514119);
+Obj x139731069553543 = PRIM_ISCONS(x139731070514119);
+if (True == x139731069553543) {
+Obj x139731069554311 = PRIM_CAR(x139731070514119);
+Obj x139731069554375 = PRIM_EQ(symdefine_45library, x139731069554311);
+if (True == x139731069554375) {
+Obj x139731069387335 = PRIM_CDR(x139731070514119);
+Obj x139731069387367 = PRIM_ISCONS(x139731069387335);
+if (True == x139731069387367) {
+Obj x139731069388007 = PRIM_CDR(x139731070514119);
+Obj x139731069388263 = PRIM_CAR(x139731069388007);
+Obj __ = x139731069388263;
+Obj x139731069388903 = PRIM_CDR(x139731070514119);
+Obj x139731069388967 = PRIM_CDR(x139731069388903);
+Obj remain = x139731069388967;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -913,7 +913,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624891015;
+__arg0 = x139731070514407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -922,7 +922,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891015;
+__arg0 = x139731070514407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -931,7 +931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891015;
+__arg0 = x139731070514407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -942,14 +942,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973624891783 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
-Obj x139973622207111 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973622207111) {
-Obj x139973622207559 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622207591 = PRIM_EQ(symbegin, x139973622207559);
-if (True == x139973622207591) {
-Obj x139973622207847 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139973622207847;
+Obj x139731070515271 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
+Obj x139731069931047 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069931047) {
+Obj x139731069551047 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069551079 = PRIM_EQ(symbegin, x139731069551047);
+if (True == x139731069551079) {
+Obj x139731069551719 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139731069551719;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -960,7 +960,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624891783;
+__arg0 = x139731070515271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -969,7 +969,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891783;
+__arg0 = x139731070515271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -980,21 +980,21 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973624892455 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
-Obj x139973622224967 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973622224967) {
-Obj x139973622225383 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622225415 = PRIM_ISCONS(x139973622225383);
-if (True == x139973622225415) {
-Obj x139973622226023 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622226055 = PRIM_CAR(x139973622226023);
-Obj x139973622226087 = PRIM_EQ(symexport, x139973622226055);
-if (True == x139973622226087) {
-Obj x139973622226503 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622226535 = PRIM_CDR(x139973622226503);
-Obj more = x139973622226535;
-Obj x139973622226791 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139973622226791;
+Obj x139731070515847 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
+Obj x139731069962087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069962087) {
+Obj x139731069963079 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069963111 = PRIM_ISCONS(x139731069963079);
+if (True == x139731069963111) {
+Obj x139731069927815 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069927879 = PRIM_CAR(x139731069927815);
+Obj x139731069927911 = PRIM_EQ(symexport, x139731069927879);
+if (True == x139731069927911) {
+Obj x139731069928839 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069928967 = PRIM_CDR(x139731069928839);
+Obj more = x139731069928967;
+Obj x139731069929479 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139731069929479;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -1005,7 +1005,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624892455;
+__arg0 = x139731070515847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1014,7 +1014,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624892455;
+__arg0 = x139731070515847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1023,7 +1023,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624892455;
+__arg0 = x139731070515847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1034,31 +1034,31 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973624893255 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
-Obj x139973623420263 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623420263) {
-Obj x139973623420679 = PRIM_CAR(closureRef(co, 0));
-Obj x139973623420711 = PRIM_ISCONS(x139973623420679);
-if (True == x139973623420711) {
-Obj x139973623421319 = PRIM_CAR(closureRef(co, 0));
-Obj x139973623421351 = PRIM_CAR(x139973623421319);
-Obj x139973623421383 = PRIM_EQ(symimport, x139973623421351);
-if (True == x139973623421383) {
-Obj x139973623421959 = PRIM_CAR(closureRef(co, 0));
-Obj x139973623421991 = PRIM_CDR(x139973623421959);
-Obj x139973623422023 = PRIM_ISCONS(x139973623421991);
-if (True == x139973623422023) {
-Obj x139973623422599 = PRIM_CAR(closureRef(co, 0));
-Obj x139973623422631 = PRIM_CDR(x139973623422599);
-Obj x139973623422663 = PRIM_CAR(x139973623422631);
-Obj pkg = x139973623422663;
-Obj x139973622223303 = PRIM_CAR(closureRef(co, 0));
-Obj x139973622223335 = PRIM_CDR(x139973622223303);
-Obj x139973622223367 = PRIM_CDR(x139973622223335);
-Obj x139973622223399 = PRIM_EQ(Nil, x139973622223367);
-if (True == x139973622223399) {
-Obj x139973622223655 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139973622223655;
+Obj x139731070516711 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
+Obj x139731070375751 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070375751) {
+Obj x139731070377383 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070377447 = PRIM_ISCONS(x139731070377383);
+if (True == x139731070377447) {
+Obj x139731070362695 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070362727 = PRIM_CAR(x139731070362695);
+Obj x139731070362759 = PRIM_EQ(symimport, x139731070362727);
+if (True == x139731070362759) {
+Obj x139731070364647 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070364711 = PRIM_CDR(x139731070364647);
+Obj x139731070364743 = PRIM_ISCONS(x139731070364711);
+if (True == x139731070364743) {
+Obj x139731070034375 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070034407 = PRIM_CDR(x139731070034375);
+Obj x139731070034631 = PRIM_CAR(x139731070034407);
+Obj pkg = x139731070034631;
+Obj x139731070036327 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070036359 = PRIM_CDR(x139731070036327);
+Obj x139731070036391 = PRIM_CDR(x139731070036359);
+Obj x139731070036455 = PRIM_EQ(Nil, x139731070036391);
+if (True == x139731070036455) {
+Obj x139731070036903 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139731070036903;
 pushCont(co, 26, clofun0, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -1070,7 +1070,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893255;
+__arg0 = x139731070516711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1079,7 +1079,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624893255;
+__arg0 = x139731070516711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1088,7 +1088,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624893255;
+__arg0 = x139731070516711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1097,7 +1097,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624893255;
+__arg0 = x139731070516711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1106,7 +1106,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624893255;
+__arg0 = x139731070516711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1117,7 +1117,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973622223911 = __arg1;
+Obj x139731070037735 = __arg1;
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -1131,7 +1131,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973624845095 = makeNative(28, clofun0, 0, 0);
+Obj x139731070374439 = makeNative(28, clofun0, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
@@ -1173,11 +1173,11 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973623452423 = __arg1;
+Obj x139731067583303 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups = x139973623452423;
+Obj groups = x139731067583303;
 pushCont(co, 31, clofun0, 3, globals, to, groups);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -1191,11 +1191,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973623452679 = __arg1;
+Obj x139731067583559 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj maxid = x139973623452679;
+Obj maxid = x139731067583559;
 pushCont(co, 32, clofun0, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1210,7 +1210,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973623452967 = __arg1;
+Obj x139731067583847 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1229,7 +1229,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973623453383 = __arg1;
+Obj x139731067584135 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1248,7 +1248,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973623454567 = __arg1;
+Obj x139731067470503 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1267,7 +1267,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973623454887 = __arg1;
+Obj x139731067470791 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1285,7 +1285,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973623455399 = __arg1;
+Obj x139731070514375 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1293,7 +1293,7 @@ pushCont(co, 37, clofun0, 3, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45entry);
 __arg1 = to;
-__arg2 = x139973623455399;
+__arg2 = x139731070514375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1303,7 +1303,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973623455431 = __arg1;
+Obj x139731070514439 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1349,12 +1349,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973623454215 = __arg1;
+Obj x139731067470183 = __arg1;
 PUSH_CONT_0(co, 41, clofun0);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = closureRef(co, 1);
-__arg2 = x139973623454215;
+__arg2 = x139731067470183;
 __arg3 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1365,7 +1365,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139973623454279 = __arg1;
+Obj x139731067470247 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 1);
@@ -1395,7 +1395,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973623473575 = __arg1;
+Obj x139731067596615 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 44, clofun0, 2, globals, to);
@@ -1412,7 +1412,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973623473863 = __arg1;
+Obj x139731067580519 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 45, clofun0, 1, to);
@@ -1429,7 +1429,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973623475975 = __arg1;
+Obj x139731067582407 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1459,7 +1459,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139973623474471 = __arg1;
+Obj x139731067581095 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 48, clofun0, 1, sym);
 __nargs = 3;
@@ -1475,7 +1475,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973623474759 = __arg1;
+Obj x139731067581383 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun0, 1, sym);
 __nargs = 3;
@@ -1491,7 +1491,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973623475111 = __arg1;
+Obj x139731067581671 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
@@ -1526,12 +1526,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973623475623 = __arg1;
+Obj x139731067582119 = __arg1;
 PUSH_CONT_0(co, 1, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
-__arg2 = x139973623475623;
+__arg2 = x139731067582119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1541,7 +1541,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973623475655 = __arg1;
+Obj x139731067582151 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1570,7 +1570,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973623472999 = __arg1;
+Obj x139731067596071 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 4, clofun1);
 __nargs = 3;
@@ -1586,7 +1586,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973623473287 = __arg1;
+Obj x139731067596359 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1600,16 +1600,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973624915527 = __arg1;
-Obj x139973624915559 = __arg2;
-Obj x139973624915591 = __arg3;
-Obj x139973624915623 = co->args[4];
-Obj x139973624916455 = makeNative(8, clofun1, 0, 4, x139973624915527, x139973624915559, x139973624915591, x139973624915623);
-Obj res = x139973624915527;
-Obj idx = x139973624915559;
-Obj acc = x139973624915591;
-Obj x139973623519591 = PRIM_EQ(Nil, x139973624915623);
-if (True == x139973623519591) {
+Obj x139731069964007 = __arg1;
+Obj x139731069964039 = __arg2;
+Obj x139731069964071 = __arg3;
+Obj x139731069964103 = co->args[4];
+Obj x139731069928103 = makeNative(8, clofun1, 0, 4, x139731069964007, x139731069964039, x139731069964071, x139731069964103);
+Obj res = x139731069964007;
+Obj idx = x139731069964039;
+Obj acc = x139731069964071;
+Obj x139731067593991 = PRIM_EQ(Nil, x139731069964103);
+if (True == x139731067593991) {
 pushCont(co, 6, clofun1, 2, acc, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -1621,7 +1621,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624916455;
+__arg0 = x139731069928103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1632,11 +1632,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973623520359 = __arg1;
+Obj x139731067594567 = __arg1;
 Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623520391 = primNot(x139973623520359);
-if (True == x139973623520391) {
+Obj x139731067594599 = primNot(x139731067594567);
+if (True == x139731067594599) {
 pushCont(co, 7, clofun1, 1, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1660,12 +1660,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973623520839 = __arg1;
+Obj x139731067594951 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973623520903 = makeCons(x139973623520839, res);
+Obj x139731067595015 = makeCons(x139731067594951, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139973623520903;
+__arg1 = x139731067595015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1675,18 +1675,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973624917511 = makeNative(10, clofun1, 0, 0);
+Obj x139731069929159 = makeNative(10, clofun1, 0, 0);
 Obj res = closureRef(co, 0);
 Obj idx = closureRef(co, 1);
 Obj acc = closureRef(co, 2);
-Obj x139973623581415 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139973623581415) {
-Obj x139973623581735 = PRIM_CAR(closureRef(co, 3));
-Obj bc = x139973623581735;
-Obj x139973623582055 = PRIM_CDR(closureRef(co, 3));
-Obj more = x139973623582055;
-Obj x139973623582375 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-if (True == x139973623582375) {
+Obj x139731067615559 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731067615559) {
+Obj x139731067615815 = PRIM_CAR(closureRef(co, 3));
+Obj bc = x139731067615815;
+Obj x139731067616071 = PRIM_CDR(closureRef(co, 3));
+Obj more = x139731067616071;
+Obj x139731067616359 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+if (True == x139731067616359) {
 pushCont(co, 9, clofun1, 3, res, bc, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1697,13 +1697,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623518503 = PRIM_ADD(idx, MAKE_NUMBER(1));
-Obj x139973623518759 = makeCons(bc, acc);
+Obj x139731067593095 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj x139731067593351 = makeCons(bc, acc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
 __arg1 = res;
-__arg2 = x139973623518503;
-__arg3 = x139973623518759;
+__arg2 = x139731067593095;
+__arg3 = x139731067593351;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1713,7 +1713,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624917511;
+__arg0 = x139731069929159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1724,18 +1724,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973623517479 = __arg1;
+Obj x139731067616871 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623517543 = makeCons(x139973623517479, res);
-Obj x139973623517959 = makeCons(bc, more);
+Obj x139731067616935 = makeCons(x139731067616871, res);
+Obj x139731067617255 = makeCons(bc, more);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = x139973623517543;
+__arg1 = x139731067616935;
 __arg2 = MAKE_NUMBER(0);
 __arg3 = Nil;
-co->args[4] = x139973623517959;
+co->args[4] = x139731067617255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1773,7 +1773,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973623667303 = __arg1;
+Obj x139731067805287 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1781,7 +1781,7 @@ pushCont(co, 13, clofun1, 3, maxid, group, to);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = to;
-__arg2 = x139973623667303;
+__arg2 = x139731067805287;
 __arg3 = maxid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1792,7 +1792,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973623667367 = __arg1;
+Obj x139731067805351 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1810,7 +1810,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973623667719 = __arg1;
+Obj x139731067805639 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1828,7 +1828,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973623668007 = __arg1;
+Obj x139731067728103 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1846,7 +1846,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973623668391 = __arg1;
+Obj x139731067728391 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1864,7 +1864,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973623668679 = __arg1;
+Obj x139731067728679 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1882,7 +1882,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973623648519 = __arg1;
+Obj x139731067728967 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1900,7 +1900,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973623648871 = __arg1;
+Obj x139731067729255 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1918,7 +1918,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973623649255 = __arg1;
+Obj x139731067729543 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1935,7 +1935,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973623649895 = __arg1;
+Obj x139731067730023 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1944,7 +1944,7 @@ __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = x139973623649895;
+__arg3 = x139731067730023;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1954,7 +1954,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973623649927 = __arg1;
+Obj x139731067730055 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1972,7 +1972,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973623650215 = __arg1;
+Obj x139731067730343 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1990,7 +1990,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973623650567 = __arg1;
+Obj x139731067730631 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2008,7 +2008,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973623651239 = __arg1;
+Obj x139731067731207 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 26, clofun1, 1, to);
 __nargs = 3;
@@ -2024,7 +2024,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973623651591 = __arg1;
+Obj x139731067731495 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 27, clofun1, 1, to);
 __nargs = 3;
@@ -2040,7 +2040,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973623651879 = __arg1;
+Obj x139731067731783 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun1, 1, to);
 __nargs = 3;
@@ -2056,7 +2056,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139973623652199 = __arg1;
+Obj x139731067613287 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun1, 1, to);
 __nargs = 3;
@@ -2072,7 +2072,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139973623578791 = __arg1;
+Obj x139731067613575 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun1, 1, to);
 __nargs = 3;
@@ -2088,7 +2088,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973623579175 = __arg1;
+Obj x139731067613863 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun1, 1, to);
 __nargs = 3;
@@ -2104,7 +2104,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973623579527 = __arg1;
+Obj x139731067614151 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2137,8 +2137,8 @@ label33:
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj x139973623676423 = PRIM_EQ(i, MAKE_NUMBER(0));
-if (True == x139973623676423) {
+Obj x139731067838215 = PRIM_EQ(i, MAKE_NUMBER(0));
+if (True == x139731067838215) {
 pushCont(co, 36, clofun1, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2150,8 +2150,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623665095 = PRIM_LT(i, n);
-if (True == x139973623665095) {
+Obj x139731067802311 = PRIM_LT(i, n);
+if (True == x139731067802311) {
 pushCont(co, 34, clofun1, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2174,7 +2174,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj x139973623665415 = __arg1;
+Obj x139731067802631 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2192,15 +2192,15 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973623665767 = __arg1;
+Obj x139731067802951 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623666279 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139731067804455 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
-__arg2 = x139973623666279;
+__arg2 = x139731067804455;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2211,7 +2211,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973623676775 = __arg1;
+Obj x139731067801703 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2228,12 +2228,12 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973625015047 = __arg1;
-Obj x139973625015079 = __arg2;
-Obj x139973625015559 = makeNative(38, clofun1, 0, 2, x139973625015047, x139973625015079);
-Obj fn = x139973625015047;
-Obj x139973623675207 = PRIM_EQ(Nil, x139973625015079);
-if (True == x139973623675207) {
+Obj x139731069961191 = __arg1;
+Obj x139731069961223 = __arg2;
+Obj x139731069961607 = makeNative(38, clofun1, 0, 2, x139731069961191, x139731069961223);
+Obj fn = x139731069961191;
+Obj x139731067837319 = PRIM_EQ(Nil, x139731069961223);
+if (True == x139731067837319) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2241,7 +2241,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625015559;
+__arg0 = x139731069961607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2252,14 +2252,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973625016167 = makeNative(40, clofun1, 0, 0);
+Obj x139731069962247 = makeNative(40, clofun1, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj x139973623673191 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973623673191) {
-Obj x139973623673543 = PRIM_CAR(closureRef(co, 1));
-Obj x = x139973623673543;
-Obj x139973623673991 = PRIM_CDR(closureRef(co, 1));
-Obj y = x139973623673991;
+Obj x139731067835815 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731067835815) {
+Obj x139731067836103 = PRIM_CAR(closureRef(co, 1));
+Obj x = x139731067836103;
+Obj x139731067836359 = PRIM_CDR(closureRef(co, 1));
+Obj y = x139731067836359;
 pushCont(co, 39, clofun1, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
@@ -2271,7 +2271,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625016167;
+__arg0 = x139731069962247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2282,7 +2282,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973623674375 = __arg1;
+Obj x139731067836615 = __arg1;
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -2325,11 +2325,11 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973623683911 = __arg1;
+Obj x139731067834503 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun1);
 __nargs = 2;
-__arg0 = x139973623683911;
+__arg0 = x139731067834503;
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2340,11 +2340,11 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973623683975 = __arg1;
+Obj x139731067834567 = __arg1;
 PUSH_CONT_0(co, 44, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert_45pass);
-__arg1 = x139973623683975;
+__arg1 = x139731067834567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2354,11 +2354,11 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973623684039 = __arg1;
+Obj x139731067834599 = __arg1;
 PUSH_CONT_0(co, 45, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45pass);
-__arg1 = x139973623684039;
+__arg1 = x139731067834599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2368,11 +2368,11 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973623684071 = __arg1;
+Obj x139731067834631 = __arg1;
 PUSH_CONT_0(co, 46, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack_45pass);
-__arg1 = x139973623684071;
+__arg1 = x139731067834631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2382,10 +2382,10 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139973623684103 = __arg1;
+Obj x139731067834663 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda_45pass);
-__arg1 = x139973623684103;
+__arg1 = x139731067834663;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2409,9 +2409,9 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973623681607 = __arg1;
+Obj x139731067861191 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj obj = x139973623681607;
+Obj obj = x139731067861191;
 pushCont(co, 49, clofun1, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35cddr);
@@ -2425,9 +2425,9 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973623681863 = __arg1;
+Obj x139731067861479 = __arg1;
 Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fns = x139973623681863;
+Obj fns = x139731067861479;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
 __arg1 = obj;
@@ -2461,12 +2461,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973625012775 = __arg1;
-Obj x139973625012807 = __arg2;
-Obj x139973625013223 = makeNative(1, clofun2, 0, 2, x139973625012775, x139973625012807);
-Obj obj = x139973625012775;
-Obj x139973623688711 = PRIM_EQ(Nil, x139973625012807);
-if (True == x139973623688711) {
+Obj x139731070035303 = __arg1;
+Obj x139731070035335 = __arg2;
+Obj x139731070035719 = makeNative(1, clofun2, 0, 2, x139731070035303, x139731070035335);
+Obj obj = x139731070035303;
+Obj x139731067860391 = PRIM_EQ(Nil, x139731070035335);
+if (True == x139731067860391) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2474,7 +2474,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625013223;
+__arg0 = x139731070035719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2485,19 +2485,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973625013799 = makeNative(2, clofun2, 0, 0);
+Obj x139731070036423 = makeNative(2, clofun2, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj x139973623686311 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973623686311) {
-Obj x139973623686663 = PRIM_CAR(closureRef(co, 1));
-Obj hd = x139973623686663;
-Obj x139973623687175 = PRIM_CDR(closureRef(co, 1));
-Obj more = x139973623687175;
-Obj x139973623687943 = makeCons(obj, Nil);
-Obj x139973623687975 = makeCons(hd, x139973623687943);
+Obj x139731067907623 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731067907623) {
+Obj x139731067907943 = PRIM_CAR(closureRef(co, 1));
+Obj hd = x139731067907943;
+Obj x139731067859047 = PRIM_CDR(closureRef(co, 1));
+Obj more = x139731067859047;
+Obj x139731067859751 = makeCons(obj, Nil);
+Obj x139731067859783 = makeCons(hd, x139731067859751);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = x139973623687975;
+__arg1 = x139731067859783;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2506,7 +2506,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625013799;
+__arg0 = x139731070036423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2543,9 +2543,9 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973624004103 = __arg1;
+Obj x139731067932647 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = x139973624004103;
+Obj v = x139731067932647;
 pushCont(co, 5, clofun2, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
@@ -2561,7 +2561,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973623730343 = __arg1;
+Obj x139731067904295 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 6, clofun2, 2, exp, v);
@@ -2579,7 +2579,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973623730759 = __arg1;
+Obj x139731067904647 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 7, clofun2, 1, v);
@@ -2596,18 +2596,18 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973623731079 = __arg1;
+Obj x139731067904967 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1 = x139973623731079;
-Obj x139973623733095 = makeCons(e1, Nil);
-Obj x139973623733127 = makeCons(Nil, x139973623733095);
-Obj x139973623733159 = makeCons(Nil, x139973623733127);
-Obj x139973623733191 = makeCons(symlambda, x139973623733159);
+Obj e1 = x139731067904967;
+Obj x139731067906151 = makeCons(e1, Nil);
+Obj x139731067906183 = makeCons(Nil, x139731067906151);
+Obj x139731067906215 = makeCons(Nil, x139731067906183);
+Obj x139731067906247 = makeCons(symlambda, x139731067906215);
 pushCont(co, 8, clofun2, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973623733191;
+__arg2 = x139731067906247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2617,7 +2617,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973623733223 = __arg1;
+Obj x139731067906279 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -2676,13 +2676,11 @@ label12:
 {
 Obj globals = __arg1;
 Obj exp = __arg2;
-__nargs = 6;
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = Nil;
-__arg2 = makeCString("");
-__arg3 = Nil;
-co->args[4] = globals;
-co->args[5] = exp;
+__arg2 = globals;
+__arg3 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2692,76 +2690,76 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973625028967 = __arg1;
-Obj x139973625028999 = __arg2;
-Obj x139973625029031 = __arg3;
-Obj x139973625029639 = makeNative(21, clofun2, 0, 3, x139973625028967, x139973625028999, x139973625029031);
-Obj w = x139973625028967;
-Obj x139973624529447 = PRIM_ISCONS(x139973625028999);
-if (True == x139973624529447) {
-Obj x139973624529863 = PRIM_CAR(x139973625028999);
-Obj label = x139973624529863;
-Obj x139973624530535 = PRIM_CDR(x139973625028999);
-Obj x139973624530567 = PRIM_ISCONS(x139973624530535);
-if (True == x139973624530567) {
-Obj x139973624531687 = PRIM_CDR(x139973625028999);
-Obj x139973624531719 = PRIM_CAR(x139973624531687);
-Obj x139973624531751 = PRIM_ISCONS(x139973624531719);
-if (True == x139973624531751) {
-Obj x139973624516935 = PRIM_CDR(x139973625028999);
-Obj x139973624516967 = PRIM_CAR(x139973624516935);
-Obj x139973624516999 = PRIM_CAR(x139973624516967);
-Obj x139973624517063 = PRIM_EQ(symlambda, x139973624516999);
-if (True == x139973624517063) {
-Obj x139973624518247 = PRIM_CDR(x139973625028999);
-Obj x139973624518279 = PRIM_CAR(x139973624518247);
-Obj x139973624518311 = PRIM_CDR(x139973624518279);
-Obj x139973624518343 = PRIM_ISCONS(x139973624518311);
-if (True == x139973624518343) {
-Obj x139973624519783 = PRIM_CDR(x139973625028999);
-Obj x139973624520007 = PRIM_CAR(x139973624519783);
-Obj x139973624520039 = PRIM_CDR(x139973624520007);
-Obj x139973624520167 = PRIM_CAR(x139973624520039);
-Obj params = x139973624520167;
-Obj x139973624415335 = PRIM_CDR(x139973625028999);
-Obj x139973624415367 = PRIM_CAR(x139973624415335);
-Obj x139973624415527 = PRIM_CDR(x139973624415367);
-Obj x139973624415559 = PRIM_CDR(x139973624415527);
-Obj x139973624415591 = PRIM_ISCONS(x139973624415559);
-if (True == x139973624415591) {
-Obj x139973624417831 = PRIM_CDR(x139973625028999);
-Obj x139973624417863 = PRIM_CAR(x139973624417831);
-Obj x139973624417895 = PRIM_CDR(x139973624417863);
-Obj x139973624417927 = PRIM_CDR(x139973624417895);
-Obj x139973624417959 = PRIM_CAR(x139973624417927);
-Obj actives = x139973624417959;
-Obj x139973624375431 = PRIM_CDR(x139973625028999);
-Obj x139973624375783 = PRIM_CAR(x139973624375431);
-Obj x139973624375815 = PRIM_CDR(x139973624375783);
-Obj x139973624375847 = PRIM_CDR(x139973624375815);
-Obj x139973624375879 = PRIM_CDR(x139973624375847);
-Obj x139973624375911 = PRIM_ISCONS(x139973624375879);
-if (True == x139973624375911) {
-Obj x139973624341319 = PRIM_CDR(x139973625028999);
-Obj x139973624341415 = PRIM_CAR(x139973624341319);
-Obj x139973624341479 = PRIM_CDR(x139973624341415);
-Obj x139973624341511 = PRIM_CDR(x139973624341479);
-Obj x139973624341543 = PRIM_CDR(x139973624341511);
-Obj x139973624341575 = PRIM_CAR(x139973624341543);
-Obj body = x139973624341575;
-Obj x139973624344391 = PRIM_CDR(x139973625028999);
-Obj x139973624344423 = PRIM_CAR(x139973624344391);
-Obj x139973624344455 = PRIM_CDR(x139973624344423);
-Obj x139973624344487 = PRIM_CDR(x139973624344455);
-Obj x139973624275079 = PRIM_CDR(x139973624344487);
-Obj x139973624275143 = PRIM_CDR(x139973624275079);
-Obj x139973624275271 = PRIM_EQ(Nil, x139973624275143);
-if (True == x139973624275271) {
-Obj x139973624276071 = PRIM_CDR(x139973625028999);
-Obj x139973624276103 = PRIM_CDR(x139973624276071);
-Obj x139973624276167 = PRIM_EQ(Nil, x139973624276103);
-if (True == x139973624276167) {
-Obj maxid = x139973625029031;
+Obj x139731070362599 = __arg1;
+Obj x139731070362631 = __arg2;
+Obj x139731070362663 = __arg3;
+Obj x139731070363303 = makeNative(21, clofun2, 0, 3, x139731070362599, x139731070362631, x139731070362663);
+Obj w = x139731070362599;
+Obj x139731068687911 = PRIM_ISCONS(x139731070362631);
+if (True == x139731068687911) {
+Obj x139731068688295 = PRIM_CAR(x139731070362631);
+Obj label = x139731068688295;
+Obj x139731068688999 = PRIM_CDR(x139731070362631);
+Obj x139731068689031 = PRIM_ISCONS(x139731068688999);
+if (True == x139731068689031) {
+Obj x139731068690087 = PRIM_CDR(x139731070362631);
+Obj x139731068690119 = PRIM_CAR(x139731068690087);
+Obj x139731068690151 = PRIM_ISCONS(x139731068690119);
+if (True == x139731068690151) {
+Obj x139731068682951 = PRIM_CDR(x139731070362631);
+Obj x139731068682983 = PRIM_CAR(x139731068682951);
+Obj x139731068683015 = PRIM_CAR(x139731068682983);
+Obj x139731068683047 = PRIM_EQ(symlambda, x139731068683015);
+if (True == x139731068683047) {
+Obj x139731068684231 = PRIM_CDR(x139731070362631);
+Obj x139731068684263 = PRIM_CAR(x139731068684231);
+Obj x139731068684295 = PRIM_CDR(x139731068684263);
+Obj x139731068684327 = PRIM_ISCONS(x139731068684295);
+if (True == x139731068684327) {
+Obj x139731068685319 = PRIM_CDR(x139731070362631);
+Obj x139731068685383 = PRIM_CAR(x139731068685319);
+Obj x139731068685415 = PRIM_CDR(x139731068685383);
+Obj x139731068685447 = PRIM_CAR(x139731068685415);
+Obj params = x139731068685447;
+Obj x139731068551591 = PRIM_CDR(x139731070362631);
+Obj x139731068551623 = PRIM_CAR(x139731068551591);
+Obj x139731068551655 = PRIM_CDR(x139731068551623);
+Obj x139731068551687 = PRIM_CDR(x139731068551655);
+Obj x139731068551719 = PRIM_ISCONS(x139731068551687);
+if (True == x139731068551719) {
+Obj x139731068552967 = PRIM_CDR(x139731070362631);
+Obj x139731068552999 = PRIM_CAR(x139731068552967);
+Obj x139731068553031 = PRIM_CDR(x139731068552999);
+Obj x139731068553063 = PRIM_CDR(x139731068553031);
+Obj x139731068553095 = PRIM_CAR(x139731068553063);
+Obj actives = x139731068553095;
+Obj x139731068554631 = PRIM_CDR(x139731070362631);
+Obj x139731068554695 = PRIM_CAR(x139731068554631);
+Obj x139731068554727 = PRIM_CDR(x139731068554695);
+Obj x139731068554759 = PRIM_CDR(x139731068554727);
+Obj x139731068554791 = PRIM_CDR(x139731068554759);
+Obj x139731068554823 = PRIM_ISCONS(x139731068554791);
+if (True == x139731068554823) {
+Obj x139731067953991 = PRIM_CDR(x139731070362631);
+Obj x139731067954023 = PRIM_CAR(x139731067953991);
+Obj x139731067954055 = PRIM_CDR(x139731067954023);
+Obj x139731067954087 = PRIM_CDR(x139731067954055);
+Obj x139731067954119 = PRIM_CDR(x139731067954087);
+Obj x139731067954183 = PRIM_CAR(x139731067954119);
+Obj body = x139731067954183;
+Obj x139731067955655 = PRIM_CDR(x139731070362631);
+Obj x139731067955751 = PRIM_CAR(x139731067955655);
+Obj x139731067955815 = PRIM_CDR(x139731067955751);
+Obj x139731067955847 = PRIM_CDR(x139731067955815);
+Obj x139731067955879 = PRIM_CDR(x139731067955847);
+Obj x139731067955911 = PRIM_CDR(x139731067955879);
+Obj x139731067955943 = PRIM_EQ(Nil, x139731067955911);
+if (True == x139731067955943) {
+Obj x139731067956711 = PRIM_CDR(x139731070362631);
+Obj x139731067956839 = PRIM_CDR(x139731067956711);
+Obj x139731067956871 = PRIM_EQ(Nil, x139731067956839);
+if (True == x139731067956871) {
+Obj maxid = x139731070362663;
 pushCont(co, 14, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2774,7 +2772,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2783,7 +2781,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2792,7 +2790,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2801,7 +2799,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2810,7 +2808,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2819,7 +2817,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2828,7 +2826,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2837,7 +2835,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2846,7 +2844,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625029639;
+__arg0 = x139731070363303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2857,18 +2855,18 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973624276775 = __arg1;
+Obj x139731067932679 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139973624278023 = PRIM_SUB(maxid, label);
+Obj x139731067933415 = PRIM_SUB(maxid, label);
 pushCont(co, 15, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139973624278023;
+__arg1 = x139731067933415;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2879,7 +2877,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973624278087 = __arg1;
+Obj x139731067933511 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2890,7 +2888,7 @@ pushCont(co, 16, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = x139973624278087;
+__arg2 = x139731067933511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2900,7 +2898,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973624278471 = __arg1;
+Obj x139731067933703 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2921,7 +2919,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973624221703 = __arg1;
+Obj x139731067934119 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2944,7 +2942,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973624222503 = __arg1;
+Obj x139731067934471 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2967,17 +2965,17 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624223463 = __arg1;
+Obj x139731067934983 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139973624224647 = makeCons(maxid, label);
+Obj x139731067935495 = makeCons(maxid, label);
 pushCont(co, 20, clofun2, 1, w);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = x139973624224647;
+__arg1 = x139731067935495;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
@@ -2990,7 +2988,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973624224775 = __arg1;
+Obj x139731067935623 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3005,7 +3003,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973625031879 = makeNative(24, clofun2, 0, 0);
+Obj x139731070033991 = makeNative(24, clofun2, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
 Obj maxid = closureRef(co, 2);
@@ -3022,7 +3020,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973624642727 = __arg1;
+Obj x139731068686535 = __arg1;
 Obj other= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 23, clofun2);
 __nargs = 2;
@@ -3037,7 +3035,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973624643079 = __arg1;
+Obj x139731068686919 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35display);
 __arg1 = makeCString("\n");
@@ -3062,16 +3060,16 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973625825927 = __arg1;
-Obj x139973625825959 = __arg2;
-Obj x139973625825991 = __arg3;
-Obj x139973625826023 = co->args[4];
-Obj x139973625787591 = makeNative(26, clofun2, 0, 4, x139973625825927, x139973625825959, x139973625825991, x139973625826023);
-Obj fn = x139973625825927;
-Obj w = x139973625825959;
-Obj idx = x139973625825991;
-Obj x139973624639623 = PRIM_EQ(Nil, x139973625826023);
-if (True == x139973624639623) {
+Obj x139731070375239 = __arg1;
+Obj x139731070375271 = __arg2;
+Obj x139731070375303 = __arg3;
+Obj x139731070375367 = co->args[4];
+Obj x139731070376199 = makeNative(26, clofun2, 0, 4, x139731070375239, x139731070375271, x139731070375303, x139731070375367);
+Obj fn = x139731070375239;
+Obj w = x139731070375271;
+Obj idx = x139731070375303;
+Obj x139731068737127 = PRIM_EQ(Nil, x139731070375367);
+if (True == x139731068737127) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3079,7 +3077,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625787591;
+__arg0 = x139731070376199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3090,16 +3088,16 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973625789351 = makeNative(28, clofun2, 0, 0);
+Obj x139731070377287 = makeNative(28, clofun2, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj x139973624685191 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139973624685191) {
-Obj x139973624685575 = PRIM_CAR(closureRef(co, 3));
-Obj a = x139973624685575;
-Obj x139973624686407 = PRIM_CDR(closureRef(co, 3));
-Obj b = x139973624686407;
+Obj x139731068749831 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731068749831) {
+Obj x139731068750343 = PRIM_CAR(closureRef(co, 3));
+Obj a = x139731068750343;
+Obj x139731068750695 = PRIM_CDR(closureRef(co, 3));
+Obj b = x139731068750695;
 pushCont(co, 27, clofun2, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
@@ -3113,7 +3111,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625789351;
+__arg0 = x139731070377287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3124,17 +3122,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973624686791 = __arg1;
+Obj x139731068751239 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973624687527 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj x139731068735911 = PRIM_ADD(idx, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
 __arg1 = fn;
 __arg2 = w;
-__arg3 = x139973624687527;
+__arg3 = x139731068735911;
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3174,7 +3172,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973624893319 = __arg1;
+Obj x139731068818951 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3194,7 +3192,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973624844903 = __arg1;
+Obj x139731068819847 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 32, clofun2, 2, i, w);
@@ -3211,7 +3209,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973624845543 = __arg1;
+Obj x139731068820263 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 33, clofun2, 1, w);
@@ -3228,7 +3226,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973624846311 = __arg1;
+Obj x139731068820743 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3260,7 +3258,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973624915495 = __arg1;
+Obj x139731068837575 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3280,11 +3278,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973624916295 = __arg1;
+Obj x139731068825991 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624916903 = PRIM_LT(i, MAKE_NUMBER(4));
-if (True == x139973624916903) {
+Obj x139731068826695 = PRIM_LT(i, MAKE_NUMBER(4));
+if (True == x139731068826695) {
 pushCont(co, 39, clofun2, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3311,7 +3309,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973624890439 = __arg1;
+Obj x139731068829063 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 38, clofun2, 1, w);
@@ -3328,7 +3326,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973624891207 = __arg1;
+Obj x139731068829671 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3343,7 +3341,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973624917447 = __arg1;
+Obj x139731068827175 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 40, clofun2, 1, w);
@@ -3360,7 +3358,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973624917927 = __arg1;
+Obj x139731068828071 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3392,7 +3390,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973625015143 = __arg1;
+Obj x139731068834503 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3411,7 +3409,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973625015943 = __arg1;
+Obj x139731068835175 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 44, clofun2, 1, w);
 __nargs = 3;
@@ -3427,7 +3425,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973624914055 = __arg1;
+Obj x139731068835847 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3445,9 +3443,9 @@ label45:
 Obj w = __arg1;
 Obj label = __arg2;
 Obj maxid = __arg3;
-Obj x139973625012711 = PRIM_SUB(maxid, label);
-Obj x139973625012871 = primDiv(x139973625012711, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-Obj gid = x139973625012871;
+Obj x139731068852679 = PRIM_SUB(maxid, label);
+Obj x139731068852743 = primDiv(x139731068852679, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+Obj gid = x139731068852743;
 pushCont(co, 46, clofun2, 2, w, gid);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3462,7 +3460,7 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139973625013415 = __arg1;
+Obj x139731068853255 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -3498,18 +3496,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973625854279 = __arg1;
-Obj x139973625854311 = __arg2;
-Obj x139973625854343 = __arg3;
-Obj x139973625854375 = co->args[4];
-Obj x139973625854407 = co->args[5];
-Obj x139973625855303 = makeNative(49, clofun2, 0, 5, x139973625854279, x139973625854311, x139973625854343, x139973625854375, x139973625854407);
-Obj self = x139973625854279;
-Obj env = x139973625854311;
-Obj fn = x139973625854343;
-Obj w = x139973625854375;
-Obj x139973625029255 = PRIM_EQ(Nil, x139973625854407);
-if (True == x139973625029255) {
+Obj x139731070513831 = __arg1;
+Obj x139731070513863 = __arg2;
+Obj x139731070513895 = __arg3;
+Obj x139731070513927 = co->args[4];
+Obj x139731070513959 = co->args[5];
+Obj x139731070514951 = makeNative(49, clofun2, 0, 5, x139731070513831, x139731070513863, x139731070513895, x139731070513927, x139731070513959);
+Obj self = x139731070513831;
+Obj env = x139731070513863;
+Obj fn = x139731070513895;
+Obj w = x139731070513927;
+Obj x139731068889959 = PRIM_EQ(Nil, x139731070513959);
+if (True == x139731068889959) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3517,7 +3515,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625855303;
+__arg0 = x139731070514951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3528,17 +3526,17 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973625823783 = makeNative(3, clofun3, 0, 0);
+Obj x139731070516327 = makeNative(3, clofun3, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj x139973625823239 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973625823239) {
-Obj x139973625823623 = PRIM_CAR(closureRef(co, 4));
-Obj a = x139973625823623;
-Obj x139973625824199 = PRIM_CDR(closureRef(co, 4));
-Obj b = x139973625824199;
+Obj x139731068891815 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x139731068891815) {
+Obj x139731068892423 = PRIM_CAR(closureRef(co, 4));
+Obj a = x139731068892423;
+Obj x139731068892999 = PRIM_CDR(closureRef(co, 4));
+Obj b = x139731068892999;
 pushCont(co, 0, clofun3, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
@@ -3553,7 +3551,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625823783;
+__arg0 = x139731070516327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3584,7 +3582,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973625825095 = __arg1;
+Obj x139731068894023 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3603,14 +3601,14 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973625787623 = __arg1;
+Obj x139731068894567 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139973625787655 = primNot(x139973625787623);
-if (True == x139973625787655) {
+Obj x139731068894599 = primNot(x139731068894567);
+if (True == x139731068894599) {
 pushCont(co, 2, clofun3, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3640,7 +3638,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139973625787911 = __arg1;
+Obj x139731068887271 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3674,28 +3672,28 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973624375015 = __arg1;
-Obj x139973624375047 = __arg2;
-Obj x139973624375079 = __arg3;
-Obj x139973625852487 = makeNative(27, clofun3, 0, 0);
-Obj self = x139973624375015;
-Obj w = x139973624375047;
-Obj x139973623474439 = PRIM_ISCONS(x139973624375079);
-if (True == x139973623474439) {
-Obj x139973623474887 = PRIM_CAR(x139973624375079);
-Obj x139973623474919 = PRIM_EQ(sym_37continuation, x139973623474887);
-if (True == x139973623474919) {
-Obj x139973623475335 = PRIM_CDR(x139973624375079);
-Obj x139973623475367 = PRIM_ISCONS(x139973623475335);
-if (True == x139973623475367) {
-Obj x139973623475783 = PRIM_CDR(x139973624375079);
-Obj x139973623475815 = PRIM_CAR(x139973623475783);
-Obj label = x139973623475815;
-Obj x139973623451655 = PRIM_CDR(x139973624375079);
-Obj x139973623451687 = PRIM_CDR(x139973623451655);
-Obj stacks = x139973623451687;
-Obj x139973623452039 = PRIM_EQ(stacks, Nil);
-if (True == x139973623452039) {
+Obj x139731070036231 = __arg1;
+Obj x139731070036263 = __arg2;
+Obj x139731070036295 = __arg3;
+Obj x139731070036871 = makeNative(27, clofun3, 0, 0);
+Obj self = x139731070036231;
+Obj w = x139731070036263;
+Obj x139731069960871 = PRIM_ISCONS(x139731070036295);
+if (True == x139731069960871) {
+Obj x139731069962023 = PRIM_CAR(x139731070036295);
+Obj x139731069962055 = PRIM_EQ(sym_37continuation, x139731069962023);
+if (True == x139731069962055) {
+Obj x139731069962759 = PRIM_CDR(x139731070036295);
+Obj x139731069962791 = PRIM_ISCONS(x139731069962759);
+if (True == x139731069962791) {
+Obj x139731069963751 = PRIM_CDR(x139731070036295);
+Obj x139731069963783 = PRIM_CAR(x139731069963751);
+Obj label = x139731069963783;
+Obj x139731069927943 = PRIM_CDR(x139731070036295);
+Obj x139731069927975 = PRIM_CDR(x139731069927943);
+Obj stacks = x139731069927975;
+Obj x139731069928519 = PRIM_EQ(stacks, Nil);
+if (True == x139731069928519) {
 pushCont(co, 16, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3720,7 +3718,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625852487;
+__arg0 = x139731070036871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3729,7 +3727,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625852487;
+__arg0 = x139731070036871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3738,7 +3736,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625852487;
+__arg0 = x139731070036871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3749,17 +3747,17 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973623427879 = __arg1;
+Obj x139731069388359 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623428647 = PRIM_CAR(self);
-Obj x139973623428711 = PRIM_SUB(x139973623428647, label);
+Obj x139731069389639 = PRIM_CAR(self);
+Obj x139731069389703 = PRIM_SUB(x139731069389639, label);
 pushCont(co, 6, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139973623428711;
+__arg1 = x139731069389703;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3770,7 +3768,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973623428775 = __arg1;
+Obj x139731069390119 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3779,7 +3777,7 @@ pushCont(co, 7, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = x139973623428775;
+__arg2 = x139731069390119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3789,7 +3787,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973623428807 = __arg1;
+Obj x139731069390151 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3808,18 +3806,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973623429095 = __arg1;
+Obj x139731069390503 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623429575 = PRIM_CAR(self);
+Obj x139731069043271 = PRIM_CAR(self);
 pushCont(co, 9, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = x139973623429575;
+__arg3 = x139731069043271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3829,12 +3827,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973623429607 = __arg1;
+Obj x139731069043335 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623429959 = PRIM_EQ(stacks, Nil);
-if (True == x139973623429959) {
+Obj x139731069043975 = PRIM_EQ(stacks, Nil);
+if (True == x139731069043975) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3861,7 +3859,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973623430439 = __arg1;
+Obj x139731069044967 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3878,7 +3876,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139973623430887 = __arg1;
+Obj x139731069045639 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3886,7 +3884,7 @@ pushCont(co, 12, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = x139973623430887;
+__arg2 = x139731069045639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3896,7 +3894,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973623430919 = __arg1;
+Obj x139731069045671 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3914,7 +3912,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973625852423 = __arg1;
+Obj x139731068895687 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3944,7 +3942,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973625851943 = __arg1;
+Obj x139731069046663 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -3961,17 +3959,17 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973623452263 = __arg1;
+Obj x139731069929255 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623453031 = PRIM_CAR(self);
-Obj x139973623453095 = PRIM_SUB(x139973623453031, label);
+Obj x139731069930407 = PRIM_CAR(self);
+Obj x139731069930471 = PRIM_SUB(x139731069930407, label);
 pushCont(co, 17, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139973623453095;
+__arg1 = x139731069930471;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3982,7 +3980,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973623453159 = __arg1;
+Obj x139731069930759 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3991,7 +3989,7 @@ pushCont(co, 18, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = x139973623453159;
+__arg2 = x139731069930759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4001,7 +3999,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973623453191 = __arg1;
+Obj x139731069930791 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4020,18 +4018,18 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973623453479 = __arg1;
+Obj x139731069931239 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623453959 = PRIM_CAR(self);
+Obj x139731069551399 = PRIM_CAR(self);
 pushCont(co, 20, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = x139973623453959;
+__arg3 = x139731069551399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4041,12 +4039,12 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973623453991 = __arg1;
+Obj x139731069551495 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623454343 = PRIM_EQ(stacks, Nil);
-if (True == x139973623454343) {
+Obj x139731069552071 = PRIM_EQ(stacks, Nil);
+if (True == x139731069552071) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4073,7 +4071,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973623454823 = __arg1;
+Obj x139731069553063 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4090,7 +4088,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973623455271 = __arg1;
+Obj x139731069554119 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4098,7 +4096,7 @@ pushCont(co, 23, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = x139973623455271;
+__arg2 = x139731069554119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4108,7 +4106,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973623455303 = __arg1;
+Obj x139731069554151 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4126,7 +4124,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973623427463 = __arg1;
+Obj x139731069387623 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4156,7 +4154,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973623427143 = __arg1;
+Obj x139731069387175 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -4189,8 +4187,8 @@ Obj self = __arg1;
 Obj env = __arg2;
 Obj w = __arg3;
 Obj x1 = co->args[4];
-Obj x139973623649799 = primIsSymbol(x1);
-if (True == x139973623649799) {
+Obj x139731070513159 = primIsSymbol(x1);
+if (True == x139731070513159) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = w;
@@ -4201,22 +4199,22 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973624684615 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
-Obj x139973623517415 = PRIM_ISCONS(x1);
-if (True == x139973623517415) {
-Obj x139973623517863 = PRIM_CAR(x1);
-Obj x139973623517927 = PRIM_EQ(sym_37global, x139973623517863);
-if (True == x139973623517927) {
-Obj x139973623518407 = PRIM_CDR(x1);
-Obj x139973623518439 = PRIM_ISCONS(x139973623518407);
-if (True == x139973623518439) {
-Obj x139973623518919 = PRIM_CDR(x1);
-Obj x139973623518951 = PRIM_CAR(x139973623518919);
-Obj x = x139973623518951;
-Obj x139973623519623 = PRIM_CDR(x1);
-Obj x139973623519655 = PRIM_CDR(x139973623519623);
-Obj x139973623519687 = PRIM_EQ(Nil, x139973623519655);
-if (True == x139973623519687) {
+Obj x139731070517095 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
+Obj x139731070377479 = PRIM_ISCONS(x1);
+if (True == x139731070377479) {
+Obj x139731070362087 = PRIM_CAR(x1);
+Obj x139731070362119 = PRIM_EQ(sym_37global, x139731070362087);
+if (True == x139731070362119) {
+Obj x139731070362951 = PRIM_CDR(x1);
+Obj x139731070363111 = PRIM_ISCONS(x139731070362951);
+if (True == x139731070363111) {
+Obj x139731070363911 = PRIM_CDR(x1);
+Obj x139731070364039 = PRIM_CAR(x139731070363911);
+Obj x = x139731070364039;
+Obj x139731070033959 = PRIM_CDR(x1);
+Obj x139731070034023 = PRIM_CDR(x139731070033959);
+Obj x139731070034055 = PRIM_EQ(Nil, x139731070034023);
+if (True == x139731070034055) {
 pushCont(co, 29, clofun3, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4229,7 +4227,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624684615;
+__arg0 = x139731070517095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4238,7 +4236,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624684615;
+__arg0 = x139731070517095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4247,7 +4245,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624684615;
+__arg0 = x139731070517095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4256,7 +4254,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624684615;
+__arg0 = x139731070517095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4268,7 +4266,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139973623472423 = __arg1;
+Obj x139731070034791 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 30, clofun3, 1, w);
@@ -4285,7 +4283,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973623472711 = __arg1;
+Obj x139731070035239 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4300,22 +4298,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973624685127 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973623578887 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973623578887) {
-Obj x139973623579367 = PRIM_CAR(closureRef(co, 2));
-Obj x139973623579399 = PRIM_EQ(sym_37closure_45ref, x139973623579367);
-if (True == x139973623579399) {
-Obj x139973623579911 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623579943 = PRIM_ISCONS(x139973623579911);
-if (True == x139973623579943) {
-Obj x139973623580391 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623580423 = PRIM_CAR(x139973623580391);
-Obj idx = x139973623580423;
-Obj x139973623581127 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623581159 = PRIM_CDR(x139973623581127);
-Obj x139973623581191 = PRIM_EQ(Nil, x139973623581159);
-if (True == x139973623581191) {
+Obj x139731070374247 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067803687 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731067803687) {
+Obj x139731070513223 = PRIM_CAR(closureRef(co, 2));
+Obj x139731070513255 = PRIM_EQ(sym_37closure_45ref, x139731070513223);
+if (True == x139731070513255) {
+Obj x139731070514503 = PRIM_CDR(closureRef(co, 2));
+Obj x139731070514535 = PRIM_ISCONS(x139731070514503);
+if (True == x139731070514535) {
+Obj x139731070515495 = PRIM_CDR(closureRef(co, 2));
+Obj x139731070515527 = PRIM_CAR(x139731070515495);
+Obj idx = x139731070515527;
+Obj x139731070516455 = PRIM_CDR(closureRef(co, 2));
+Obj x139731070516487 = PRIM_CDR(x139731070516455);
+Obj x139731070516551 = PRIM_EQ(Nil, x139731070516487);
+if (True == x139731070516551) {
 pushCont(co, 32, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4328,7 +4326,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624685127;
+__arg0 = x139731070374247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4337,7 +4335,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685127;
+__arg0 = x139731070374247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4346,7 +4344,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685127;
+__arg0 = x139731070374247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4355,7 +4353,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685127;
+__arg0 = x139731070374247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4366,7 +4364,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973623581511 = __arg1;
+Obj x139731070516999 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun3);
 __nargs = 3;
@@ -4382,7 +4380,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973623581831 = __arg1;
+Obj x139731070374151 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4396,22 +4394,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973624685639 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973623648807 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973623648807) {
-Obj x139973623649351 = PRIM_CAR(closureRef(co, 2));
-Obj x139973623649383 = PRIM_EQ(sym_37stack_45ref, x139973623649351);
-if (True == x139973623649383) {
-Obj x139973623649831 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623649863 = PRIM_ISCONS(x139973623649831);
-if (True == x139973623649863) {
-Obj x139973623650279 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623650311 = PRIM_CAR(x139973623650279);
-Obj idx = x139973623650311;
-Obj x139973623650919 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623650951 = PRIM_CDR(x139973623650919);
-Obj x139973623650983 = PRIM_EQ(Nil, x139973623650951);
-if (True == x139973623650983) {
+Obj x139731070374823 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067836967 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731067836967) {
+Obj x139731067837415 = PRIM_CAR(closureRef(co, 2));
+Obj x139731067837447 = PRIM_EQ(sym_37stack_45ref, x139731067837415);
+if (True == x139731067837447) {
+Obj x139731067837863 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067837895 = PRIM_ISCONS(x139731067837863);
+if (True == x139731067837895) {
+Obj x139731067838311 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067838343 = PRIM_CAR(x139731067838311);
+Obj idx = x139731067838343;
+Obj x139731067802087 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067802119 = PRIM_CDR(x139731067802087);
+Obj x139731067802151 = PRIM_EQ(Nil, x139731067802119);
+if (True == x139731067802151) {
 pushCont(co, 35, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4424,7 +4422,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624685639;
+__arg0 = x139731070374823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4433,7 +4431,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685639;
+__arg0 = x139731070374823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4442,7 +4440,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685639;
+__arg0 = x139731070374823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4451,7 +4449,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624685639;
+__arg0 = x139731070374823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4462,7 +4460,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973623651271 = __arg1;
+Obj x139731067802439 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 36, clofun3);
 __nargs = 3;
@@ -4478,7 +4476,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973623651559 = __arg1;
+Obj x139731067802727 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4492,24 +4490,24 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973624686183 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139973623673063 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973623673063) {
-Obj x139973623673607 = PRIM_CAR(closureRef(co, 2));
-Obj x139973623673671 = PRIM_EQ(sym_37const, x139973623673607);
-if (True == x139973623673671) {
-Obj x139973623674215 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623674279 = PRIM_ISCONS(x139973623674215);
-if (True == x139973623674279) {
-Obj x139973623674727 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623674759 = PRIM_CAR(x139973623674727);
-Obj x = x139973623674759;
-Obj x139973623675463 = PRIM_CDR(closureRef(co, 2));
-Obj x139973623675495 = PRIM_CDR(x139973623675463);
-Obj x139973623675527 = PRIM_EQ(Nil, x139973623675495);
-if (True == x139973623675527) {
-Obj x139973623676007 = primIsSymbol(x);
-if (True == x139973623676007) {
+Obj x139731070375335 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139731067907399 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731067907399) {
+Obj x139731067907847 = PRIM_CAR(closureRef(co, 2));
+Obj x139731067907879 = PRIM_EQ(sym_37const, x139731067907847);
+if (True == x139731067907879) {
+Obj x139731067859143 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067859175 = PRIM_ISCONS(x139731067859143);
+if (True == x139731067859175) {
+Obj x139731067859591 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067859623 = PRIM_CAR(x139731067859591);
+Obj x = x139731067859623;
+Obj x139731067860231 = PRIM_CDR(closureRef(co, 2));
+Obj x139731067860263 = PRIM_CDR(x139731067860231);
+Obj x139731067860295 = PRIM_EQ(Nil, x139731067860263);
+if (True == x139731067860295) {
+Obj x139731067860551 = primIsSymbol(x);
+if (True == x139731067860551) {
 pushCont(co, 44, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4533,7 +4531,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686183;
+__arg0 = x139731070375335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4542,7 +4540,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686183;
+__arg0 = x139731070375335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4551,7 +4549,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686183;
+__arg0 = x139731070375335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4560,7 +4558,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686183;
+__arg0 = x139731070375335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4571,9 +4569,9 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973623676839 = __arg1;
+Obj x139731067861287 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139973623676839) {
+if (True == x139731067861287) {
 pushCont(co, 42, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4585,8 +4583,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623665607 = primIsString(x);
-if (True == x139973623665607) {
+Obj x139731067862311 = primIsString(x);
+if (True == x139731067862311) {
 pushCont(co, 39, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4598,8 +4596,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623667015 = PRIM_EQ(x, Nil);
-if (True == x139973623667015) {
+Obj x139731067834887 = PRIM_EQ(x, Nil);
+if (True == x139731067834887) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4610,8 +4608,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623667527 = PRIM_EQ(x, True);
-if (True == x139973623667527) {
+Obj x139731067835367 = PRIM_EQ(x, True);
+if (True == x139731067835367) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4622,8 +4620,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623668039 = PRIM_EQ(x, False);
-if (True == x139973623668039) {
+Obj x139731067835847 = PRIM_EQ(x, False);
+if (True == x139731067835847) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4651,7 +4649,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973623665927 = __arg1;
+Obj x139731067862599 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun3);
 __nargs = 2;
@@ -4666,12 +4664,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973623666439 = __arg1;
+Obj x139731067834375 = __arg1;
 PUSH_CONT_0(co, 41, clofun3);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = x139973623666439;
+__arg2 = x139731067834375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4681,7 +4679,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139973623666503 = __arg1;
+Obj x139731067834407 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4695,7 +4693,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973623664871 = __arg1;
+Obj x139731067861575 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun3);
 __nargs = 3;
@@ -4711,7 +4709,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973623665159 = __arg1;
+Obj x139731067861863 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4725,7 +4723,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973623676327 = __arg1;
+Obj x139731067860839 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
@@ -4740,42 +4738,42 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973624686695 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973624002503 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624002503) {
-Obj x139973624003303 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624003431 = PRIM_EQ(symlet, x139973624003303);
-if (True == x139973624003431) {
-Obj x139973624004167 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624004199 = PRIM_ISCONS(x139973624004167);
-if (True == x139973624004199) {
-Obj x139973623730471 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623730503 = PRIM_CAR(x139973623730471);
-Obj a = x139973623730503;
-Obj x139973623731303 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623731335 = PRIM_CDR(x139973623731303);
-Obj x139973623731527 = PRIM_ISCONS(x139973623731335);
-if (True == x139973623731527) {
-Obj x139973623732135 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623732167 = PRIM_CDR(x139973623732135);
-Obj x139973623732391 = PRIM_CAR(x139973623732167);
-Obj b = x139973623732391;
-Obj x139973623733351 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623733447 = PRIM_CDR(x139973623733351);
-Obj x139973623733479 = PRIM_CDR(x139973623733447);
-Obj x139973623733511 = PRIM_ISCONS(x139973623733479);
-if (True == x139973623733511) {
-Obj x139973623685703 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623685735 = PRIM_CDR(x139973623685703);
-Obj x139973623685767 = PRIM_CDR(x139973623685735);
-Obj x139973623685799 = PRIM_CAR(x139973623685767);
-Obj c = x139973623685799;
-Obj x139973623686919 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623686951 = PRIM_CDR(x139973623686919);
-Obj x139973623686983 = PRIM_CDR(x139973623686951);
-Obj x139973623687015 = PRIM_CDR(x139973623686983);
-Obj x139973623687047 = PRIM_EQ(Nil, x139973623687015);
-if (True == x139973623687047) {
+Obj x139731070375911 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731067954535 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731067954535) {
+Obj x139731067955015 = PRIM_CAR(closureRef(co, 0));
+Obj x139731067955079 = PRIM_EQ(symlet, x139731067955015);
+if (True == x139731067955079) {
+Obj x139731067955495 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067955527 = PRIM_ISCONS(x139731067955495);
+if (True == x139731067955527) {
+Obj x139731067956039 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067956071 = PRIM_CAR(x139731067956039);
+Obj a = x139731067956071;
+Obj x139731067956743 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067956775 = PRIM_CDR(x139731067956743);
+Obj x139731067956807 = PRIM_ISCONS(x139731067956775);
+if (True == x139731067956807) {
+Obj x139731067932839 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067932871 = PRIM_CDR(x139731067932839);
+Obj x139731067932903 = PRIM_CAR(x139731067932871);
+Obj b = x139731067932903;
+Obj x139731067933831 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067933863 = PRIM_CDR(x139731067933831);
+Obj x139731067933895 = PRIM_CDR(x139731067933863);
+Obj x139731067933927 = PRIM_ISCONS(x139731067933895);
+if (True == x139731067933927) {
+Obj x139731067934663 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067934695 = PRIM_CDR(x139731067934663);
+Obj x139731067934727 = PRIM_CDR(x139731067934695);
+Obj x139731067934759 = PRIM_CAR(x139731067934727);
+Obj c = x139731067934759;
+Obj x139731067935783 = PRIM_CDR(closureRef(co, 0));
+Obj x139731067935815 = PRIM_CDR(x139731067935783);
+Obj x139731067935847 = PRIM_CDR(x139731067935815);
+Obj x139731067935943 = PRIM_CDR(x139731067935847);
+Obj x139731067935975 = PRIM_EQ(Nil, x139731067935943);
+if (True == x139731067935975) {
 pushCont(co, 46, clofun3, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -4788,7 +4786,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4797,7 +4795,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4806,7 +4804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4815,7 +4813,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4824,7 +4822,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4833,7 +4831,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686695;
+__arg0 = x139731070375911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4844,13 +4842,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139973623687367 = __arg1;
+Obj x139731067936295 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj idx = x139973623687367;
-Obj x139973623687815 = PRIM_LT(idx, MAKE_NUMBER(0));
-if (True == x139973623687815) {
+Obj idx = x139731067936295;
+Obj x139731067936679 = PRIM_LT(idx, MAKE_NUMBER(0));
+if (True == x139731067936679) {
 pushCont(co, 1, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4878,7 +4876,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139973623682375 = __arg1;
+Obj x139731067930951 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4896,7 +4894,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973623682695 = __arg1;
+Obj x139731067931271 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4916,7 +4914,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973623683239 = __arg1;
+Obj x139731067931655 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 0, clofun4, 2, a, c);
@@ -4953,14 +4951,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973623683559 = __arg1;
+Obj x139731067905895 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623684007 = makeCons(a, closureRef(co, 2));
+Obj x139731067906311 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = x139973623684007;
+__arg2 = x139731067906311;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -4972,7 +4970,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973623688103 = __arg1;
+Obj x139731067928743 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4990,7 +4988,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139973623688423 = __arg1;
+Obj x139731067929063 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5008,7 +5006,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973623688807 = __arg1;
+Obj x139731067929383 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5028,7 +5026,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973623681191 = __arg1;
+Obj x139731067929767 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 5, clofun4, 2, a, c);
@@ -5045,14 +5043,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973623681511 = __arg1;
+Obj x139731067930087 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623681959 = makeCons(a, closureRef(co, 2));
+Obj x139731067930567 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = x139973623681959;
+__arg2 = x139731067930567;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -5064,31 +5062,31 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973624687687 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973624276487 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624276487) {
-Obj x139973624277319 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624277351 = PRIM_ISCONS(x139973624277319);
-if (True == x139973624277351) {
-Obj x139973624278119 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624278151 = PRIM_CAR(x139973624278119);
-Obj x139973624278311 = PRIM_EQ(sym_37builtin, x139973624278151);
-if (True == x139973624278311) {
-Obj x139973624222119 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624222151 = PRIM_CDR(x139973624222119);
-Obj x139973624222183 = PRIM_ISCONS(x139973624222151);
-if (True == x139973624222183) {
-Obj x139973624223655 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624223687 = PRIM_CDR(x139973624223655);
-Obj x139973624223751 = PRIM_CAR(x139973624223687);
-Obj f = x139973624223751;
-Obj x139973624225063 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624225159 = PRIM_CDR(x139973624225063);
-Obj x139973624225191 = PRIM_CDR(x139973624225159);
-Obj x139973624225223 = PRIM_EQ(Nil, x139973624225191);
-if (True == x139973624225223) {
-Obj x139973624078471 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139973624078471;
+Obj x139731070376935 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731068683719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068683719) {
+Obj x139731068684359 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068684391 = PRIM_ISCONS(x139731068684359);
+if (True == x139731068684391) {
+Obj x139731068685063 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068685095 = PRIM_CAR(x139731068685063);
+Obj x139731068685159 = PRIM_EQ(sym_37builtin, x139731068685095);
+if (True == x139731068685159) {
+Obj x139731068685767 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068685799 = PRIM_CDR(x139731068685767);
+Obj x139731068685831 = PRIM_ISCONS(x139731068685799);
+if (True == x139731068685831) {
+Obj x139731068551463 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068551495 = PRIM_CDR(x139731068551463);
+Obj x139731068551527 = PRIM_CAR(x139731068551495);
+Obj f = x139731068551527;
+Obj x139731068552455 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068552487 = PRIM_CDR(x139731068552455);
+Obj x139731068552519 = PRIM_CDR(x139731068552487);
+Obj x139731068552551 = PRIM_EQ(Nil, x139731068552519);
+if (True == x139731068552551) {
+Obj x139731068552807 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139731068552807;
 pushCont(co, 7, clofun4, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62name);
@@ -5100,7 +5098,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624687687;
+__arg0 = x139731070376935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5109,7 +5107,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687687;
+__arg0 = x139731070376935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5118,7 +5116,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687687;
+__arg0 = x139731070376935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5127,7 +5125,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687687;
+__arg0 = x139731070376935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5136,7 +5134,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687687;
+__arg0 = x139731070376935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5147,14 +5145,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973624079303 = __arg1;
+Obj x139731068553511 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 8, clofun4, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = x139973624079303;
+__arg2 = x139731068553511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5164,11 +5162,11 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973624079335 = __arg1;
+Obj x139731068553543 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624079815 = PRIM_EQ(f, symset);
-if (True == x139973624079815) {
+Obj x139731068553959 = PRIM_EQ(f, symset);
+if (True == x139731068553959) {
 pushCont(co, 11, clofun4, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5195,7 +5193,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973624081703 = __arg1;
+Obj x139731068555015 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 10, clofun4);
 __nargs = 5;
@@ -5213,7 +5211,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973624000647 = __arg1;
+Obj x139731067953287 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5227,7 +5225,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139973624080071 = __arg1;
+Obj x139731068554183 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 12, clofun4);
 __nargs = 5;
@@ -5245,7 +5243,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973624081223 = __arg1;
+Obj x139731068554567 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5259,42 +5257,42 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973624688423 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973624518407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624518407) {
-Obj x139973624519239 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624519271 = PRIM_EQ(symif, x139973624519239);
-if (True == x139973624519271) {
-Obj x139973624520199 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624520231 = PRIM_ISCONS(x139973624520199);
-if (True == x139973624520231) {
-Obj x139973624414343 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624414375 = PRIM_CAR(x139973624414343);
-Obj a = x139973624414375;
-Obj x139973624415399 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624415431 = PRIM_CDR(x139973624415399);
-Obj x139973624415495 = PRIM_ISCONS(x139973624415431);
-if (True == x139973624415495) {
-Obj x139973624416871 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624416903 = PRIM_CDR(x139973624416871);
-Obj x139973624416967 = PRIM_CAR(x139973624416903);
-Obj b = x139973624416967;
-Obj x139973624418151 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624418183 = PRIM_CDR(x139973624418151);
-Obj x139973624373319 = PRIM_CDR(x139973624418183);
-Obj x139973624373351 = PRIM_ISCONS(x139973624373319);
-if (True == x139973624373351) {
-Obj x139973624374663 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624374695 = PRIM_CDR(x139973624374663);
-Obj x139973624374727 = PRIM_CDR(x139973624374695);
-Obj x139973624374823 = PRIM_CAR(x139973624374727);
-Obj c = x139973624374823;
-Obj x139973624376711 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624376743 = PRIM_CDR(x139973624376711);
-Obj x139973624376775 = PRIM_CDR(x139973624376743);
-Obj x139973624376807 = PRIM_CDR(x139973624376775);
-Obj x139973624377287 = PRIM_EQ(Nil, x139973624376807);
-if (True == x139973624377287) {
+Obj x139731070377703 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731068748199 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068748199) {
+Obj x139731068749031 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068749095 = PRIM_EQ(symif, x139731068749031);
+if (True == x139731068749095) {
+Obj x139731068749767 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068749799 = PRIM_ISCONS(x139731068749767);
+if (True == x139731068749799) {
+Obj x139731068750503 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068750535 = PRIM_CAR(x139731068750503);
+Obj a = x139731068750535;
+Obj x139731068751335 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068751367 = PRIM_CDR(x139731068751335);
+Obj x139731068751399 = PRIM_ISCONS(x139731068751367);
+if (True == x139731068751399) {
+Obj x139731068736103 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068736135 = PRIM_CDR(x139731068736103);
+Obj x139731068736167 = PRIM_CAR(x139731068736135);
+Obj b = x139731068736167;
+Obj x139731068737479 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068737511 = PRIM_CDR(x139731068737479);
+Obj x139731068737543 = PRIM_CDR(x139731068737511);
+Obj x139731068737639 = PRIM_ISCONS(x139731068737543);
+if (True == x139731068737639) {
+Obj x139731068738823 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068738951 = PRIM_CDR(x139731068738823);
+Obj x139731068738983 = PRIM_CDR(x139731068738951);
+Obj x139731068739111 = PRIM_CAR(x139731068738983);
+Obj c = x139731068739111;
+Obj x139731068687271 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068687303 = PRIM_CDR(x139731068687271);
+Obj x139731068687367 = PRIM_CDR(x139731068687303);
+Obj x139731068687591 = PRIM_CDR(x139731068687367);
+Obj x139731068687623 = PRIM_EQ(Nil, x139731068687591);
+if (True == x139731068687623) {
 pushCont(co, 14, clofun4, 3, a, b, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5307,7 +5305,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5316,7 +5314,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5325,7 +5323,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5334,7 +5332,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5343,7 +5341,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5352,7 +5350,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624688423;
+__arg0 = x139731070377703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5363,7 +5361,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973624340775 = __arg1;
+Obj x139731068687943 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5383,7 +5381,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973624341447 = __arg1;
+Obj x139731068688519 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 16, clofun4, 2, b, c);
@@ -5400,7 +5398,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973624341767 = __arg1;
+Obj x139731068688903 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 17, clofun4, 1, c);
@@ -5419,7 +5417,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973624342855 = __arg1;
+Obj x139731068689415 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun4, 1, c);
 __nargs = 3;
@@ -5435,7 +5433,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973624343303 = __arg1;
+Obj x139731068689959 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 19, clofun4);
 __nargs = 5;
@@ -5453,7 +5451,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624344135 = __arg1;
+Obj x139731068690343 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5467,30 +5465,30 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973624640231 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973624847399 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624847399) {
-Obj x139973624848167 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624848263 = PRIM_EQ(sym_37closure, x139973624848167);
-if (True == x139973624848263) {
-Obj x139973624685255 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624685287 = PRIM_ISCONS(x139973624685255);
-if (True == x139973624685287) {
-Obj x139973624685895 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624686087 = PRIM_CAR(x139973624685895);
-Obj label = x139973624686087;
-Obj x139973624686951 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624686983 = PRIM_CDR(x139973624686951);
-Obj x139973624687015 = PRIM_ISCONS(x139973624686983);
-if (True == x139973624687015) {
-Obj x139973624687879 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624688039 = PRIM_CDR(x139973624687879);
-Obj x139973624688071 = PRIM_CAR(x139973624688039);
-Obj nargs = x139973624688071;
-Obj x139973624639943 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624639975 = PRIM_CDR(x139973624639943);
-Obj x139973624640007 = PRIM_CDR(x139973624639975);
-Obj frees = x139973624640007;
+Obj x139731070362375 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731068850791 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068850791) {
+Obj x139731068851687 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068851719 = PRIM_EQ(sym_37closure, x139731068851687);
+if (True == x139731068851719) {
+Obj x139731068852327 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068852455 = PRIM_ISCONS(x139731068852327);
+if (True == x139731068852455) {
+Obj x139731068853063 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068853095 = PRIM_CAR(x139731068853063);
+Obj label = x139731068853095;
+Obj x139731068854183 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068854215 = PRIM_CDR(x139731068854183);
+Obj x139731068833799 = PRIM_ISCONS(x139731068854215);
+if (True == x139731068833799) {
+Obj x139731068834791 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068834855 = PRIM_CDR(x139731068834791);
+Obj x139731068834983 = PRIM_CAR(x139731068834855);
+Obj nargs = x139731068834983;
+Obj x139731068836263 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068836295 = PRIM_CDR(x139731068836263);
+Obj x139731068836327 = PRIM_CDR(x139731068836295);
+Obj frees = x139731068836327;
 pushCont(co, 21, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5503,7 +5501,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624640231;
+__arg0 = x139731070362375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5512,7 +5510,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640231;
+__arg0 = x139731070362375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5521,7 +5519,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640231;
+__arg0 = x139731070362375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5530,7 +5528,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640231;
+__arg0 = x139731070362375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5541,16 +5539,16 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973624640583 = __arg1;
+Obj x139731068836839 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624641895 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624642087 = PRIM_SUB(x139973624641895, label);
+Obj x139731068825703 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068825959 = PRIM_SUB(x139731068825703, label);
 pushCont(co, 22, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139973624642087;
+__arg1 = x139731068825959;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5561,7 +5559,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973624642151 = __arg1;
+Obj x139731068826279 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5569,7 +5567,7 @@ pushCont(co, 23, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = x139973624642151;
+__arg2 = x139731068826279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5579,7 +5577,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973624642183 = __arg1;
+Obj x139731068826311 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5597,17 +5595,17 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973624642919 = __arg1;
+Obj x139731068826663 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624529063 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068827847 = PRIM_CAR(closureRef(co, 1));
 pushCont(co, 25, clofun4, 2, nargs, frees);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
 __arg2 = label;
-__arg3 = x139973624529063;
+__arg3 = x139731068827847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5617,7 +5615,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973624529095 = __arg1;
+Obj x139731068827879 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 26, clofun4, 2, nargs, frees);
@@ -5634,7 +5632,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973624529543 = __arg1;
+Obj x139731068828327 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 27, clofun4, 1, frees);
@@ -5651,7 +5649,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973624530023 = __arg1;
+Obj x139731068828839 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun4, 1, frees);
 __nargs = 3;
@@ -5667,7 +5665,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139973624530311 = __arg1;
+Obj x139731068829319 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun4, 1, frees);
 __nargs = 2;
@@ -5682,13 +5680,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139973624531175 = __arg1;
+Obj x139731068817799 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = x139973624531175;
+__arg2 = x139731068817799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5698,7 +5696,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973624531207 = __arg1;
+Obj x139731068817831 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun4, 1, frees);
 __nargs = 2;
@@ -5713,10 +5711,10 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973624532039 = __arg1;
+Obj x139731068818791 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624532071 = primNot(x139973624532039);
-if (True == x139973624532071) {
+Obj x139731068818823 = primNot(x139731068818791);
+if (True == x139731068818823) {
 pushCont(co, 32, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5743,7 +5741,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973624532583 = __arg1;
+Obj x139731068819271 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun4);
 __nargs = 5;
@@ -5761,7 +5759,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973624532871 = __arg1;
+Obj x139731068819943 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5775,31 +5773,31 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973624640999 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139973624914919 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624914919) {
-Obj x139973624915879 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624915975 = PRIM_EQ(symdo, x139973624915879);
-if (True == x139973624915975) {
-Obj x139973624916583 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624916615 = PRIM_ISCONS(x139973624916583);
-if (True == x139973624916615) {
-Obj x139973624917351 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624917383 = PRIM_CAR(x139973624917351);
-Obj a = x139973624917383;
-Obj x139973624889991 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624890023 = PRIM_CDR(x139973624889991);
-Obj x139973624890055 = PRIM_ISCONS(x139973624890023);
-if (True == x139973624890055) {
-Obj x139973624890919 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624890951 = PRIM_CDR(x139973624890919);
-Obj x139973624891175 = PRIM_CAR(x139973624890951);
-Obj b = x139973624891175;
-Obj x139973624892679 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624892711 = PRIM_CDR(x139973624892679);
-Obj x139973624892743 = PRIM_CDR(x139973624892711);
-Obj x139973624892775 = PRIM_EQ(Nil, x139973624892743);
-if (True == x139973624892775) {
+Obj x139731070363271 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139731068898311 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068898311) {
+Obj x139731068898951 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068898983 = PRIM_EQ(symdo, x139731068898951);
+if (True == x139731068898983) {
+Obj x139731068891687 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068891719 = PRIM_ISCONS(x139731068891687);
+if (True == x139731068891719) {
+Obj x139731068892583 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068892615 = PRIM_CAR(x139731068892583);
+Obj a = x139731068892615;
+Obj x139731068893703 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068893863 = PRIM_CDR(x139731068893703);
+Obj x139731068893895 = PRIM_ISCONS(x139731068893863);
+if (True == x139731068893895) {
+Obj x139731068895079 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068895111 = PRIM_CDR(x139731068895079);
+Obj x139731068887047 = PRIM_CAR(x139731068895111);
+Obj b = x139731068887047;
+Obj x139731068888199 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068888231 = PRIM_CDR(x139731068888199);
+Obj x139731068888263 = PRIM_CDR(x139731068888231);
+Obj x139731068888615 = PRIM_EQ(Nil, x139731068888263);
+if (True == x139731068888615) {
 pushCont(co, 35, clofun4, 1, b);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5814,7 +5812,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624640999;
+__arg0 = x139731070363271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5823,7 +5821,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640999;
+__arg0 = x139731070363271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5832,7 +5830,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640999;
+__arg0 = x139731070363271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5841,7 +5839,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640999;
+__arg0 = x139731070363271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5850,7 +5848,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640999;
+__arg0 = x139731070363271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5861,7 +5859,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973624844423 = __arg1;
+Obj x139731068889127 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 36, clofun4, 1, b);
 __nargs = 3;
@@ -5877,7 +5875,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973624845351 = __arg1;
+Obj x139731068889735 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5894,22 +5892,22 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973624641735 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139973625789159 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625789159) {
-Obj x139973625789895 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625789927 = PRIM_EQ(symreturn, x139973625789895);
-if (True == x139973625789927) {
-Obj x139973625028775 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625028839 = PRIM_ISCONS(x139973625028775);
-if (True == x139973625028839) {
-Obj x139973625029735 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625029799 = PRIM_CAR(x139973625029735);
-Obj x = x139973625029799;
-Obj x139973625030759 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625030823 = PRIM_CDR(x139973625030759);
-Obj x139973625030855 = PRIM_EQ(Nil, x139973625030823);
-if (True == x139973625030855) {
+Obj x139731070364103 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139731069387751 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069387751) {
+Obj x139731069388487 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069388519 = PRIM_EQ(symreturn, x139731069388487);
+if (True == x139731069388519) {
+Obj x139731069389159 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069389191 = PRIM_ISCONS(x139731069389159);
+if (True == x139731069389191) {
+Obj x139731069389767 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069390087 = PRIM_CAR(x139731069389767);
+Obj x = x139731069390087;
+Obj x139731069042855 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069042887 = PRIM_CDR(x139731069042855);
+Obj x139731069042919 = PRIM_EQ(Nil, x139731069042887);
+if (True == x139731069042919) {
 pushCont(co, 38, clofun4, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5922,7 +5920,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624641735;
+__arg0 = x139731070364103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5931,7 +5929,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624641735;
+__arg0 = x139731070364103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5940,7 +5938,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624641735;
+__arg0 = x139731070364103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5949,7 +5947,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624641735;
+__arg0 = x139731070364103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5960,7 +5958,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973625031335 = __arg1;
+Obj x139731069043303 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 39, clofun4, 1, x);
 __nargs = 3;
@@ -5976,7 +5974,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973625032039 = __arg1;
+Obj x139731069043687 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun4);
 __nargs = 5;
@@ -5994,7 +5992,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973625032647 = __arg1;
+Obj x139731069044231 = __arg1;
 PUSH_CONT_0(co, 41, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6009,7 +6007,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139973625012743 = __arg1;
+Obj x139731069044935 = __arg1;
 PUSH_CONT_0(co, 42, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6024,7 +6022,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973625013287 = __arg1;
+Obj x139731069045255 = __arg1;
 PUSH_CONT_0(co, 43, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6039,15 +6037,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973625013703 = __arg1;
-Obj x139973625014727 = PRIM_CDR(closureRef(co, 2));
-Obj x139973625014951 = PRIM_CAR(closureRef(co, 2));
+Obj x139731069045735 = __arg1;
+Obj x139731069046567 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068895335 = PRIM_CAR(closureRef(co, 2));
 PUSH_CONT_0(co, 44, clofun4);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
-__arg2 = x139973625014727;
-__arg3 = x139973625014951;
+__arg2 = x139731069046567;
+__arg3 = x139731068895335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6057,7 +6055,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973625015015 = __arg1;
+Obj x139731068895367 = __arg1;
 PUSH_CONT_0(co, 45, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6072,7 +6070,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973625015783 = __arg1;
+Obj x139731068895751 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6086,22 +6084,22 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139973624642247 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139973625854471 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625854471) {
-Obj x139973625855239 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625855271 = PRIM_EQ(symtailcall, x139973625855239);
-if (True == x139973625855271) {
-Obj x139973625855847 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625855911 = PRIM_ISCONS(x139973625855847);
-if (True == x139973625855911) {
-Obj x139973625823815 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625823911 = PRIM_CAR(x139973625823815);
-Obj exp = x139973625823911;
-Obj x139973625825127 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625825159 = PRIM_CDR(x139973625825127);
-Obj x139973625825351 = PRIM_EQ(Nil, x139973625825159);
-if (True == x139973625825351) {
+Obj x139731070364679 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139731069931271 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069931271) {
+Obj x139731069551207 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069551335 = PRIM_EQ(symtailcall, x139731069551207);
+if (True == x139731069551335) {
+Obj x139731069551911 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069551943 = PRIM_ISCONS(x139731069551911);
+if (True == x139731069551943) {
+Obj x139731069552871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069552903 = PRIM_CAR(x139731069552871);
+Obj exp = x139731069552903;
+Obj x139731069554023 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069554055 = PRIM_CDR(x139731069554023);
+Obj x139731069554087 = PRIM_EQ(Nil, x139731069554055);
+if (True == x139731069554087) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6115,7 +6113,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624642247;
+__arg0 = x139731070364679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6124,7 +6122,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642247;
+__arg0 = x139731070364679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6133,7 +6131,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642247;
+__arg0 = x139731070364679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6142,7 +6140,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642247;
+__arg0 = x139731070364679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6153,31 +6151,31 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139973624642791 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139973623517895 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623517895) {
-Obj x139973623518343 = PRIM_CAR(closureRef(co, 0));
-Obj x139973623518375 = PRIM_EQ(symcall, x139973623518343);
-if (True == x139973623518375) {
-Obj x139973623518791 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623518823 = PRIM_ISCONS(x139973623518791);
-if (True == x139973623518823) {
-Obj x139973623519239 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623519271 = PRIM_CAR(x139973623519239);
-Obj exp = x139973623519271;
-Obj x139973623519847 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623519879 = PRIM_CDR(x139973623519847);
-Obj x139973623519911 = PRIM_ISCONS(x139973623519879);
-if (True == x139973623519911) {
-Obj x139973623520487 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623520519 = PRIM_CDR(x139973623520487);
-Obj x139973623520551 = PRIM_CAR(x139973623520519);
-Obj cont = x139973623520551;
-Obj x139973623472167 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623472199 = PRIM_CDR(x139973623472167);
-Obj x139973623472231 = PRIM_CDR(x139973623472199);
-Obj x139973623472263 = PRIM_EQ(Nil, x139973623472231);
-if (True == x139973623472263) {
+Obj x139731070365223 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139731070037031 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070037031) {
+Obj x139731069960295 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069960327 = PRIM_EQ(symcall, x139731069960295);
+if (True == x139731069960327) {
+Obj x139731069960903 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069960967 = PRIM_ISCONS(x139731069960903);
+if (True == x139731069960967) {
+Obj x139731069961895 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069961959 = PRIM_CAR(x139731069961895);
+Obj exp = x139731069961959;
+Obj x139731069962823 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069962887 = PRIM_CDR(x139731069962823);
+Obj x139731069963015 = PRIM_ISCONS(x139731069962887);
+if (True == x139731069963015) {
+Obj x139731069964135 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069964167 = PRIM_CDR(x139731069964135);
+Obj x139731069964199 = PRIM_CAR(x139731069964167);
+Obj cont = x139731069964199;
+Obj x139731069928583 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069928615 = PRIM_CDR(x139731069928583);
+Obj x139731069928647 = PRIM_CDR(x139731069928615);
+Obj x139731069928679 = PRIM_EQ(Nil, x139731069928647);
+if (True == x139731069928679) {
 pushCont(co, 48, clofun4, 1, exp);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45cont);
@@ -6191,7 +6189,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624642791;
+__arg0 = x139731070365223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6200,7 +6198,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642791;
+__arg0 = x139731070365223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6209,7 +6207,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642791;
+__arg0 = x139731070365223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6218,7 +6216,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642791;
+__arg0 = x139731070365223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6227,7 +6225,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624642791;
+__arg0 = x139731070365223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6238,7 +6236,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973625852199 = __arg1;
+Obj x139731069929383 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -6255,13 +6253,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973624643527 = makeNative(11, clofun5, 0, 0);
-Obj x139973623652071 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623652071) {
-Obj x139973623652327 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139973623652327;
-Obj x139973623578855 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139973623578855;
+Obj x139731070034311 = makeNative(11, clofun5, 0, 0);
+Obj x139731070374183 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070374183) {
+Obj x139731070375015 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139731070375015;
+Obj x139731070375559 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139731070375559;
 pushCont(co, 0, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6274,7 +6272,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624643527;
+__arg0 = x139731070034311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6305,7 +6303,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973623579143 = __arg1;
+Obj x139731070376999 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 1, clofun5, 2, f, args);
@@ -6321,15 +6319,15 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973623579783 = __arg1;
+Obj x139731070361927 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623579815 = PRIM_ADD(MAKE_NUMBER(1), x139973623579783);
+Obj x139731070361959 = PRIM_ADD(MAKE_NUMBER(1), x139731070361927);
 pushCont(co, 2, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 2);
-__arg2 = x139973623579815;
+__arg2 = x139731070361959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6339,7 +6337,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139973623579847 = __arg1;
+Obj x139731070361991 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 3, clofun5, 2, f, args);
@@ -6356,17 +6354,17 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973623580135 = __arg1;
+Obj x139731070362439 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623580679 = makeCons(f, args);
+Obj x139731070363527 = makeCons(f, args);
 PUSH_CONT_0(co, 4, clofun5);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = MAKE_NUMBER(0);
-co->args[4] = x139973623580679;
+co->args[4] = x139731070363527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6376,7 +6374,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973623580711 = __arg1;
+Obj x139731070363559 = __arg1;
 PUSH_CONT_0(co, 5, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6391,7 +6389,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973623580999 = __arg1;
+Obj x139731070364455 = __arg1;
 PUSH_CONT_0(co, 6, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6406,7 +6404,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973623581287 = __arg1;
+Obj x139731070364999 = __arg1;
 PUSH_CONT_0(co, 7, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6421,7 +6419,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973623581575 = __arg1;
+Obj x139731070365447 = __arg1;
 PUSH_CONT_0(co, 8, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6436,15 +6434,15 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973623581863 = __arg1;
-Obj x139973623582311 = PRIM_CDR(closureRef(co, 1));
-Obj x139973623582535 = PRIM_CAR(closureRef(co, 1));
+Obj x139731070034343 = __arg1;
+Obj x139731070035143 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070035495 = PRIM_CAR(closureRef(co, 1));
 PUSH_CONT_0(co, 9, clofun5);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 2);
-__arg2 = x139973623582311;
-__arg3 = x139973623582535;
+__arg2 = x139731070035143;
+__arg3 = x139731070035495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6454,7 +6452,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973623582567 = __arg1;
+Obj x139731070035527 = __arg1;
 PUSH_CONT_0(co, 10, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6469,7 +6467,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973623517319 = __arg1;
+Obj x139731070036167 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -6510,10 +6508,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973623648455 = __arg1;
+Obj x139731067904519 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val = x139973623648455;
+Obj val = x139731067904519;
 pushCont(co, 14, clofun5, 3, sym, val, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -6528,21 +6526,21 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973623648743 = __arg1;
+Obj x139731067904807 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139973623648743) {
+if (True == x139731067904807) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139973623649159 = makeCons(sym, val);
-Obj x139973623649191 = primSet(co, globals, x139973623649159);
+Obj x139731067905223 = makeCons(sym, val);
+Obj x139731067905255 = primSet(co, globals, x139731067905223);
 __nargs = 2;
-__arg1 = x139973623649191;
+__arg1 = x139731067905255;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6551,16 +6549,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj x139973624845223 = __arg1;
-Obj x139973624845255 = __arg2;
-Obj x139973624845287 = __arg3;
-Obj x139973624845319 = co->args[4];
-Obj x139973624846023 = makeNative(16, clofun5, 0, 4, x139973624845223, x139973624845255, x139973624845287, x139973624845319);
-Obj self = x139973624845223;
-Obj w = x139973624845255;
-Obj i = x139973624845287;
-Obj x139973623668199 = PRIM_EQ(Nil, x139973624845319);
-if (True == x139973623668199) {
+Obj x139731070513511 = __arg1;
+Obj x139731070513543 = __arg2;
+Obj x139731070513575 = __arg3;
+Obj x139731070513607 = co->args[4];
+Obj x139731070514471 = makeNative(16, clofun5, 0, 4, x139731070513511, x139731070513543, x139731070513575, x139731070513607);
+Obj self = x139731070513511;
+Obj w = x139731070513543;
+Obj i = x139731070513575;
+Obj x139731067932455 = PRIM_EQ(Nil, x139731070513607);
+if (True == x139731067932455) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -6568,7 +6566,7 @@ if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624846023;
+__arg0 = x139731070514471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6579,19 +6577,19 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973624847047 = makeNative(28, clofun5, 0, 0);
+Obj x139731070515559 = makeNative(28, clofun5, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj x139973623684423 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139973623684423) {
-Obj x139973623684743 = PRIM_CAR(closureRef(co, 3));
-Obj x = x139973623684743;
-Obj x139973623684999 = PRIM_CDR(closureRef(co, 3));
-Obj more = x139973623684999;
-Obj x139973623673287 = PRIM_GT(i, MAKE_NUMBER(3));
-Obj x139973623673319 = primNot(x139973623673287);
-if (True == x139973623673319) {
+Obj x139731067934855 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139731067934855) {
+Obj x139731067935111 = PRIM_CAR(closureRef(co, 3));
+Obj x = x139731067935111;
+Obj x139731067935367 = PRIM_CDR(closureRef(co, 3));
+Obj more = x139731067935367;
+Obj x139731067935879 = PRIM_GT(i, MAKE_NUMBER(3));
+Obj x139731067935911 = primNot(x139731067935879);
+if (True == x139731067935911) {
 pushCont(co, 23, clofun5, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6616,7 +6614,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624847047;
+__arg0 = x139731070515559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6627,7 +6625,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973623665671 = __arg1;
+Obj x139731067929927 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6647,7 +6645,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973623665959 = __arg1;
+Obj x139731067930215 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6667,7 +6665,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973623666183 = __arg1;
+Obj x139731067930439 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6687,7 +6685,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973623666471 = __arg1;
+Obj x139731067930727 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6709,7 +6707,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973623666823 = __arg1;
+Obj x139731067931079 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6728,17 +6726,17 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973623667111 = __arg1;
+Obj x139731067931367 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623667559 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139731067931815 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = x139973623667559;
+__arg3 = x139731067931815;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6749,7 +6747,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973623673639 = __arg1;
+Obj x139731067936199 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6769,7 +6767,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973623673927 = __arg1;
+Obj x139731067936423 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6789,7 +6787,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973623674247 = __arg1;
+Obj x139731067936711 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6811,7 +6809,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973623674599 = __arg1;
+Obj x139731067928871 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6830,17 +6828,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973623674887 = __arg1;
+Obj x139731067929159 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139973623675367 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139731067929607 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = x139973623675367;
+__arg3 = x139731067929607;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6865,8 +6863,8 @@ label29:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj x139973623681927 = primGenSym();
-Obj tmp = x139973623681927;
+Obj x139731067957127 = primGenSym();
+Obj tmp = x139731067957127;
 pushCont(co, 30, clofun5, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
@@ -6880,15 +6878,15 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973623682951 = __arg1;
+Obj x139731067933479 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623683015 = makeCons(x139973623682951, Nil);
-Obj x139973623683047 = makeCons(x, x139973623683015);
-Obj x139973623683079 = makeCons(tmp, x139973623683047);
-Obj x139973623683111 = makeCons(symlet, x139973623683079);
+Obj x139731067933543 = makeCons(x139731067933479, Nil);
+Obj x139731067933575 = makeCons(x, x139731067933543);
+Obj x139731067933607 = makeCons(tmp, x139731067933575);
+Obj x139731067933639 = makeCons(symlet, x139731067933607);
 __nargs = 2;
-__arg1 = x139973623683111;
+__arg1 = x139731067933639;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6912,10 +6910,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973623687463 = __arg1;
+Obj x139731067954759 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj idx = x139973623687463;
+Obj idx = x139731067954759;
 pushCont(co, 33, clofun5, 3, val, idx, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -6930,22 +6928,22 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973623687783 = __arg1;
+Obj x139731067955047 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cur = x139973623687783;
-Obj x139973623688519 = makeCons(val, Nil);
-Obj x139973623688551 = makeCons(idx, x139973623688519);
-Obj x139973623688615 = makeCons(x139973623688551, cur);
-Obj cur1 = x139973623688615;
-Obj x139973623681063 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj cur = x139731067955047;
+Obj x139731067955687 = makeCons(val, Nil);
+Obj x139731067955719 = makeCons(idx, x139731067955687);
+Obj x139731067955783 = makeCons(x139731067955719, cur);
+Obj cur1 = x139731067955783;
+Obj x139731067956295 = PRIM_ADD(idx, MAKE_NUMBER(1));
 pushCont(co, 34, clofun5, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
 __arg1 = v;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = x139973623681063;
+__arg3 = x139731067956295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6955,7 +6953,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973623681127 = __arg1;
+Obj x139731067956327 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -6972,60 +6970,60 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973624890727 = __arg1;
-Obj x139973624890759 = __arg2;
-Obj x139973624891143 = makeNative(1, clofun6, 0, 2, x139973624890727, x139973624890759);
-Obj v = x139973624890727;
-Obj x139973624519015 = PRIM_ISCONS(x139973624890759);
-if (True == x139973624519015) {
-Obj x139973624519495 = PRIM_CAR(x139973624890759);
-Obj clo_45or_45cont = x139973624519495;
-Obj x139973624520263 = PRIM_CDR(x139973624890759);
-Obj x139973624520295 = PRIM_ISCONS(x139973624520263);
-if (True == x139973624520295) {
-Obj x139973624414727 = PRIM_CDR(x139973624890759);
-Obj x139973624414759 = PRIM_CAR(x139973624414727);
-Obj x139973624414791 = PRIM_ISCONS(x139973624414759);
-if (True == x139973624414791) {
-Obj x139973624415783 = PRIM_CDR(x139973624890759);
-Obj x139973624415815 = PRIM_CAR(x139973624415783);
-Obj x139973624415847 = PRIM_CAR(x139973624415815);
-Obj x139973624415975 = PRIM_EQ(symlambda, x139973624415847);
-if (True == x139973624415975) {
-Obj x139973624417511 = PRIM_CDR(x139973624890759);
-Obj x139973624417543 = PRIM_CAR(x139973624417511);
-Obj x139973624417607 = PRIM_CDR(x139973624417543);
-Obj x139973624417639 = PRIM_ISCONS(x139973624417607);
-if (True == x139973624417639) {
-Obj x139973624373543 = PRIM_CDR(x139973624890759);
-Obj x139973624373575 = PRIM_CAR(x139973624373543);
-Obj x139973624373607 = PRIM_CDR(x139973624373575);
-Obj x139973624373639 = PRIM_CAR(x139973624373607);
-Obj params = x139973624373639;
-Obj x139973624375239 = PRIM_CDR(x139973624890759);
-Obj x139973624375271 = PRIM_CAR(x139973624375239);
-Obj x139973624375303 = PRIM_CDR(x139973624375271);
-Obj x139973624375335 = PRIM_CDR(x139973624375303);
-Obj x139973624375367 = PRIM_ISCONS(x139973624375335);
-if (True == x139973624375367) {
-Obj x139973624376999 = PRIM_CDR(x139973624890759);
-Obj x139973624377159 = PRIM_CAR(x139973624376999);
-Obj x139973624377191 = PRIM_CDR(x139973624377159);
-Obj x139973624377223 = PRIM_CDR(x139973624377191);
-Obj x139973624377255 = PRIM_CAR(x139973624377223);
-Obj body = x139973624377255;
-Obj x139973624342055 = PRIM_CDR(x139973624890759);
-Obj x139973624342087 = PRIM_CAR(x139973624342055);
-Obj x139973624342119 = PRIM_CDR(x139973624342087);
-Obj x139973624342151 = PRIM_CDR(x139973624342119);
-Obj x139973624342183 = PRIM_CDR(x139973624342151);
-Obj x139973624342215 = PRIM_EQ(Nil, x139973624342183);
-if (True == x139973624342215) {
-Obj x139973624343015 = PRIM_CDR(x139973624890759);
-Obj x139973624343143 = PRIM_CDR(x139973624343015);
-Obj fvs = x139973624343143;
-Obj x139973624343623 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139973624343623) {
+Obj x139731069962151 = __arg1;
+Obj x139731069962183 = __arg2;
+Obj x139731069962599 = makeNative(1, clofun6, 0, 2, x139731069962151, x139731069962183);
+Obj v = x139731069962151;
+Obj x139731068834759 = PRIM_ISCONS(x139731069962183);
+if (True == x139731068834759) {
+Obj x139731068835271 = PRIM_CAR(x139731069962183);
+Obj clo_45or_45cont = x139731068835271;
+Obj x139731068836103 = PRIM_CDR(x139731069962183);
+Obj x139731068836199 = PRIM_ISCONS(x139731068836103);
+if (True == x139731068836199) {
+Obj x139731068837063 = PRIM_CDR(x139731069962183);
+Obj x139731068837095 = PRIM_CAR(x139731068837063);
+Obj x139731068837255 = PRIM_ISCONS(x139731068837095);
+if (True == x139731068837255) {
+Obj x139731068826023 = PRIM_CDR(x139731069962183);
+Obj x139731068826055 = PRIM_CAR(x139731068826023);
+Obj x139731068826119 = PRIM_CAR(x139731068826055);
+Obj x139731068826151 = PRIM_EQ(symlambda, x139731068826119);
+if (True == x139731068826151) {
+Obj x139731068827527 = PRIM_CDR(x139731069962183);
+Obj x139731068827559 = PRIM_CAR(x139731068827527);
+Obj x139731068827591 = PRIM_CDR(x139731068827559);
+Obj x139731068827655 = PRIM_ISCONS(x139731068827591);
+if (True == x139731068827655) {
+Obj x139731068828679 = PRIM_CDR(x139731069962183);
+Obj x139731068828711 = PRIM_CAR(x139731068828679);
+Obj x139731068828743 = PRIM_CDR(x139731068828711);
+Obj x139731068828807 = PRIM_CAR(x139731068828743);
+Obj params = x139731068828807;
+Obj x139731068817927 = PRIM_CDR(x139731069962183);
+Obj x139731068817959 = PRIM_CAR(x139731068817927);
+Obj x139731068817991 = PRIM_CDR(x139731068817959);
+Obj x139731068818023 = PRIM_CDR(x139731068817991);
+Obj x139731068818055 = PRIM_ISCONS(x139731068818023);
+if (True == x139731068818055) {
+Obj x139731068819431 = PRIM_CDR(x139731069962183);
+Obj x139731068819463 = PRIM_CAR(x139731068819431);
+Obj x139731068819495 = PRIM_CDR(x139731068819463);
+Obj x139731068819527 = PRIM_CDR(x139731068819495);
+Obj x139731068819655 = PRIM_CAR(x139731068819527);
+Obj body = x139731068819655;
+Obj x139731068821415 = PRIM_CDR(x139731069962183);
+Obj x139731068747783 = PRIM_CAR(x139731068821415);
+Obj x139731068747815 = PRIM_CDR(x139731068747783);
+Obj x139731068747847 = PRIM_CDR(x139731068747815);
+Obj x139731068747879 = PRIM_CDR(x139731068747847);
+Obj x139731068747911 = PRIM_EQ(Nil, x139731068747879);
+if (True == x139731068747911) {
+Obj x139731068748679 = PRIM_CDR(x139731069962183);
+Obj x139731068748711 = PRIM_CDR(x139731068748679);
+Obj fvs = x139731068748711;
+Obj x139731068749063 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139731068749063) {
 if (True == True) {
 pushCont(co, 46, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7039,7 +7037,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7047,8 +7045,8 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x139973624224807 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
-if (True == x139973624224807) {
+Obj x139731068686599 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
+if (True == x139731068686599) {
 if (True == True) {
 pushCont(co, 41, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7062,7 +7060,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7083,7 +7081,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7094,7 +7092,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7103,7 +7101,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7112,7 +7110,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7121,7 +7119,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7130,7 +7128,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7139,7 +7137,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7148,7 +7146,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624891143;
+__arg0 = x139731069962599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7159,12 +7157,12 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973624003399 = __arg1;
+Obj x139731068684551 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139973624003399;
+Obj body1 = x139731068684551;
 pushCont(co, 37, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7179,39 +7177,39 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973624003911 = __arg1;
+Obj x139731068684839 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139973624003911;
-Obj x139973624004263 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139973624004263) {
-Obj x139973623731367 = makeCons(body1, Nil);
-Obj x139973623731399 = makeCons(Nil, x139973623731367);
-Obj x139973623731431 = makeCons(params, x139973623731399);
-Obj x139973623731463 = makeCons(symlambda, x139973623731431);
+Obj cur = x139731068684839;
+Obj x139731068685127 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139731068685127) {
+Obj x139731068686247 = makeCons(body1, Nil);
+Obj x139731068686279 = makeCons(Nil, x139731068686247);
+Obj x139731068686311 = makeCons(params, x139731068686279);
+Obj x139731068551175 = makeCons(symlambda, x139731068686311);
 pushCont(co, 39, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973623731463;
+__arg2 = x139731068551175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623733895 = makeCons(body1, Nil);
-Obj x139973623733927 = makeCons(fvs, x139973623733895);
-Obj x139973623733959 = makeCons(params, x139973623733927);
-Obj x139973623733991 = makeCons(symlambda, x139973623733959);
+Obj x139731068553255 = makeCons(body1, Nil);
+Obj x139731068553287 = makeCons(fvs, x139731068553255);
+Obj x139731068553319 = makeCons(params, x139731068553287);
+Obj x139731068553351 = makeCons(symlambda, x139731068553319);
 pushCont(co, 38, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973623733991;
+__arg2 = x139731068553351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7222,14 +7220,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973623734023 = __arg1;
+Obj x139731068553383 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623685543 = makeCons(cur, fvs);
-Obj x139973623685607 = makeCons(clo_45or_45cont, x139973623685543);
+Obj x139731068553831 = makeCons(cur, fvs);
+Obj x139731068553863 = makeCons(clo_45or_45cont, x139731068553831);
 __nargs = 2;
-__arg1 = x139973623685607;
+__arg1 = x139731068553863;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7237,7 +7235,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label39:
 {
-Obj x139973623731495 = __arg1;
+Obj x139731068551207 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7255,15 +7253,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973623732455 = __arg1;
+Obj x139731068552007 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973623732519 = makeCons(x139973623732455, fvs);
-Obj x139973623732551 = makeCons(cur, x139973623732519);
-Obj x139973623732583 = makeCons(clo_45or_45cont, x139973623732551);
+Obj x139731068552071 = makeCons(x139731068552007, fvs);
+Obj x139731068552103 = makeCons(cur, x139731068552071);
+Obj x139731068552135 = makeCons(clo_45or_45cont, x139731068552103);
 __nargs = 2;
-__arg1 = x139973623732583;
+__arg1 = x139731068552135;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7271,12 +7269,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj x139973624225095 = __arg1;
+Obj x139731068687047 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139973624225095;
+Obj body1 = x139731068687047;
 pushCont(co, 42, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7291,39 +7289,39 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973624225703 = __arg1;
+Obj x139731068687335 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139973624225703;
-Obj x139973624078727 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139973624078727) {
-Obj x139973624080551 = makeCons(body1, Nil);
-Obj x139973624080743 = makeCons(Nil, x139973624080551);
-Obj x139973624080775 = makeCons(params, x139973624080743);
-Obj x139973624080807 = makeCons(symlambda, x139973624080775);
+Obj cur = x139731068687335;
+Obj x139731068687815 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139731068687815) {
+Obj x139731068689191 = makeCons(body1, Nil);
+Obj x139731068689223 = makeCons(Nil, x139731068689191);
+Obj x139731068689255 = makeCons(params, x139731068689223);
+Obj x139731068689287 = makeCons(symlambda, x139731068689255);
 pushCont(co, 44, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973624080807;
+__arg2 = x139731068689287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973624001831 = makeCons(body1, Nil);
-Obj x139973624001927 = makeCons(fvs, x139973624001831);
-Obj x139973624001959 = makeCons(params, x139973624001927);
-Obj x139973624001991 = makeCons(symlambda, x139973624001959);
+Obj x139731068683367 = makeCons(body1, Nil);
+Obj x139731068683399 = makeCons(fvs, x139731068683367);
+Obj x139731068683431 = makeCons(params, x139731068683399);
+Obj x139731068683463 = makeCons(symlambda, x139731068683431);
 pushCont(co, 43, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973624001991;
+__arg2 = x139731068683463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7334,14 +7332,14 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973624002023 = __arg1;
+Obj x139731068683495 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624002631 = makeCons(cur, fvs);
-Obj x139973624002791 = makeCons(clo_45or_45cont, x139973624002631);
+Obj x139731068683943 = makeCons(cur, fvs);
+Obj x139731068683975 = makeCons(clo_45or_45cont, x139731068683943);
 __nargs = 2;
-__arg1 = x139973624002791;
+__arg1 = x139731068683975;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7349,7 +7347,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj x139973624080839 = __arg1;
+Obj x139731068689319 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7367,15 +7365,15 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973624082055 = __arg1;
+Obj x139731068690311 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624082151 = makeCons(x139973624082055, fvs);
-Obj x139973624082183 = makeCons(cur, x139973624082151);
-Obj x139973624082215 = makeCons(clo_45or_45cont, x139973624082183);
+Obj x139731068690375 = makeCons(x139731068690311, fvs);
+Obj x139731068690407 = makeCons(cur, x139731068690375);
+Obj x139731068682247 = makeCons(clo_45or_45cont, x139731068690407);
 __nargs = 2;
-__arg1 = x139973624082215;
+__arg1 = x139731068682247;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7383,12 +7381,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj x139973624344231 = __arg1;
+Obj x139731068749575 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139973624344231;
+Obj body1 = x139731068749575;
 pushCont(co, 47, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7403,39 +7401,39 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139973624275047 = __arg1;
+Obj x139731068749863 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139973624275047;
-Obj x139973624275463 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139973624275463) {
-Obj x139973624277031 = makeCons(body1, Nil);
-Obj x139973624277159 = makeCons(Nil, x139973624277031);
-Obj x139973624277223 = makeCons(params, x139973624277159);
-Obj x139973624277255 = makeCons(symlambda, x139973624277223);
+Obj cur = x139731068749863;
+Obj x139731068750375 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139731068750375) {
+Obj x139731068751783 = makeCons(body1, Nil);
+Obj x139731068735655 = makeCons(Nil, x139731068751783);
+Obj x139731068735687 = makeCons(params, x139731068735655);
+Obj x139731068735719 = makeCons(symlambda, x139731068735687);
 pushCont(co, 49, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973624277255;
+__arg2 = x139731068735719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973624222919 = makeCons(body1, Nil);
-Obj x139973624222951 = makeCons(fvs, x139973624222919);
-Obj x139973624222983 = makeCons(params, x139973624222951);
-Obj x139973624223015 = makeCons(symlambda, x139973624222983);
+Obj x139731068738471 = makeCons(body1, Nil);
+Obj x139731068738503 = makeCons(fvs, x139731068738471);
+Obj x139731068738535 = makeCons(params, x139731068738503);
+Obj x139731068738567 = makeCons(symlambda, x139731068738535);
 pushCont(co, 48, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139973624223015;
+__arg2 = x139731068738567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7446,14 +7444,14 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973624223047 = __arg1;
+Obj x139731068738599 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624223911 = makeCons(cur, fvs);
-Obj x139973624223943 = makeCons(clo_45or_45cont, x139973624223911);
+Obj x139731068739239 = makeCons(cur, fvs);
+Obj x139731068739271 = makeCons(clo_45or_45cont, x139731068739239);
 __nargs = 2;
-__arg1 = x139973624223943;
+__arg1 = x139731068739271;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7461,7 +7459,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label49:
 {
-Obj x139973624277287 = __arg1;
+Obj x139731068735751 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7499,15 +7497,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973624278215 = __arg1;
+Obj x139731068736615 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624278375 = makeCons(x139973624278215, fvs);
-Obj x139973624278407 = makeCons(cur, x139973624278375);
-Obj x139973624278439 = makeCons(clo_45or_45cont, x139973624278407);
+Obj x139731068736839 = makeCons(x139731068736615, fvs);
+Obj x139731068736871 = makeCons(cur, x139731068736839);
+Obj x139731068736903 = makeCons(clo_45or_45cont, x139731068736871);
 __nargs = 2;
-__arg1 = x139973624278439;
+__arg1 = x139731068736903;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7515,11 +7513,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label1:
 {
-Obj x139973624892935 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731069927495 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj x139973624517447 = PRIM_ISCONS(f_45args);
-if (True == x139973624517447) {
+Obj x139731068853735 = PRIM_ISCONS(f_45args);
+if (True == x139731068853735) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = makeNative(2, clofun6, 1, 1, v);
@@ -7531,7 +7529,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624892935;
+__arg0 = x139731069927495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7556,7 +7554,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973624844359 = makeNative(4, clofun6, 0, 0);
+Obj x139731069928071 = makeNative(4, clofun6, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
@@ -7580,12 +7578,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973625015431 = __arg1;
-Obj x139973625015463 = __arg2;
-Obj x139973625015847 = makeNative(7, clofun6, 0, 2, x139973625015431, x139973625015463);
-Obj __ = x139973625015431;
-Obj x = x139973625015463;
-pushCont(co, 6, clofun6, 2, x, x139973625015847);
+Obj x139731070365479 = __arg1;
+Obj x139731070365511 = __arg2;
+Obj x139731070034151 = makeNative(7, clofun6, 0, 2, x139731070365479, x139731070365511);
+Obj __ = x139731070365479;
+Obj x = x139731070365511;
+pushCont(co, 6, clofun6, 2, x, x139731070034151);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -7598,10 +7596,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973624531623 = __arg1;
+Obj x139731068851207 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973625015847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624531623) {
+Obj x139731070034151= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731068851207) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7609,7 +7607,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625015847;
+__arg0 = x139731070034151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7620,11 +7618,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973624914023 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731070034695 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj x139973624530823 = primIsSymbol(var);
-if (True == x139973624530823) {
+Obj x139731068891111 = primIsSymbol(var);
+if (True == x139731068891111) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7632,7 +7630,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624914023;
+__arg0 = x139731070034695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7643,32 +7641,32 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973624914567 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731070035271 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj x139973624686599 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973624686599) {
-Obj x139973624687079 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624687111 = PRIM_EQ(symlambda, x139973624687079);
-if (True == x139973624687111) {
-Obj x139973624687655 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624687719 = PRIM_ISCONS(x139973624687655);
-if (True == x139973624687719) {
-Obj x139973624688295 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624688327 = PRIM_CAR(x139973624688295);
-Obj args = x139973624688327;
-Obj x139973624640103 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624640135 = PRIM_CDR(x139973624640103);
-Obj x139973624640167 = PRIM_ISCONS(x139973624640135);
-if (True == x139973624640167) {
-Obj x139973624641159 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624641223 = PRIM_CDR(x139973624641159);
-Obj x139973624641255 = PRIM_CAR(x139973624641223);
-Obj body = x139973624641255;
-Obj x139973624642599 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624642631 = PRIM_CDR(x139973624642599);
-Obj x139973624642663 = PRIM_CDR(x139973624642631);
-Obj x139973624642695 = PRIM_EQ(Nil, x139973624642663);
-if (True == x139973624642695) {
+Obj x139731068898663 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731068898663) {
+Obj x139731068891303 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068891335 = PRIM_EQ(symlambda, x139731068891303);
+if (True == x139731068891335) {
+Obj x139731068891911 = PRIM_CDR(closureRef(co, 1));
+Obj x139731068892007 = PRIM_ISCONS(x139731068891911);
+if (True == x139731068892007) {
+Obj x139731068892743 = PRIM_CDR(closureRef(co, 1));
+Obj x139731068892775 = PRIM_CAR(x139731068892743);
+Obj args = x139731068892775;
+Obj x139731068893927 = PRIM_CDR(closureRef(co, 1));
+Obj x139731068893959 = PRIM_CDR(x139731068893927);
+Obj x139731068893991 = PRIM_ISCONS(x139731068893959);
+if (True == x139731068893991) {
+Obj x139731068894631 = PRIM_CDR(closureRef(co, 1));
+Obj x139731068894663 = PRIM_CDR(x139731068894631);
+Obj x139731068894695 = PRIM_CAR(x139731068894663);
+Obj body = x139731068894695;
+Obj x139731068887783 = PRIM_CDR(closureRef(co, 1));
+Obj x139731068887815 = PRIM_CDR(x139731068887783);
+Obj x139731068887847 = PRIM_CDR(x139731068887815);
+Obj x139731068887943 = PRIM_EQ(Nil, x139731068887847);
+if (True == x139731068887943) {
 pushCont(co, 9, clofun6, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7681,7 +7679,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624914567;
+__arg0 = x139731070035271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7690,7 +7688,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624914567;
+__arg0 = x139731070035271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7699,7 +7697,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624914567;
+__arg0 = x139731070035271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7708,7 +7706,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624914567;
+__arg0 = x139731070035271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7717,7 +7715,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624914567;
+__arg0 = x139731070035271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7728,13 +7726,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973624529191 = __arg1;
+Obj x139731068889511 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624529287 = makeCons(x139973624529191, Nil);
-Obj x139973624529319 = makeCons(args, x139973624529287);
-Obj x139973624529351 = makeCons(symlambda, x139973624529319);
+Obj x139731068889575 = makeCons(x139731068889511, Nil);
+Obj x139731068889607 = makeCons(args, x139731068889575);
+Obj x139731068889639 = makeCons(symlambda, x139731068889607);
 __nargs = 2;
-__arg1 = x139973624529351;
+__arg1 = x139731068889639;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7742,32 +7740,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label10:
 {
-Obj x139973624915847 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731070036487 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj x139973624916807 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973624916807) {
-Obj x139973624917479 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624917575 = PRIM_EQ(symcontinuation, x139973624917479);
-if (True == x139973624917575) {
-Obj x139973624889415 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624889447 = PRIM_ISCONS(x139973624889415);
-if (True == x139973624889447) {
-Obj x139973624890311 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624890343 = PRIM_CAR(x139973624890311);
-Obj val = x139973624890343;
-Obj x139973624891303 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624891463 = PRIM_CDR(x139973624891303);
-Obj x139973624891495 = PRIM_ISCONS(x139973624891463);
-if (True == x139973624891495) {
-Obj x139973624892391 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624892519 = PRIM_CDR(x139973624892391);
-Obj x139973624892551 = PRIM_CAR(x139973624892519);
-Obj body = x139973624892551;
-Obj x139973624844935 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624844967 = PRIM_CDR(x139973624844935);
-Obj x139973624844999 = PRIM_CDR(x139973624844967);
-Obj x139973624845031 = PRIM_EQ(Nil, x139973624844999);
-if (True == x139973624845031) {
+Obj x139731069387943 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731069387943) {
+Obj x139731069388679 = PRIM_CAR(closureRef(co, 1));
+Obj x139731069388711 = PRIM_EQ(symcontinuation, x139731069388679);
+if (True == x139731069388711) {
+Obj x139731069389255 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069389287 = PRIM_ISCONS(x139731069389255);
+if (True == x139731069389287) {
+Obj x139731069389799 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069389991 = PRIM_CAR(x139731069389799);
+Obj val = x139731069389991;
+Obj x139731069390695 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069042727 = PRIM_CDR(x139731069390695);
+Obj x139731069042759 = PRIM_ISCONS(x139731069042727);
+if (True == x139731069042759) {
+Obj x139731069043431 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069043463 = PRIM_CDR(x139731069043431);
+Obj x139731069043495 = PRIM_CAR(x139731069043463);
+Obj body = x139731069043495;
+Obj x139731069044551 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069044583 = PRIM_CDR(x139731069044551);
+Obj x139731069044615 = PRIM_CDR(x139731069044583);
+Obj x139731069044775 = PRIM_EQ(Nil, x139731069044615);
+if (True == x139731069044775) {
 pushCont(co, 11, clofun6, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -7779,7 +7777,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624915847;
+__arg0 = x139731070036487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7788,7 +7786,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624915847;
+__arg0 = x139731070036487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7797,7 +7795,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624915847;
+__arg0 = x139731070036487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7806,7 +7804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624915847;
+__arg0 = x139731070036487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7815,7 +7813,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624915847;
+__arg0 = x139731070036487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7826,14 +7824,14 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139973624845895 = __arg1;
+Obj x139731069045383 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 12, clofun6, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139973624845895;
+__arg1 = x139731069045383;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7844,11 +7842,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973624845959 = __arg1;
+Obj x139731069045447 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = x139973624845959;
+Obj fvs1 = x139731069045447;
 pushCont(co, 13, clofun6, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7862,14 +7860,14 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973624846599 = __arg1;
+Obj x139731069046023 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 14, clofun6, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973624846599;
+__arg1 = x139731069046023;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7880,11 +7878,11 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973624846823 = __arg1;
+Obj x139731069046183 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs2 = x139973624846823;
+Obj fvs2 = x139731069046183;
 pushCont(co, 15, clofun6, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7899,16 +7897,16 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973624684647 = __arg1;
+Obj x139731068897095 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624684711 = makeCons(x139973624684647, Nil);
-Obj x139973624684775 = makeCons(val, x139973624684711);
-Obj x139973624684807 = makeCons(symlambda, x139973624684775);
-Obj x139973624684935 = makeCons(x139973624684807, fvs2);
-Obj x139973624684999 = makeCons(sym_37continuation, x139973624684935);
+Obj x139731068897159 = makeCons(x139731068897095, Nil);
+Obj x139731068897191 = makeCons(val, x139731068897159);
+Obj x139731068897223 = makeCons(symlambda, x139731068897191);
+Obj x139731068897287 = makeCons(x139731068897223, fvs2);
+Obj x139731068897319 = makeCons(sym_37continuation, x139731068897287);
 __nargs = 2;
-__arg1 = x139973624684999;
+__arg1 = x139731068897319;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7916,32 +7914,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj x139973624917095 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731070037703 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj x139973625030471 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973625030471) {
-Obj x139973625031015 = PRIM_CAR(closureRef(co, 1));
-Obj x139973625031047 = PRIM_EQ(symcall, x139973625031015);
-if (True == x139973625031047) {
-Obj x139973625031943 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625031975 = PRIM_ISCONS(x139973625031943);
-if (True == x139973625031975) {
-Obj x139973625032583 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625032615 = PRIM_CAR(x139973625032583);
-Obj exp = x139973625032615;
-Obj x139973625013127 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625013159 = PRIM_CDR(x139973625013127);
-Obj x139973625013191 = PRIM_ISCONS(x139973625013159);
-if (True == x139973625013191) {
-Obj x139973625013991 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625014023 = PRIM_CDR(x139973625013991);
-Obj x139973625014055 = PRIM_CAR(x139973625014023);
-Obj cont = x139973625014055;
-Obj x139973625015399 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625015495 = PRIM_CDR(x139973625015399);
-Obj x139973625015655 = PRIM_CDR(x139973625015495);
-Obj x139973625015719 = PRIM_EQ(Nil, x139973625015655);
-if (True == x139973625015719) {
+Obj x139731069928295 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731069928295) {
+Obj x139731069928871 = PRIM_CAR(closureRef(co, 1));
+Obj x139731069928903 = PRIM_EQ(symcall, x139731069928871);
+if (True == x139731069928903) {
+Obj x139731069929543 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069929671 = PRIM_ISCONS(x139731069929543);
+if (True == x139731069929671) {
+Obj x139731069930183 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069930215 = PRIM_CAR(x139731069930183);
+Obj exp = x139731069930215;
+Obj x139731069931111 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069931143 = PRIM_CDR(x139731069931111);
+Obj x139731069931175 = PRIM_ISCONS(x139731069931143);
+if (True == x139731069931175) {
+Obj x139731069551239 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069551271 = PRIM_CDR(x139731069551239);
+Obj x139731069551303 = PRIM_CAR(x139731069551271);
+Obj cont = x139731069551303;
+Obj x139731069552295 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069552327 = PRIM_CDR(x139731069552295);
+Obj x139731069552359 = PRIM_CDR(x139731069552327);
+Obj x139731069552391 = PRIM_EQ(Nil, x139731069552359);
+if (True == x139731069552391) {
 pushCont(co, 17, clofun6, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7953,7 +7951,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624917095;
+__arg0 = x139731070037703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7962,7 +7960,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624917095;
+__arg0 = x139731070037703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7971,7 +7969,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624917095;
+__arg0 = x139731070037703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7980,7 +7978,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624917095;
+__arg0 = x139731070037703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7989,7 +7987,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624917095;
+__arg0 = x139731070037703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8000,14 +7998,14 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973624914375 = __arg1;
+Obj x139731069553767 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 18, clofun6, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973624914375;
+__arg1 = x139731069553767;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8018,10 +8016,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973624914439 = __arg1;
+Obj x139731069553831 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 19, clofun6, 1, x139973624914439);
+pushCont(co, 19, clofun6, 1, x139731069553831);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
 __arg1 = fvs;
@@ -8035,13 +8033,13 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624915015 = __arg1;
-Obj x139973624914439= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624915079 = makeCons(x139973624915015, Nil);
-Obj x139973624915175 = makeCons(x139973624914439, x139973624915079);
-Obj x139973624915207 = makeCons(symcall, x139973624915175);
+Obj x139731069554343 = __arg1;
+Obj x139731069553831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069554567 = makeCons(x139731069554343, Nil);
+Obj x139731069554599 = makeCons(x139731069553831, x139731069554567);
+Obj x139731069554631 = makeCons(symcall, x139731069554599);
 __nargs = 2;
-__arg1 = x139973624915207;
+__arg1 = x139731069554631;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8049,14 +8047,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label20:
 {
-Obj x139973624889703 = makeNative(22, clofun6, 0, 0);
+Obj x139731069961127 = makeNative(22, clofun6, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj x139973625789767 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973625789767) {
-Obj x139973625790087 = PRIM_CAR(closureRef(co, 1));
-Obj f = x139973625790087;
-Obj x139973625028679 = PRIM_CDR(closureRef(co, 1));
-Obj args = x139973625028679;
+Obj x139731069962631 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731069962631) {
+Obj x139731069962919 = PRIM_CAR(closureRef(co, 1));
+Obj f = x139731069962919;
+Obj x139731069963335 = PRIM_CDR(closureRef(co, 1));
+Obj args = x139731069963335;
 pushCont(co, 21, clofun6, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -8068,7 +8066,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624889703;
+__arg0 = x139731069961127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8079,14 +8077,14 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973625029415 = __arg1;
+Obj x139731069963943 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625029767 = makeCons(f, args);
+Obj x139731069927655 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973625029415;
-__arg2 = x139973625029767;
+__arg1 = x139731069963943;
+__arg2 = x139731069927655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8108,14 +8106,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973625012423 = __arg1;
-Obj x139973625012455 = __arg2;
-Obj x139973625012487 = __arg3;
-Obj x139973625013063 = makeNative(30, clofun6, 0, 3, x139973625012423, x139973625012455, x139973625012487);
-Obj x139973623683815 = PRIM_EQ(Nil, x139973625012423);
-if (True == x139973623683815) {
-Obj ls = x139973625012455;
-Obj next = x139973625012487;
+Obj x139731070362503 = __arg1;
+Obj x139731070362535 = __arg2;
+Obj x139731070362567 = __arg3;
+Obj x139731070363143 = makeNative(30, clofun6, 0, 3, x139731070362503, x139731070362535, x139731070362567);
+Obj x139731068554663 = PRIM_EQ(Nil, x139731070362503);
+if (True == x139731068554663) {
+Obj ls = x139731070362535;
+Obj next = x139731070362567;
 pushCont(co, 24, clofun6, 1, next);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -8127,7 +8125,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625013063;
+__arg0 = x139731070363143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8138,14 +8136,14 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973623684199 = __arg1;
+Obj x139731068555047 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp = x139973623684199;
-Obj x139973623684679 = PRIM_CAR(exp);
+Obj exp = x139731068555047;
+Obj x139731067953415 = PRIM_CAR(exp);
 pushCont(co, 25, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = x139973623684679;
+__arg1 = x139731067953415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8155,10 +8153,10 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973623684711 = __arg1;
+Obj x139731067953447 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973623684711) {
+if (True == x139731067953447) {
 pushCont(co, 27, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -8180,20 +8178,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973625853991 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139973625853991) {
-Obj x139973625854759 = makeCons(exp, Nil);
-Obj x139973625854791 = makeCons(symtailcall, x139973625854759);
+Obj x139731070365319 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139731070365319) {
+Obj x139731070034247 = makeCons(exp, Nil);
+Obj x139731070034279 = makeCons(symtailcall, x139731070034247);
 __nargs = 2;
-__arg1 = x139973625854791;
+__arg1 = x139731070034279;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139973625855047 = primGenSym();
-Obj val = x139973625855047;
-Obj x139973625823879 = makeCons(val, Nil);
-pushCont(co, 26, clofun6, 2, x139973625823879, exp);
+Obj x139731070034759 = primGenSym();
+Obj val = x139731070034759;
+Obj x139731070036615 = makeCons(val, Nil);
+pushCont(co, 26, clofun6, 2, x139731070036615, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8209,17 +8207,17 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973625824359 = __arg1;
-Obj x139973625823879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731070037287 = __arg1;
+Obj x139731070036615= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625824487 = makeCons(x139973625824359, Nil);
-Obj x139973625824519 = makeCons(x139973625823879, x139973625824487);
-Obj x139973625824647 = makeCons(symcontinuation, x139973625824519);
-Obj x139973625824743 = makeCons(x139973625824647, Nil);
-Obj x139973625824775 = makeCons(exp, x139973625824743);
-Obj x139973625824807 = makeCons(symcall, x139973625824775);
+Obj x139731070037351 = makeCons(x139731070037287, Nil);
+Obj x139731070037383 = makeCons(x139731070036615, x139731070037351);
+Obj x139731070037511 = makeCons(symcontinuation, x139731070037383);
+Obj x139731070037575 = makeCons(x139731070037511, Nil);
+Obj x139731070037607 = makeCons(exp, x139731070037575);
+Obj x139731070037639 = makeCons(symcall, x139731070037607);
 __nargs = 2;
-__arg1 = x139973625824807;
+__arg1 = x139731070037639;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8227,11 +8225,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x139973623672839 = __arg1;
+Obj x139731067953863 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623672903 = PRIM_EQ(x139973623672839, sym_37builtin);
-if (True == x139973623672903) {
+Obj x139731067953927 = PRIM_EQ(x139731067953863, sym_37builtin);
+if (True == x139731067953927) {
 if (True == True) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
@@ -8243,20 +8241,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623673383 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139973623673383) {
-Obj x139973623673799 = makeCons(exp, Nil);
-Obj x139973623673831 = makeCons(symtailcall, x139973623673799);
+Obj x139731070514183 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139731070514183) {
+Obj x139731070514823 = makeCons(exp, Nil);
+Obj x139731070514855 = makeCons(symtailcall, x139731070514823);
 __nargs = 2;
-__arg1 = x139973623673831;
+__arg1 = x139731070514855;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139973623674055 = primGenSym();
-Obj val = x139973623674055;
-Obj x139973623675175 = makeCons(val, Nil);
-pushCont(co, 29, clofun6, 2, x139973623675175, exp);
+Obj x139731070515431 = primGenSym();
+Obj val = x139731070515431;
+Obj x139731070517127 = makeCons(val, Nil);
+pushCont(co, 29, clofun6, 2, x139731070517127, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8279,20 +8277,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973623676295 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139973623676295) {
-Obj x139973623676711 = makeCons(exp, Nil);
-Obj x139973623676743 = makeCons(symtailcall, x139973623676711);
+Obj x139731070375815 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == x139731070375815) {
+Obj x139731070377223 = makeCons(exp, Nil);
+Obj x139731070377255 = makeCons(symtailcall, x139731070377223);
 __nargs = 2;
-__arg1 = x139973623676743;
+__arg1 = x139731070377255;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139973623664679 = primGenSym();
-Obj val = x139973623664679;
-Obj x139973625852167 = makeCons(val, Nil);
-pushCont(co, 28, clofun6, 2, x139973625852167, exp);
+Obj x139731070377607 = primGenSym();
+Obj val = x139731070377607;
+Obj x139731070363431 = makeCons(val, Nil);
+pushCont(co, 28, clofun6, 2, x139731070363431, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8308,17 +8306,17 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139973625852871 = __arg1;
-Obj x139973625852167= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731070364007 = __arg1;
+Obj x139731070363431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625852935 = makeCons(x139973625852871, Nil);
-Obj x139973625852967 = makeCons(x139973625852167, x139973625852935);
-Obj x139973625853031 = makeCons(symcontinuation, x139973625852967);
-Obj x139973625853095 = makeCons(x139973625853031, Nil);
-Obj x139973625853127 = makeCons(exp, x139973625853095);
-Obj x139973625853255 = makeCons(symcall, x139973625853127);
+Obj x139731070364231 = makeCons(x139731070364007, Nil);
+Obj x139731070364359 = makeCons(x139731070363431, x139731070364231);
+Obj x139731070364423 = makeCons(symcontinuation, x139731070364359);
+Obj x139731070364487 = makeCons(x139731070364423, Nil);
+Obj x139731070364519 = makeCons(exp, x139731070364487);
+Obj x139731070364551 = makeCons(symcall, x139731070364519);
 __nargs = 2;
-__arg1 = x139973625853255;
+__arg1 = x139731070364551;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8326,17 +8324,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label29:
 {
-Obj x139973623675559 = __arg1;
-Obj x139973623675175= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731070374311 = __arg1;
+Obj x139731070517127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623675623 = makeCons(x139973623675559, Nil);
-Obj x139973623675655 = makeCons(x139973623675175, x139973623675623);
-Obj x139973623675687 = makeCons(symcontinuation, x139973623675655);
-Obj x139973623675751 = makeCons(x139973623675687, Nil);
-Obj x139973623675783 = makeCons(exp, x139973623675751);
-Obj x139973623675815 = makeCons(symcall, x139973623675783);
+Obj x139731070374407 = makeCons(x139731070374311, Nil);
+Obj x139731070374503 = makeCons(x139731070517127, x139731070374407);
+Obj x139731070374567 = makeCons(symcontinuation, x139731070374503);
+Obj x139731070374631 = makeCons(x139731070374567, Nil);
+Obj x139731070374663 = makeCons(exp, x139731070374631);
+Obj x139731070374727 = makeCons(symcall, x139731070374663);
 __nargs = 2;
-__arg1 = x139973623675815;
+__arg1 = x139731070374727;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8344,13 +8342,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label30:
 {
-Obj x139973625013863 = makeNative(32, clofun6, 0, 0);
-Obj x139973623682055 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623682055) {
-Obj x139973623682311 = PRIM_CAR(closureRef(co, 0));
-Obj hd = x139973623682311;
-Obj x139973623682567 = PRIM_CDR(closureRef(co, 0));
-Obj tl = x139973623682567;
+Obj x139731070363975 = makeNative(32, clofun6, 0, 0);
+Obj x139731068552903 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068552903) {
+Obj x139731068553159 = PRIM_CAR(closureRef(co, 0));
+Obj hd = x139731068553159;
+Obj x139731068553415 = PRIM_CDR(closureRef(co, 0));
+Obj tl = x139731068553415;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 __nargs = 3;
@@ -8364,7 +8362,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625013863;
+__arg0 = x139731070363975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8376,11 +8374,11 @@ goto *jumpTable[ps.label];
 label31:
 {
 Obj hd1 = __arg1;
-Obj x139973623683367 = makeCons(hd1, closureRef(co, 1));
+Obj x139731068554215 = makeCons(hd1, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
 __arg1 = closureRef(co, 0);
-__arg2 = x139973623683367;
+__arg2 = x139731068554215;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8403,13 +8401,13 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973625824839 = __arg1;
-Obj x139973625824871 = __arg2;
-Obj x139973625825255 = makeNative(35, clofun6, 0, 2, x139973625824839, x139973625824871);
-Obj x = x139973625824839;
-Obj next = x139973625824871;
-Obj x139973623687079 = primIsSymbol(x);
-if (True == x139973623687079) {
+Obj x139731070513703 = __arg1;
+Obj x139731070513735 = __arg2;
+Obj x139731070514151 = makeNative(35, clofun6, 0, 2, x139731070513703, x139731070513735);
+Obj x = x139731070513703;
+Obj next = x139731070513735;
+Obj x139731068685927 = primIsSymbol(x);
+if (True == x139731068685927) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8421,7 +8419,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625825255;
+__arg0 = x139731070514151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8429,7 +8427,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 34, clofun6, 3, next, x, x139973625825255);
+pushCont(co, 34, clofun6, 3, next, x, x139731070514151);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8443,11 +8441,11 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973623687623 = __arg1;
+Obj x139731068551303 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625825255= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139973623687623) {
+Obj x139731070514151= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139731068551303) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8459,7 +8457,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625825255;
+__arg0 = x139731070514151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8478,7 +8476,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625825255;
+__arg0 = x139731070514151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8490,10 +8488,10 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973625825799 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731070514727 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 36, clofun6, 2, x, x139973625825799);
+pushCont(co, 36, clofun6, 2, x, x139731070514727);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8506,10 +8504,10 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973623686439 = __arg1;
+Obj x139731068685351 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973625825799= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973623686439) {
+Obj x139731070514727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731068685351) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -8517,7 +8515,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625825799;
+__arg0 = x139731070514727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8528,42 +8526,42 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973625826343 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973624082087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624082087) {
-Obj x139973624000743 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624000775 = PRIM_EQ(symif, x139973624000743);
-if (True == x139973624000775) {
-Obj x139973624001319 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624001351 = PRIM_ISCONS(x139973624001319);
-if (True == x139973624001351) {
-Obj x139973624001863 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624001895 = PRIM_CAR(x139973624001863);
-Obj a = x139973624001895;
-Obj x139973624002663 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624002727 = PRIM_CDR(x139973624002663);
-Obj x139973624002759 = PRIM_ISCONS(x139973624002727);
-if (True == x139973624002759) {
-Obj x139973624003527 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624003655 = PRIM_CDR(x139973624003527);
-Obj x139973624003687 = PRIM_CAR(x139973624003655);
-Obj b = x139973624003687;
-Obj x139973623730183 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623730247 = PRIM_CDR(x139973623730183);
-Obj x139973623730279 = PRIM_CDR(x139973623730247);
-Obj x139973623730311 = PRIM_ISCONS(x139973623730279);
-if (True == x139973623730311) {
-Obj x139973623731111 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623731143 = PRIM_CDR(x139973623731111);
-Obj x139973623731175 = PRIM_CDR(x139973623731143);
-Obj x139973623731239 = PRIM_CAR(x139973623731175);
-Obj c = x139973623731239;
-Obj x139973623732199 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623732231 = PRIM_CDR(x139973623732199);
-Obj x139973623732263 = PRIM_CDR(x139973623732231);
-Obj x139973623732295 = PRIM_CDR(x139973623732263);
-Obj x139973623732327 = PRIM_EQ(Nil, x139973623732295);
-if (True == x139973623732327) {
+Obj x139731070515303 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068736327 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068736327) {
+Obj x139731068737031 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068737063 = PRIM_EQ(symif, x139731068737031);
+if (True == x139731068737063) {
+Obj x139731068737575 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068737607 = PRIM_ISCONS(x139731068737575);
+if (True == x139731068737607) {
+Obj x139731068738247 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068738279 = PRIM_CAR(x139731068738247);
+Obj a = x139731068738279;
+Obj x139731068738855 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068738887 = PRIM_CDR(x139731068738855);
+Obj x139731068738919 = PRIM_ISCONS(x139731068738887);
+if (True == x139731068738919) {
+Obj x139731068686375 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068686471 = PRIM_CDR(x139731068686375);
+Obj x139731068686503 = PRIM_CAR(x139731068686471);
+Obj b = x139731068686503;
+Obj x139731068687463 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068687495 = PRIM_CDR(x139731068687463);
+Obj x139731068687527 = PRIM_CDR(x139731068687495);
+Obj x139731068687559 = PRIM_ISCONS(x139731068687527);
+if (True == x139731068687559) {
+Obj x139731068688391 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068688423 = PRIM_CDR(x139731068688391);
+Obj x139731068688455 = PRIM_CDR(x139731068688423);
+Obj x139731068688487 = PRIM_CAR(x139731068688455);
+Obj c = x139731068688487;
+Obj x139731068689639 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068689703 = PRIM_CDR(x139731068689639);
+Obj x139731068689767 = PRIM_CDR(x139731068689703);
+Obj x139731068682503 = PRIM_CDR(x139731068689767);
+Obj x139731068682535 = PRIM_EQ(Nil, x139731068682503);
+if (True == x139731068682535) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8576,7 +8574,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8585,7 +8583,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8594,7 +8592,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8603,7 +8601,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8612,7 +8610,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8621,7 +8619,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625826343;
+__arg0 = x139731070515303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8647,9 +8645,9 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973623733639 = __arg1;
+Obj x139731068683623 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 40, clofun6, 2, x139973623733639, ra);
+pushCont(co, 40, clofun6, 2, x139731068683623, ra);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 1);
@@ -8663,15 +8661,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973623734119 = __arg1;
-Obj x139973623733639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068684039 = __arg1;
+Obj x139731068683623= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973623734183 = makeCons(x139973623734119, Nil);
-Obj x139973623734215 = makeCons(x139973623733639, x139973623734183);
-Obj x139973623734247 = makeCons(ra, x139973623734215);
-Obj x139973623685127 = makeCons(symif, x139973623734247);
+Obj x139731068684103 = makeCons(x139731068684039, Nil);
+Obj x139731068684135 = makeCons(x139731068683623, x139731068684103);
+Obj x139731068684167 = makeCons(ra, x139731068684135);
+Obj x139731068684199 = makeCons(symif, x139731068684167);
 __nargs = 2;
-__arg1 = x139973623685127;
+__arg1 = x139731068684199;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8679,31 +8677,31 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj x139973625789319 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973624277735 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624277735) {
-Obj x139973624278247 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624278279 = PRIM_EQ(symdo, x139973624278247);
-if (True == x139973624278279) {
-Obj x139973624278951 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624278983 = PRIM_ISCONS(x139973624278951);
-if (True == x139973624278983) {
-Obj x139973624222215 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624222247 = PRIM_CAR(x139973624222215);
-Obj a = x139973624222247;
-Obj x139973624223079 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624223111 = PRIM_CDR(x139973624223079);
-Obj x139973624223143 = PRIM_ISCONS(x139973624223111);
-if (True == x139973624223143) {
-Obj x139973624224071 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624224103 = PRIM_CDR(x139973624224071);
-Obj x139973624224359 = PRIM_CAR(x139973624224103);
-Obj b = x139973624224359;
-Obj x139973624225415 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624225447 = PRIM_CDR(x139973624225415);
-Obj x139973624225479 = PRIM_CDR(x139973624225447);
-Obj x139973624225511 = PRIM_EQ(Nil, x139973624225479);
-if (True == x139973624225511) {
+Obj x139731070516807 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068818471 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068818471) {
+Obj x139731068819175 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068819239 = PRIM_EQ(symdo, x139731068819175);
+if (True == x139731068819239) {
+Obj x139731068819751 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068819783 = PRIM_ISCONS(x139731068819751);
+if (True == x139731068819783) {
+Obj x139731068820359 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068820455 = PRIM_CAR(x139731068820359);
+Obj a = x139731068820455;
+Obj x139731068821255 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068821287 = PRIM_CDR(x139731068821255);
+Obj x139731068821319 = PRIM_ISCONS(x139731068821287);
+if (True == x139731068821319) {
+Obj x139731068748295 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068748327 = PRIM_CDR(x139731068748295);
+Obj x139731068748359 = PRIM_CAR(x139731068748327);
+Obj b = x139731068748359;
+Obj x139731068749319 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068749447 = PRIM_CDR(x139731068749319);
+Obj x139731068749479 = PRIM_CDR(x139731068749447);
+Obj x139731068749511 = PRIM_EQ(Nil, x139731068749479);
+if (True == x139731068749511) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8716,7 +8714,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625789319;
+__arg0 = x139731070516807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8725,7 +8723,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625789319;
+__arg0 = x139731070516807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8734,7 +8732,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625789319;
+__arg0 = x139731070516807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8743,7 +8741,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625789319;
+__arg0 = x139731070516807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8752,7 +8750,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625789319;
+__arg0 = x139731070516807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8764,8 +8762,8 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj ra = __arg1;
-Obj x139973624078983 = primIsSymbol(ra);
-if (True == x139973624078983) {
+Obj x139731068750183 = primIsSymbol(ra);
+if (True == x139731068750183) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 0);
@@ -8791,13 +8789,13 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973624080519 = __arg1;
+Obj x139731068751463 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624080647 = makeCons(x139973624080519, Nil);
-Obj x139973624080679 = makeCons(ra, x139973624080647);
-Obj x139973624080711 = makeCons(symdo, x139973624080679);
+Obj x139731068751527 = makeCons(x139731068751463, Nil);
+Obj x139731068751559 = makeCons(ra, x139731068751527);
+Obj x139731068751591 = makeCons(symdo, x139731068751559);
 __nargs = 2;
-__arg1 = x139973624080711;
+__arg1 = x139731068751591;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8805,42 +8803,42 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj x139973625028647 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973624418119 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624418119) {
-Obj x139973624373703 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624373735 = PRIM_EQ(symlet, x139973624373703);
-if (True == x139973624373735) {
-Obj x139973624374343 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624374375 = PRIM_ISCONS(x139973624374343);
-if (True == x139973624374375) {
-Obj x139973624374983 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624375111 = PRIM_CAR(x139973624374983);
-Obj a = x139973624375111;
-Obj x139973624376039 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624376071 = PRIM_CDR(x139973624376039);
-Obj x139973624376135 = PRIM_ISCONS(x139973624376071);
-if (True == x139973624376135) {
-Obj x139973624376903 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624376935 = PRIM_CDR(x139973624376903);
-Obj x139973624376967 = PRIM_CAR(x139973624376935);
-Obj b = x139973624376967;
-Obj x139973624341063 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624341127 = PRIM_CDR(x139973624341063);
-Obj x139973624341159 = PRIM_CDR(x139973624341127);
-Obj x139973624341255 = PRIM_ISCONS(x139973624341159);
-if (True == x139973624341255) {
-Obj x139973624342247 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624342279 = PRIM_CDR(x139973624342247);
-Obj x139973624342343 = PRIM_CDR(x139973624342279);
-Obj x139973624342375 = PRIM_CAR(x139973624342343);
-Obj c = x139973624342375;
-Obj x139973624343751 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624343815 = PRIM_CDR(x139973624343751);
-Obj x139973624343975 = PRIM_CDR(x139973624343815);
-Obj x139973624344007 = PRIM_CDR(x139973624343975);
-Obj x139973624344039 = PRIM_EQ(Nil, x139973624344007);
-if (True == x139973624344039) {
+Obj x139731070374695 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068852583 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068852583) {
+Obj x139731068853127 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068853191 = PRIM_EQ(symlet, x139731068853127);
+if (True == x139731068853191) {
+Obj x139731068853863 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068853895 = PRIM_ISCONS(x139731068853863);
+if (True == x139731068853895) {
+Obj x139731068834055 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068834087 = PRIM_CAR(x139731068834055);
+Obj a = x139731068834087;
+Obj x139731068834887 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068834919 = PRIM_CDR(x139731068834887);
+Obj x139731068834951 = PRIM_ISCONS(x139731068834919);
+if (True == x139731068834951) {
+Obj x139731068835975 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068836007 = PRIM_CDR(x139731068835975);
+Obj x139731068836039 = PRIM_CAR(x139731068836007);
+Obj b = x139731068836039;
+Obj x139731068837127 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068837159 = PRIM_CDR(x139731068837127);
+Obj x139731068837191 = PRIM_CDR(x139731068837159);
+Obj x139731068837223 = PRIM_ISCONS(x139731068837191);
+if (True == x139731068837223) {
+Obj x139731068825767 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068825799 = PRIM_CDR(x139731068825767);
+Obj x139731068825863 = PRIM_CDR(x139731068825799);
+Obj x139731068825895 = PRIM_CAR(x139731068825863);
+Obj c = x139731068825895;
+Obj x139731068827239 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068827271 = PRIM_CDR(x139731068827239);
+Obj x139731068827399 = PRIM_CDR(x139731068827271);
+Obj x139731068827431 = PRIM_CDR(x139731068827399);
+Obj x139731068827463 = PRIM_EQ(Nil, x139731068827431);
+if (True == x139731068827463) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8853,7 +8851,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8862,7 +8860,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8871,7 +8869,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8880,7 +8878,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8889,7 +8887,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8898,7 +8896,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625028647;
+__arg0 = x139731070374695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8924,14 +8922,14 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139973624276135 = __arg1;
+Obj x139731068829255 = __arg1;
 Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624276231 = makeCons(x139973624276135, Nil);
-Obj x139973624276263 = makeCons(rb, x139973624276231);
-Obj x139973624276295 = makeCons(closureRef(co, 0), x139973624276263);
-Obj x139973624276327 = makeCons(symlet, x139973624276295);
+Obj x139731068829351 = makeCons(x139731068829255, Nil);
+Obj x139731068829415 = makeCons(rb, x139731068829351);
+Obj x139731068829447 = makeCons(closureRef(co, 0), x139731068829415);
+Obj x139731068829479 = makeCons(symlet, x139731068829447);
 __nargs = 2;
-__arg1 = x139973624276327;
+__arg1 = x139731068829479;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8939,56 +8937,56 @@ goto *jumpTable[co->ctx.pc.label];
 
 label47:
 {
-Obj x139973625030151 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973624641191 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624641191) {
-Obj x139973624641767 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624641799 = PRIM_EQ(sym_37closure, x139973624641767);
-if (True == x139973624641799) {
-Obj x139973624642375 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624642439 = PRIM_ISCONS(x139973624642375);
-if (True == x139973624642439) {
-Obj x139973624643207 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624643239 = PRIM_CAR(x139973624643207);
-Obj x139973624643271 = PRIM_ISCONS(x139973624643239);
-if (True == x139973624643271) {
-Obj x139973624529639 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624529671 = PRIM_CAR(x139973624529639);
-Obj x139973624529703 = PRIM_CAR(x139973624529671);
-Obj x139973624529735 = PRIM_EQ(symlambda, x139973624529703);
-if (True == x139973624529735) {
-Obj x139973624530663 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624530695 = PRIM_CAR(x139973624530663);
-Obj x139973624530727 = PRIM_CDR(x139973624530695);
-Obj x139973624530759 = PRIM_ISCONS(x139973624530727);
-if (True == x139973624530759) {
-Obj x139973624531783 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624531815 = PRIM_CAR(x139973624531783);
-Obj x139973624531847 = PRIM_CDR(x139973624531815);
-Obj x139973624531879 = PRIM_CAR(x139973624531847);
-Obj args = x139973624531879;
-Obj x139973624516615 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624516647 = PRIM_CAR(x139973624516615);
-Obj x139973624516679 = PRIM_CDR(x139973624516647);
-Obj x139973624516711 = PRIM_CDR(x139973624516679);
-Obj x139973624516871 = PRIM_ISCONS(x139973624516711);
-if (True == x139973624516871) {
-Obj x139973624517991 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624518023 = PRIM_CAR(x139973624517991);
-Obj x139973624518119 = PRIM_CDR(x139973624518023);
-Obj x139973624518151 = PRIM_CDR(x139973624518119);
-Obj x139973624518183 = PRIM_CAR(x139973624518151);
-Obj body = x139973624518183;
-Obj x139973624519815 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624519847 = PRIM_CAR(x139973624519815);
-Obj x139973624519879 = PRIM_CDR(x139973624519847);
-Obj x139973624519911 = PRIM_CDR(x139973624519879);
-Obj x139973624519943 = PRIM_CDR(x139973624519911);
-Obj x139973624519975 = PRIM_EQ(Nil, x139973624519943);
-if (True == x139973624519975) {
-Obj x139973624520519 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624520551 = PRIM_CDR(x139973624520519);
-Obj frees = x139973624520551;
+Obj x139731070376167 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731069045703 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069045703) {
+Obj x139731069046407 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069046439 = PRIM_EQ(sym_37closure, x139731069046407);
+if (True == x139731069046439) {
+Obj x139731068895399 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068895463 = PRIM_ISCONS(x139731068895399);
+if (True == x139731068895463) {
+Obj x139731068896999 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068897031 = PRIM_CAR(x139731068896999);
+Obj x139731068897063 = PRIM_ISCONS(x139731068897031);
+if (True == x139731068897063) {
+Obj x139731068898023 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068898055 = PRIM_CAR(x139731068898023);
+Obj x139731068898087 = PRIM_CAR(x139731068898055);
+Obj x139731068898119 = PRIM_EQ(symlambda, x139731068898087);
+if (True == x139731068898119) {
+Obj x139731068899079 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068899111 = PRIM_CAR(x139731068899079);
+Obj x139731068899143 = PRIM_CDR(x139731068899111);
+Obj x139731068899175 = PRIM_ISCONS(x139731068899143);
+if (True == x139731068899175) {
+Obj x139731068892039 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068892071 = PRIM_CAR(x139731068892039);
+Obj x139731068892103 = PRIM_CDR(x139731068892071);
+Obj x139731068892231 = PRIM_CAR(x139731068892103);
+Obj args = x139731068892231;
+Obj x139731068893415 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068893447 = PRIM_CAR(x139731068893415);
+Obj x139731068893479 = PRIM_CDR(x139731068893447);
+Obj x139731068893511 = PRIM_CDR(x139731068893479);
+Obj x139731068893639 = PRIM_ISCONS(x139731068893511);
+if (True == x139731068893639) {
+Obj x139731068894727 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068894759 = PRIM_CAR(x139731068894727);
+Obj x139731068894823 = PRIM_CDR(x139731068894759);
+Obj x139731068894855 = PRIM_CDR(x139731068894823);
+Obj x139731068894951 = PRIM_CAR(x139731068894855);
+Obj body = x139731068894951;
+Obj x139731068888295 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068888327 = PRIM_CAR(x139731068888295);
+Obj x139731068888391 = PRIM_CDR(x139731068888327);
+Obj x139731068888423 = PRIM_CDR(x139731068888391);
+Obj x139731068888455 = PRIM_CDR(x139731068888423);
+Obj x139731068888583 = PRIM_EQ(Nil, x139731068888455);
+if (True == x139731068888583) {
+Obj x139731068889159 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068889255 = PRIM_CDR(x139731068889159);
+Obj frees = x139731068889255;
 Obj next = closureRef(co, 1);
 pushCont(co, 48, clofun6, 3, args, frees, next);
 __nargs = 3;
@@ -9002,7 +9000,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9011,7 +9009,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9020,7 +9018,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9029,7 +9027,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9038,7 +9036,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9047,7 +9045,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9056,7 +9054,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9065,7 +9063,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030151;
+__arg0 = x139731070376167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9076,18 +9074,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973624415943 = __arg1;
+Obj x139731068891079 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624416103 = makeCons(x139973624415943, Nil);
-Obj x139973624416135 = makeCons(args, x139973624416103);
-Obj x139973624416167 = makeCons(symlambda, x139973624416135);
-Obj x139973624416231 = makeCons(x139973624416167, frees);
-Obj x139973624416263 = makeCons(sym_37closure, x139973624416231);
+Obj x139731068850215 = makeCons(x139731068891079, Nil);
+Obj x139731068850247 = makeCons(args, x139731068850215);
+Obj x139731068850279 = makeCons(symlambda, x139731068850247);
+Obj x139731068850407 = makeCons(x139731068850279, frees);
+Obj x139731068850439 = makeCons(sym_37closure, x139731068850407);
 __nargs = 2;
 __arg0 = next;
-__arg1 = x139973624416263;
+__arg1 = x139731068850439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9097,18 +9095,18 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973625031815 = makeNative(0, clofun7, 0, 0);
-Obj x139973624688263 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624688263) {
-Obj x139973624639527 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139973624639527;
-Obj x139973624639847 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139973624639847;
+Obj x139731070377831 = makeNative(0, clofun7, 0, 0);
+Obj x139731069043943 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069043943) {
+Obj x139731069044199 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139731069044199;
+Obj x139731069044519 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139731069044519;
 Obj next = closureRef(co, 1);
-Obj x139973624640487 = makeCons(f, args);
+Obj x139731069045159 = makeCons(f, args);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = x139973624640487;
+__arg1 = x139731069045159;
 __arg2 = Nil;
 __arg3 = next;
 co->ctx.frees = __arg0;
@@ -9118,7 +9116,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625031815;
+__arg0 = x139731070377831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9162,10 +9160,10 @@ goto *jumpTable[ps.label];
 label1:
 {
 Obj x = __arg1;
-Obj x139973624686119 = makeCons(x, Nil);
-Obj x139973624686151 = makeCons(symreturn, x139973624686119);
+Obj x139731069389895 = makeCons(x, Nil);
+Obj x139731069389927 = makeCons(symreturn, x139731069389895);
 __nargs = 2;
-__arg1 = x139973624686151;
+__arg1 = x139731069389927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9173,12 +9171,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label2:
 {
-Obj x139973625852263 = __arg1;
-Obj x139973625852295 = __arg2;
-Obj x139973625852679 = makeNative(4, clofun7, 0, 2, x139973625852263, x139973625852295);
-Obj __ = x139973625852263;
-Obj x = x139973625852295;
-pushCont(co, 3, clofun7, 2, x, x139973625852679);
+Obj x139731069927431 = __arg1;
+Obj x139731069927463 = __arg2;
+Obj x139731069927847 = makeNative(4, clofun7, 0, 2, x139731069927431, x139731069927463);
+Obj __ = x139731069927431;
+Obj x = x139731069927463;
+pushCont(co, 3, clofun7, 2, x, x139731069927847);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9191,10 +9189,10 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973624684743 = __arg1;
+Obj x139731069388775 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973625852679= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624684743) {
+Obj x139731069927847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731069388775) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9202,7 +9200,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625852679;
+__arg0 = x139731069927847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9213,11 +9211,11 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973625853223 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731069928391 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj x139973624846471 = primIsSymbol(var);
-if (True == x139973624846471) {
+Obj x139731069386823 = primIsSymbol(var);
+if (True == x139731069386823) {
 pushCont(co, 5, clofun7, 1, var);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -9230,7 +9228,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625853223;
+__arg0 = x139731069928391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9241,21 +9239,21 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973624846919 = __arg1;
+Obj x139731069387239 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pos = x139973624846919;
-Obj x139973624847271 = PRIM_EQ(MAKE_NUMBER(-1), pos);
-if (True == x139973624847271) {
+Obj pos = x139731069387239;
+Obj x139731069387591 = PRIM_EQ(MAKE_NUMBER(-1), pos);
+if (True == x139731069387591) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139973624847719 = makeCons(pos, Nil);
-Obj x139973624847751 = makeCons(sym_37closure_45ref, x139973624847719);
+Obj x139731069388039 = makeCons(pos, Nil);
+Obj x139731069388103 = makeCons(sym_37closure_45ref, x139731069388039);
 __nargs = 2;
-__arg1 = x139973624847751;
+__arg1 = x139731069388103;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9264,39 +9262,39 @@ goto *jumpTable[co->ctx.pc.label];
 
 label6:
 {
-Obj x139973625853767 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731069928935 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj x139973625016103 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973625016103) {
-Obj x139973624914311 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624914343 = PRIM_EQ(symlambda, x139973624914311);
-if (True == x139973624914343) {
-Obj x139973624914855 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624914887 = PRIM_ISCONS(x139973624914855);
-if (True == x139973624914887) {
-Obj x139973624915367 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624915399 = PRIM_CAR(x139973624915367);
-Obj args = x139973624915399;
-Obj x139973624916359 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624916391 = PRIM_CDR(x139973624916359);
-Obj x139973624916423 = PRIM_ISCONS(x139973624916391);
-if (True == x139973624916423) {
-Obj x139973624917191 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624917223 = PRIM_CDR(x139973624917191);
-Obj x139973624917287 = PRIM_CAR(x139973624917223);
-Obj body = x139973624917287;
-Obj x139973624889575 = PRIM_CDR(closureRef(co, 1));
-Obj x139973624889639 = PRIM_CDR(x139973624889575);
-Obj x139973624889863 = PRIM_CDR(x139973624889639);
-Obj x139973624889895 = PRIM_EQ(Nil, x139973624889863);
-if (True == x139973624889895) {
-Obj x139973624890983 = makeCons(body, Nil);
-Obj x139973624891047 = makeCons(args, x139973624890983);
-Obj x139973624891079 = makeCons(symlambda, x139973624891047);
+Obj x139731069962855 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731069962855) {
+Obj x139731069963591 = PRIM_CAR(closureRef(co, 1));
+Obj x139731069963623 = PRIM_EQ(symlambda, x139731069963591);
+if (True == x139731069963623) {
+Obj x139731069964231 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069964263 = PRIM_ISCONS(x139731069964231);
+if (True == x139731069964263) {
+Obj x139731069928007 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069928039 = PRIM_CAR(x139731069928007);
+Obj args = x139731069928039;
+Obj x139731069928711 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069928743 = PRIM_CDR(x139731069928711);
+Obj x139731069928775 = PRIM_ISCONS(x139731069928743);
+if (True == x139731069928775) {
+Obj x139731069929575 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069929607 = PRIM_CDR(x139731069929575);
+Obj x139731069929639 = PRIM_CAR(x139731069929607);
+Obj body = x139731069929639;
+Obj x139731069930631 = PRIM_CDR(closureRef(co, 1));
+Obj x139731069930663 = PRIM_CDR(x139731069930631);
+Obj x139731069930695 = PRIM_CDR(x139731069930663);
+Obj x139731069930727 = PRIM_EQ(Nil, x139731069930695);
+if (True == x139731069930727) {
+Obj x139731069550855 = makeCons(body, Nil);
+Obj x139731069550919 = makeCons(args, x139731069550855);
+Obj x139731069550951 = makeCons(symlambda, x139731069550919);
 pushCont(co, 7, clofun7, 3, body, args, fvs);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139973624891079;
+__arg1 = x139731069550951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9304,16 +9302,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625853767;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973625853767;
+__arg0 = x139731069928935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9322,7 +9311,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625853767;
+__arg0 = x139731069928935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9331,7 +9320,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625853767;
+__arg0 = x139731069928935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9340,7 +9329,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625853767;
+__arg0 = x139731069928935;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731069928935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9351,11 +9349,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973624891111 = __arg1;
+Obj x139731069550983 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = x139973624891111;
+Obj fvs1 = x139731069550983;
 pushCont(co, 8, clofun7, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9370,14 +9368,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139973624892903 = __arg1;
+Obj x139731069552487 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139973624892999 = makeCons(x139973624892903, Nil);
-Obj x139973624893031 = makeCons(args, x139973624892999);
-Obj x139973624893063 = makeCons(symlambda, x139973624893031);
-pushCont(co, 9, clofun7, 2, fvs1, x139973624893063);
+Obj x139731069552679 = makeCons(x139731069552487, Nil);
+Obj x139731069552711 = makeCons(args, x139731069552679);
+Obj x139731069552743 = makeCons(symlambda, x139731069552711);
+pushCont(co, 9, clofun7, 2, fvs1, x139731069552743);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9390,13 +9388,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973624844487 = __arg1;
+Obj x139731069553127 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624893063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 10, clofun7, 1, x139973624893063);
+Obj x139731069552743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 10, clofun7, 1, x139731069552743);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973624844487;
+__arg1 = x139731069553127;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9407,12 +9405,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973624844647 = __arg1;
-Obj x139973624893063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624844775 = makeCons(x139973624893063, x139973624844647);
-Obj x139973624844807 = makeCons(sym_37closure, x139973624844775);
+Obj x139731069553287 = __arg1;
+Obj x139731069552743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069553319 = makeCons(x139731069552743, x139731069553287);
+Obj x139731069553351 = makeCons(sym_37closure, x139731069553319);
 __nargs = 2;
-__arg1 = x139973624844807;
+__arg1 = x139731069553351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9420,43 +9418,43 @@ goto *jumpTable[co->ctx.pc.label];
 
 label11:
 {
-Obj x139973625854951 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731069930119 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj x139973625825319 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973625825319) {
-Obj x139973625787463 = PRIM_CAR(closureRef(co, 1));
-Obj x139973625787495 = PRIM_EQ(symlet, x139973625787463);
-if (True == x139973625787495) {
-Obj x139973625787975 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625788007 = PRIM_ISCONS(x139973625787975);
-if (True == x139973625788007) {
-Obj x139973625789383 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625789415 = PRIM_CAR(x139973625789383);
-Obj a = x139973625789415;
-Obj x139973625790215 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625790247 = PRIM_CDR(x139973625790215);
-Obj x139973625790279 = PRIM_ISCONS(x139973625790247);
-if (True == x139973625790279) {
-Obj x139973625029287 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625029319 = PRIM_CDR(x139973625029287);
-Obj x139973625029383 = PRIM_CAR(x139973625029319);
-Obj b = x139973625029383;
-Obj x139973625030311 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625030343 = PRIM_CDR(x139973625030311);
-Obj x139973625030375 = PRIM_CDR(x139973625030343);
-Obj x139973625030407 = PRIM_ISCONS(x139973625030375);
-if (True == x139973625030407) {
-Obj x139973625031399 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625031463 = PRIM_CDR(x139973625031399);
-Obj x139973625031495 = PRIM_CDR(x139973625031463);
-Obj x139973625031559 = PRIM_CAR(x139973625031495);
-Obj c = x139973625031559;
-Obj x139973625012359 = PRIM_CDR(closureRef(co, 1));
-Obj x139973625012391 = PRIM_CDR(x139973625012359);
-Obj x139973625012519 = PRIM_CDR(x139973625012391);
-Obj x139973625012583 = PRIM_CDR(x139973625012519);
-Obj x139973625012615 = PRIM_EQ(Nil, x139973625012583);
-if (True == x139973625012615) {
+Obj x139731070377415 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731070377415) {
+Obj x139731070361735 = PRIM_CAR(closureRef(co, 1));
+Obj x139731070361767 = PRIM_EQ(symlet, x139731070361735);
+if (True == x139731070361767) {
+Obj x139731070362311 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070362407 = PRIM_ISCONS(x139731070362311);
+if (True == x139731070362407) {
+Obj x139731070363207 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070363239 = PRIM_CAR(x139731070363207);
+Obj a = x139731070363239;
+Obj x139731070364071 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070364135 = PRIM_CDR(x139731070364071);
+Obj x139731070364199 = PRIM_ISCONS(x139731070364135);
+if (True == x139731070364199) {
+Obj x139731070365063 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070365095 = PRIM_CDR(x139731070365063);
+Obj x139731070365127 = PRIM_CAR(x139731070365095);
+Obj b = x139731070365127;
+Obj x139731070034439 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070034471 = PRIM_CDR(x139731070034439);
+Obj x139731070034503 = PRIM_CDR(x139731070034471);
+Obj x139731070034567 = PRIM_ISCONS(x139731070034503);
+if (True == x139731070034567) {
+Obj x139731070035655 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070035687 = PRIM_CDR(x139731070035655);
+Obj x139731070035751 = PRIM_CDR(x139731070035687);
+Obj x139731070035783 = PRIM_CAR(x139731070035751);
+Obj c = x139731070035783;
+Obj x139731070037127 = PRIM_CDR(closureRef(co, 1));
+Obj x139731070037159 = PRIM_CDR(x139731070037127);
+Obj x139731070037191 = PRIM_CDR(x139731070037159);
+Obj x139731070037223 = PRIM_CDR(x139731070037191);
+Obj x139731070037255 = PRIM_EQ(Nil, x139731070037223);
+if (True == x139731070037255) {
 pushCont(co, 12, clofun7, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9469,7 +9467,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9478,7 +9476,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9487,7 +9485,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9496,7 +9494,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9505,7 +9503,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9514,7 +9512,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625854951;
+__arg0 = x139731069930119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9525,11 +9523,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973625013639 = __arg1;
+Obj x139731069960391 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 13, clofun7, 2, x139973625013639, a);
+pushCont(co, 13, clofun7, 2, x139731069960391, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9543,15 +9541,15 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973625014183 = __arg1;
-Obj x139973625013639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069960935 = __arg1;
+Obj x139731069960391= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625014247 = makeCons(x139973625014183, Nil);
-Obj x139973625014279 = makeCons(x139973625013639, x139973625014247);
-Obj x139973625014311 = makeCons(a, x139973625014279);
-Obj x139973625014375 = makeCons(symlet, x139973625014311);
+Obj x139731069961031 = makeCons(x139731069960935, Nil);
+Obj x139731069961063 = makeCons(x139731069960391, x139731069961031);
+Obj x139731069961255 = makeCons(a, x139731069961063);
+Obj x139731069961287 = makeCons(symlet, x139731069961255);
 __nargs = 2;
-__arg1 = x139973625014375;
+__arg1 = x139731069961287;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9559,14 +9557,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label14:
 {
-Obj x139973625823591 = makeNative(16, clofun7, 0, 0);
+Obj x139731069550599 = makeNative(16, clofun7, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj x139973625855879 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973625855879) {
-Obj x139973625823431 = PRIM_CAR(closureRef(co, 1));
-Obj f = x139973625823431;
-Obj x139973625823847 = PRIM_CDR(closureRef(co, 1));
-Obj args = x139973625823847;
+Obj x139731070374087 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731070374087) {
+Obj x139731070374375 = PRIM_CAR(closureRef(co, 1));
+Obj f = x139731070374375;
+Obj x139731070374759 = PRIM_CDR(closureRef(co, 1));
+Obj args = x139731070374759;
 pushCont(co, 15, clofun7, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9578,7 +9576,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625823591;
+__arg0 = x139731069550599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9589,14 +9587,14 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139973625824263 = __arg1;
+Obj x139731070375495 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973625824679 = makeCons(f, args);
+Obj x139731070375943 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973625824263;
-__arg2 = x139973625824679;
+__arg1 = x139731070375495;
+__arg2 = x139731070375943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9618,10 +9616,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973624002151 = __arg1;
-Obj x139973624002375 = makeNative(19, clofun7, 0, 1, x139973624002151);
-Obj x = x139973624002151;
-pushCont(co, 18, clofun7, 1, x139973624002375);
+Obj x139731070363719 = __arg1;
+Obj x139731070363943 = makeNative(19, clofun7, 0, 1, x139731070363719);
+Obj x = x139731070363719;
+pushCont(co, 18, clofun7, 1, x139731070363943);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9634,9 +9632,9 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139973625853639 = __arg1;
-Obj x139973624002375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139973625853639) {
+Obj x139731070514887 = __arg1;
+Obj x139731070363943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139731070514887) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9644,7 +9642,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624002375;
+__arg0 = x139731070363943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9655,19 +9653,19 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624002695 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731070364263 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj x139973625852775 = primIsSymbol(x);
-if (True == x139973625852775) {
-Obj x139973625852999 = makeCons(x, Nil);
+Obj x139731070513447 = primIsSymbol(x);
+if (True == x139731070513447) {
+Obj x139731070514247 = makeCons(x, Nil);
 __nargs = 2;
-__arg1 = x139973625852999;
+__arg1 = x139731070514247;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624002695;
+__arg0 = x139731070364263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9678,31 +9676,31 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973624003015 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624001287 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624001287) {
-Obj x139973624001767 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624001799 = PRIM_EQ(symlambda, x139973624001767);
-if (True == x139973624001799) {
-Obj x139973624002279 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624002311 = PRIM_ISCONS(x139973624002279);
-if (True == x139973624002311) {
-Obj x139973624002855 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624002887 = PRIM_CAR(x139973624002855);
-Obj args = x139973624002887;
-Obj x139973624003559 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624003591 = PRIM_CDR(x139973624003559);
-Obj x139973624003623 = PRIM_ISCONS(x139973624003591);
-if (True == x139973624003623) {
-Obj x139973624004391 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624004423 = PRIM_CDR(x139973624004391);
-Obj x139973623688071 = PRIM_CAR(x139973624004423);
-Obj body = x139973623688071;
-Obj x139973623688839 = PRIM_CDR(closureRef(co, 0));
-Obj x139973623688871 = PRIM_CDR(x139973623688839);
-Obj x139973623688903 = PRIM_CDR(x139973623688871);
-Obj x139973623688935 = PRIM_EQ(Nil, x139973623688903);
-if (True == x139973623688935) {
+Obj x139731070364583 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068739207 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068739207) {
+Obj x139731068686407 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068686439 = PRIM_EQ(symlambda, x139731068686407);
+if (True == x139731068686439) {
+Obj x139731068686951 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068686983 = PRIM_ISCONS(x139731068686951);
+if (True == x139731068686983) {
+Obj x139731068687399 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068687431 = PRIM_CAR(x139731068687399);
+Obj args = x139731068687431;
+Obj x139731068688007 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068688039 = PRIM_CDR(x139731068688007);
+Obj x139731068688071 = PRIM_ISCONS(x139731068688039);
+if (True == x139731068688071) {
+Obj x139731068688647 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068688679 = PRIM_CDR(x139731068688647);
+Obj x139731068688711 = PRIM_CAR(x139731068688679);
+Obj body = x139731068688711;
+Obj x139731068689479 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068689511 = PRIM_CDR(x139731068689479);
+Obj x139731068689543 = PRIM_CDR(x139731068689511);
+Obj x139731068689575 = PRIM_EQ(Nil, x139731068689543);
+if (True == x139731068689575) {
 pushCont(co, 21, clofun7, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -9714,7 +9712,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624003015;
+__arg0 = x139731070364583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9723,7 +9721,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003015;
+__arg0 = x139731070364583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9732,7 +9730,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003015;
+__arg0 = x139731070364583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9741,7 +9739,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003015;
+__arg0 = x139731070364583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9750,7 +9748,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003015;
+__arg0 = x139731070364583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9761,11 +9759,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139973623681095 = __arg1;
+Obj x139731068689927 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139973623681095;
+__arg1 = x139731068689927;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9776,50 +9774,50 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973624003975 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624278183 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624278183) {
-Obj x139973624278663 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624278695 = PRIM_EQ(symif, x139973624278663);
-if (True == x139973624278695) {
-Obj x139973624221959 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624221991 = PRIM_ISCONS(x139973624221959);
-if (True == x139973624221991) {
-Obj x139973624222663 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624222695 = PRIM_CAR(x139973624222663);
-Obj x = x139973624222695;
-Obj x139973624223495 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624223527 = PRIM_CDR(x139973624223495);
-Obj x139973624223559 = PRIM_ISCONS(x139973624223527);
-if (True == x139973624223559) {
-Obj x139973624224391 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624224423 = PRIM_CDR(x139973624224391);
-Obj x139973624224455 = PRIM_CAR(x139973624224423);
-Obj y = x139973624224455;
-Obj x139973624225255 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624225287 = PRIM_CDR(x139973624225255);
-Obj x139973624225319 = PRIM_CDR(x139973624225287);
-Obj x139973624225351 = PRIM_ISCONS(x139973624225319);
-if (True == x139973624225351) {
-Obj x139973624078855 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624078887 = PRIM_CDR(x139973624078855);
-Obj x139973624078919 = PRIM_CDR(x139973624078887);
-Obj x139973624078951 = PRIM_CAR(x139973624078919);
-Obj z = x139973624078951;
-Obj x139973624080263 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624080295 = PRIM_CDR(x139973624080263);
-Obj x139973624080327 = PRIM_CDR(x139973624080295);
-Obj x139973624080359 = PRIM_CDR(x139973624080327);
-Obj x139973624080423 = PRIM_EQ(Nil, x139973624080359);
-if (True == x139973624080423) {
-Obj x139973624081735 = makeCons(z, Nil);
-Obj x139973624081767 = makeCons(y, x139973624081735);
-Obj x139973624081799 = makeCons(x, x139973624081767);
+Obj x139731070365543 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068819815 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068819815) {
+Obj x139731068820391 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068820423 = PRIM_EQ(symif, x139731068820391);
+if (True == x139731068820423) {
+Obj x139731068820871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068820903 = PRIM_ISCONS(x139731068820871);
+if (True == x139731068820903) {
+Obj x139731068821447 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068821479 = PRIM_CAR(x139731068821447);
+Obj x = x139731068821479;
+Obj x139731068748391 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068748455 = PRIM_CDR(x139731068748391);
+Obj x139731068748583 = PRIM_ISCONS(x139731068748455);
+if (True == x139731068748583) {
+Obj x139731068749991 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068750023 = PRIM_CDR(x139731068749991);
+Obj x139731068750055 = PRIM_CAR(x139731068750023);
+Obj y = x139731068750055;
+Obj x139731068750887 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068750919 = PRIM_CDR(x139731068750887);
+Obj x139731068750951 = PRIM_CDR(x139731068750919);
+Obj x139731068750983 = PRIM_ISCONS(x139731068750951);
+if (True == x139731068750983) {
+Obj x139731068751815 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068751847 = PRIM_CDR(x139731068751815);
+Obj x139731068735495 = PRIM_CDR(x139731068751847);
+Obj x139731068735527 = PRIM_CAR(x139731068735495);
+Obj z = x139731068735527;
+Obj x139731068736647 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068736679 = PRIM_CDR(x139731068736647);
+Obj x139731068736711 = PRIM_CDR(x139731068736679);
+Obj x139731068736743 = PRIM_CDR(x139731068736711);
+Obj x139731068736775 = PRIM_EQ(Nil, x139731068736743);
+if (True == x139731068736775) {
+Obj x139731068737895 = makeCons(z, Nil);
+Obj x139731068737927 = makeCons(y, x139731068737895);
+Obj x139731068737959 = makeCons(x, x139731068737927);
 PUSH_CONT_0(co, 23, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139973624081799;
+__arg2 = x139731068737959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9827,16 +9825,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624003975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624003975;
+__arg0 = x139731070365543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9845,7 +9834,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003975;
+__arg0 = x139731070365543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9854,7 +9843,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003975;
+__arg0 = x139731070365543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9863,7 +9852,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003975;
+__arg0 = x139731070365543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9872,7 +9861,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624003975;
+__arg0 = x139731070365543;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731070365543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9883,12 +9881,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973624081831 = __arg1;
+Obj x139731068737991 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = x139973624081831;
+__arg3 = x139731068737991;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9898,38 +9896,38 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139973623730727 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624341383 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624341383) {
-Obj x139973624341959 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624341991 = PRIM_EQ(symdo, x139973624341959);
-if (True == x139973624341991) {
-Obj x139973624342439 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624342471 = PRIM_ISCONS(x139973624342439);
-if (True == x139973624342471) {
-Obj x139973624343047 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624343079 = PRIM_CAR(x139973624343047);
-Obj x = x139973624343079;
-Obj x139973624343847 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624343879 = PRIM_CDR(x139973624343847);
-Obj x139973624343911 = PRIM_ISCONS(x139973624343879);
-if (True == x139973624343911) {
-Obj x139973624344551 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624274983 = PRIM_CDR(x139973624344551);
-Obj x139973624275015 = PRIM_CAR(x139973624274983);
-Obj y = x139973624275015;
-Obj x139973624275911 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624275975 = PRIM_CDR(x139973624275911);
-Obj x139973624276007 = PRIM_CDR(x139973624275975);
-Obj x139973624276039 = PRIM_EQ(Nil, x139973624276007);
-if (True == x139973624276039) {
-Obj x139973624277063 = makeCons(y, Nil);
-Obj x139973624277095 = makeCons(x, x139973624277063);
+Obj x139731070034951 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068825639 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068825639) {
+Obj x139731068826183 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068826247 = PRIM_EQ(symdo, x139731068826183);
+if (True == x139731068826247) {
+Obj x139731068826727 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068826759 = PRIM_ISCONS(x139731068826727);
+if (True == x139731068826759) {
+Obj x139731068827303 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068827335 = PRIM_CAR(x139731068827303);
+Obj x = x139731068827335;
+Obj x139731068828135 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068828167 = PRIM_CDR(x139731068828135);
+Obj x139731068828199 = PRIM_ISCONS(x139731068828167);
+if (True == x139731068828199) {
+Obj x139731068828871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068828903 = PRIM_CDR(x139731068828871);
+Obj x139731068828935 = PRIM_CAR(x139731068828903);
+Obj y = x139731068828935;
+Obj x139731068817543 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068817575 = PRIM_CDR(x139731068817543);
+Obj x139731068817607 = PRIM_CDR(x139731068817575);
+Obj x139731068817639 = PRIM_EQ(Nil, x139731068817607);
+if (True == x139731068817639) {
+Obj x139731068818599 = makeCons(y, Nil);
+Obj x139731068818631 = makeCons(x, x139731068818599);
 PUSH_CONT_0(co, 25, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139973624277095;
+__arg2 = x139731068818631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9937,16 +9935,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623730727;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973623730727;
+__arg0 = x139731070034951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9955,7 +9944,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623730727;
+__arg0 = x139731070034951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9964,7 +9953,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623730727;
+__arg0 = x139731070034951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9973,7 +9962,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623730727;
+__arg0 = x139731070034951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731070034951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9984,12 +9982,12 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973624277127 = __arg1;
+Obj x139731068818663 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = x139973624277127;
+__arg3 = x139731068818663;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9999,42 +9997,42 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973623731687 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624520487 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624520487) {
-Obj x139973624414631 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624414663 = PRIM_EQ(symlet, x139973624414631);
-if (True == x139973624414663) {
-Obj x139973624415143 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624415175 = PRIM_ISCONS(x139973624415143);
-if (True == x139973624415175) {
-Obj x139973624415623 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624415655 = PRIM_CAR(x139973624415623);
-Obj a = x139973624415655;
-Obj x139973624416455 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624416487 = PRIM_CDR(x139973624416455);
-Obj x139973624416519 = PRIM_ISCONS(x139973624416487);
-if (True == x139973624416519) {
-Obj x139973624417383 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624417415 = PRIM_CDR(x139973624417383);
-Obj x139973624417447 = PRIM_CAR(x139973624417415);
-Obj b = x139973624417447;
-Obj x139973624418215 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624418247 = PRIM_CDR(x139973624418215);
-Obj x139973624418279 = PRIM_CDR(x139973624418247);
-Obj x139973624373287 = PRIM_ISCONS(x139973624418279);
-if (True == x139973624373287) {
-Obj x139973624374087 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624374119 = PRIM_CDR(x139973624374087);
-Obj x139973624374183 = PRIM_CDR(x139973624374119);
-Obj x139973624374215 = PRIM_CAR(x139973624374183);
-Obj c = x139973624374215;
-Obj x139973624375463 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624375495 = PRIM_CDR(x139973624375463);
-Obj x139973624375527 = PRIM_CDR(x139973624375495);
-Obj x139973624375559 = PRIM_CDR(x139973624375527);
-Obj x139973624375687 = PRIM_EQ(Nil, x139973624375559);
-if (True == x139973624375687) {
+Obj x139731070035911 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068889863 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068889863) {
+Obj x139731068890375 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068890439 = PRIM_EQ(symlet, x139731068890375);
+if (True == x139731068890439) {
+Obj x139731068890983 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068891015 = PRIM_ISCONS(x139731068890983);
+if (True == x139731068891015) {
+Obj x139731068850567 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068850663 = PRIM_CAR(x139731068850567);
+Obj a = x139731068850663;
+Obj x139731068851463 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068851527 = PRIM_CDR(x139731068851463);
+Obj x139731068851591 = PRIM_ISCONS(x139731068851527);
+if (True == x139731068851591) {
+Obj x139731068852359 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068852391 = PRIM_CDR(x139731068852359);
+Obj x139731068852423 = PRIM_CAR(x139731068852391);
+Obj b = x139731068852423;
+Obj x139731068853383 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068853415 = PRIM_CDR(x139731068853383);
+Obj x139731068853479 = PRIM_CDR(x139731068853415);
+Obj x139731068853511 = PRIM_ISCONS(x139731068853479);
+if (True == x139731068853511) {
+Obj x139731068833927 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068833959 = PRIM_CDR(x139731068833927);
+Obj x139731068833991 = PRIM_CDR(x139731068833959);
+Obj x139731068834023 = PRIM_CAR(x139731068833991);
+Obj c = x139731068834023;
+Obj x139731068835303 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068835335 = PRIM_CDR(x139731068835303);
+Obj x139731068835399 = PRIM_CDR(x139731068835335);
+Obj x139731068835431 = PRIM_CDR(x139731068835399);
+Obj x139731068835463 = PRIM_EQ(Nil, x139731068835431);
+if (True == x139731068835463) {
 pushCont(co, 27, clofun7, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10046,7 +10044,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10055,7 +10053,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10064,7 +10062,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10073,7 +10071,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10082,7 +10080,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10091,7 +10089,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623731687;
+__arg0 = x139731070035911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10102,10 +10100,10 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139973624376103 = __arg1;
+Obj x139731068835911 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 28, clofun7, 2, a, x139973624376103);
+pushCont(co, 28, clofun7, 2, a, x139731068835911);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = c;
@@ -10118,15 +10116,15 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139973624376551 = __arg1;
+Obj x139731068836359 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624376103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624376839 = makeCons(a, Nil);
-pushCont(co, 29, clofun7, 1, x139973624376103);
+Obj x139731068835911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731068836679 = makeCons(a, Nil);
+pushCont(co, 29, clofun7, 1, x139731068835911);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139973624376551;
-__arg2 = x139973624376839;
+__arg1 = x139731068836359;
+__arg2 = x139731068836679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10136,12 +10134,12 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139973624376871 = __arg1;
-Obj x139973624376103= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068836711 = __arg1;
+Obj x139731068835911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = x139973624376103;
-__arg2 = x139973624376871;
+__arg1 = x139731068835911;
+__arg2 = x139731068836711;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10151,25 +10149,25 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139973623732871 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624517031 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624517031) {
-Obj x139973624517479 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624517511 = PRIM_EQ(sym_37closure, x139973624517479);
-if (True == x139973624517511) {
-Obj x139973624518055 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624518087 = PRIM_ISCONS(x139973624518055);
-if (True == x139973624518087) {
-Obj x139973624518503 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624518535 = PRIM_CAR(x139973624518503);
-Obj lam = x139973624518535;
-Obj x139973624519175 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624519207 = PRIM_CDR(x139973624519175);
-Obj more = x139973624519207;
-Obj x139973624519751 = makeCons(lam, more);
+Obj x139731070037095 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068894503 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068894503) {
+Obj x139731068895143 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068895175 = PRIM_EQ(sym_37closure, x139731068895143);
+if (True == x139731068895175) {
+Obj x139731068887431 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068887463 = PRIM_ISCONS(x139731068887431);
+if (True == x139731068887463) {
+Obj x139731068887879 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068887911 = PRIM_CAR(x139731068887879);
+Obj lam = x139731068887911;
+Obj x139731068888487 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068888519 = PRIM_CDR(x139731068888487);
+Obj more = x139731068888519;
+Obj x139731068889031 = makeCons(lam, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139973624519751;
+__arg1 = x139731068889031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10177,16 +10175,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623732871;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973623732871;
+__arg0 = x139731070037095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10195,7 +10184,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623732871;
+__arg0 = x139731070037095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731070037095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10206,22 +10204,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139973623733607 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624529927 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624529927) {
-Obj x139973624530471 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624530503 = PRIM_EQ(symreturn, x139973624530471);
-if (True == x139973624530503) {
-Obj x139973624530983 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624531015 = PRIM_ISCONS(x139973624530983);
-if (True == x139973624531015) {
-Obj x139973624531431 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624531559 = PRIM_CAR(x139973624531431);
-Obj x = x139973624531559;
-Obj x139973624532167 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624532199 = PRIM_CDR(x139973624532167);
-Obj x139973624532231 = PRIM_EQ(Nil, x139973624532199);
-if (True == x139973624532231) {
+Obj x139731070037831 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731068899047 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068899047) {
+Obj x139731068891399 = PRIM_CAR(closureRef(co, 0));
+Obj x139731068891431 = PRIM_EQ(symreturn, x139731068891399);
+if (True == x139731068891431) {
+Obj x139731068891943 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068891975 = PRIM_ISCONS(x139731068891943);
+if (True == x139731068891975) {
+Obj x139731068892487 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068892519 = PRIM_CAR(x139731068892487);
+Obj x = x139731068892519;
+Obj x139731068893255 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068893287 = PRIM_CDR(x139731068893255);
+Obj x139731068893319 = PRIM_EQ(Nil, x139731068893287);
+if (True == x139731068893319) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = x;
@@ -10232,7 +10230,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623733607;
+__arg0 = x139731070037831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10241,7 +10239,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623733607;
+__arg0 = x139731070037831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10250,7 +10248,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623733607;
+__arg0 = x139731070037831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10259,7 +10257,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623733607;
+__arg0 = x139731070037831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10270,38 +10268,38 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139973623685191 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624687367 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624687367) {
-Obj x139973624687911 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624688007 = PRIM_EQ(symcall, x139973624687911);
-if (True == x139973624688007) {
-Obj x139973624688519 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624688551 = PRIM_ISCONS(x139973624688519);
-if (True == x139973624688551) {
-Obj x139973624639879 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624639911 = PRIM_CAR(x139973624639879);
-Obj exp = x139973624639911;
-Obj x139973624640647 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624640679 = PRIM_CDR(x139973624640647);
-Obj x139973624640711 = PRIM_ISCONS(x139973624640679);
-if (True == x139973624640711) {
-Obj x139973624641415 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624641447 = PRIM_CDR(x139973624641415);
-Obj x139973624641479 = PRIM_CAR(x139973624641447);
-Obj cont = x139973624641479;
-Obj x139973624642471 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624642503 = PRIM_CDR(x139973624642471);
-Obj x139973624642535 = PRIM_CDR(x139973624642503);
-Obj x139973624642567 = PRIM_EQ(Nil, x139973624642535);
-if (True == x139973624642567) {
-Obj x139973624528935 = makeCons(cont, Nil);
-Obj x139973624528967 = makeCons(exp, x139973624528935);
+Obj x139731069960743 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731069043719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069043719) {
+Obj x139731069044263 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069044295 = PRIM_EQ(symcall, x139731069044263);
+if (True == x139731069044295) {
+Obj x139731069044839 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069044871 = PRIM_ISCONS(x139731069044839);
+if (True == x139731069044871) {
+Obj x139731069045287 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069045319 = PRIM_CAR(x139731069045287);
+Obj exp = x139731069045319;
+Obj x139731069046055 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069046087 = PRIM_CDR(x139731069046055);
+Obj x139731069046119 = PRIM_ISCONS(x139731069046087);
+if (True == x139731069046119) {
+Obj x139731069046727 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069046759 = PRIM_CDR(x139731069046727);
+Obj x139731068895239 = PRIM_CAR(x139731069046759);
+Obj cont = x139731068895239;
+Obj x139731068896839 = PRIM_CDR(closureRef(co, 0));
+Obj x139731068896871 = PRIM_CDR(x139731068896839);
+Obj x139731068896935 = PRIM_CDR(x139731068896871);
+Obj x139731068896967 = PRIM_EQ(Nil, x139731068896935);
+if (True == x139731068896967) {
+Obj x139731068897895 = makeCons(cont, Nil);
+Obj x139731068897927 = makeCons(exp, x139731068897895);
 PUSH_CONT_0(co, 33, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139973624528967;
+__arg2 = x139731068897927;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10309,16 +10307,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623685191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973623685191;
+__arg0 = x139731069960743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10327,7 +10316,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623685191;
+__arg0 = x139731069960743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10336,7 +10325,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623685191;
+__arg0 = x139731069960743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10345,7 +10334,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623685191;
+__arg0 = x139731069960743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731069960743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10356,12 +10354,12 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139973624528999 = __arg1;
+Obj x139731068897959 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = x139973624528999;
+__arg3 = x139731068897959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10371,22 +10369,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139973623686151 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624847527 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624847527) {
-Obj x139973624848199 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624848231 = PRIM_EQ(symtailcall, x139973624848199);
-if (True == x139973624848231) {
-Obj x139973624684839 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624684871 = PRIM_ISCONS(x139973624684839);
-if (True == x139973624684871) {
-Obj x139973624685351 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624685383 = PRIM_CAR(x139973624685351);
-Obj exp = x139973624685383;
-Obj x139973624686311 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624686343 = PRIM_CDR(x139973624686311);
-Obj x139973624686375 = PRIM_EQ(Nil, x139973624686343);
-if (True == x139973624686375) {
+Obj x139731069961703 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731069388583 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069388583) {
+Obj x139731069389031 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069389063 = PRIM_EQ(symtailcall, x139731069389031);
+if (True == x139731069389063) {
+Obj x139731069389511 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069389543 = PRIM_ISCONS(x139731069389511);
+if (True == x139731069389543) {
+Obj x139731069390023 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069390055 = PRIM_CAR(x139731069390023);
+Obj exp = x139731069390055;
+Obj x139731069390791 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069390823 = PRIM_CDR(x139731069390791);
+Obj x139731069042695 = PRIM_EQ(Nil, x139731069390823);
+if (True == x139731069042695) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = exp;
@@ -10397,7 +10395,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623686151;
+__arg0 = x139731069961703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10406,7 +10404,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686151;
+__arg0 = x139731069961703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10415,7 +10413,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686151;
+__arg0 = x139731069961703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10424,7 +10422,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686151;
+__arg0 = x139731069961703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10435,31 +10433,31 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139973623686887 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973624890247 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624890247) {
-Obj x139973624890695 = PRIM_CAR(closureRef(co, 0));
-Obj x139973624890855 = PRIM_EQ(symcontinuation, x139973624890695);
-if (True == x139973624890855) {
-Obj x139973624891399 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624891431 = PRIM_ISCONS(x139973624891399);
-if (True == x139973624891431) {
-Obj x139973624891943 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624891975 = PRIM_CAR(x139973624891943);
-Obj arg = x139973624891975;
-Obj x139973624892807 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624892839 = PRIM_CDR(x139973624892807);
-Obj x139973624892871 = PRIM_ISCONS(x139973624892839);
-if (True == x139973624892871) {
-Obj x139973624844519 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624844551 = PRIM_CDR(x139973624844519);
-Obj x139973624844583 = PRIM_CAR(x139973624844551);
-Obj body = x139973624844583;
-Obj x139973624845639 = PRIM_CDR(closureRef(co, 0));
-Obj x139973624845799 = PRIM_CDR(x139973624845639);
-Obj x139973624845831 = PRIM_CDR(x139973624845799);
-Obj x139973624845863 = PRIM_EQ(Nil, x139973624845831);
-if (True == x139973624845863) {
+Obj x139731069962439 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731069550887 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069550887) {
+Obj x139731069551431 = PRIM_CAR(closureRef(co, 0));
+Obj x139731069551463 = PRIM_EQ(symcontinuation, x139731069551431);
+if (True == x139731069551463) {
+Obj x139731069551975 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069552007 = PRIM_ISCONS(x139731069551975);
+if (True == x139731069552007) {
+Obj x139731069552423 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069552455 = PRIM_CAR(x139731069552423);
+Obj arg = x139731069552455;
+Obj x139731069553159 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069553191 = PRIM_CDR(x139731069553159);
+Obj x139731069553223 = PRIM_ISCONS(x139731069553191);
+if (True == x139731069553223) {
+Obj x139731069553927 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069553959 = PRIM_CDR(x139731069553927);
+Obj x139731069553991 = PRIM_CAR(x139731069553959);
+Obj body = x139731069553991;
+Obj x139731069386983 = PRIM_CDR(closureRef(co, 0));
+Obj x139731069387015 = PRIM_CDR(x139731069386983);
+Obj x139731069387047 = PRIM_CDR(x139731069387015);
+Obj x139731069387079 = PRIM_EQ(Nil, x139731069387047);
+if (True == x139731069387079) {
 pushCont(co, 36, clofun7, 1, arg);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10471,7 +10469,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623686887;
+__arg0 = x139731069962439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10480,7 +10478,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686887;
+__arg0 = x139731069962439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10489,7 +10487,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686887;
+__arg0 = x139731069962439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10498,7 +10496,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686887;
+__arg0 = x139731069962439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10507,7 +10505,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973623686887;
+__arg0 = x139731069962439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10518,11 +10516,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139973624846375 = __arg1;
+Obj x139731069387463 = __arg1;
 Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139973624846375;
+__arg1 = x139731069387463;
 __arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -10533,19 +10531,19 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139973623687847 = makeNative(39, clofun7, 0, 0);
-Obj x139973624916967 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624916967) {
-Obj x139973624917255 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139973624917255;
-Obj x139973624917543 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139973624917543;
-Obj x139973624889799 = makeCons(f, args);
+Obj x139731069963399 = makeNative(39, clofun7, 0, 0);
+Obj x139731069929959 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731069929959) {
+Obj x139731069930279 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139731069930279;
+Obj x139731069930599 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139731069930599;
+Obj x139731069931303 = makeCons(f, args);
 PUSH_CONT_0(co, 38, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139973624889799;
+__arg2 = x139731069931303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10553,7 +10551,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973623687847;
+__arg0 = x139731069963399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10564,12 +10562,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139973624889831 = __arg1;
+Obj x139731069931335 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = x139973624889831;
+__arg3 = x139731069931335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10591,23 +10589,23 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973624079431 = __arg1;
-Obj x139973624079655 = makeNative(41, clofun7, 0, 1, x139973624079431);
-Obj x139973625013031 = PRIM_ISCONS(x139973624079431);
-if (True == x139973625013031) {
-Obj x139973625013575 = PRIM_CAR(x139973624079431);
-Obj x139973625013607 = PRIM_EQ(sym_37const, x139973625013575);
-if (True == x139973625013607) {
-Obj x139973625014087 = PRIM_CDR(x139973624079431);
-Obj x139973625014119 = PRIM_ISCONS(x139973625014087);
-if (True == x139973625014119) {
-Obj x139973625014567 = PRIM_CDR(x139973624079431);
-Obj x139973625014599 = PRIM_CAR(x139973625014567);
-Obj x = x139973625014599;
-Obj x139973625015527 = PRIM_CDR(x139973624079431);
-Obj x139973625015591 = PRIM_CDR(x139973625015527);
-Obj x139973625015623 = PRIM_EQ(Nil, x139973625015591);
-if (True == x139973625015623) {
+Obj x139731070375463 = __arg1;
+Obj x139731070375687 = makeNative(41, clofun7, 0, 1, x139731070375463);
+Obj x139731069960551 = PRIM_ISCONS(x139731070375463);
+if (True == x139731069960551) {
+Obj x139731069961095 = PRIM_CAR(x139731070375463);
+Obj x139731069961159 = PRIM_EQ(sym_37const, x139731069961095);
+if (True == x139731069961159) {
+Obj x139731069961767 = PRIM_CDR(x139731070375463);
+Obj x139731069961799 = PRIM_ISCONS(x139731069961767);
+if (True == x139731069961799) {
+Obj x139731069962375 = PRIM_CDR(x139731070375463);
+Obj x139731069962407 = PRIM_CAR(x139731069962375);
+Obj x = x139731069962407;
+Obj x139731069963143 = PRIM_CDR(x139731070375463);
+Obj x139731069963175 = PRIM_CDR(x139731069963143);
+Obj x139731069963207 = PRIM_EQ(Nil, x139731069963175);
+if (True == x139731069963207) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10615,7 +10613,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624079655;
+__arg0 = x139731070375687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10624,7 +10622,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624079655;
+__arg0 = x139731070375687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10633,7 +10631,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624079655;
+__arg0 = x139731070375687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10642,7 +10640,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624079655;
+__arg0 = x139731070375687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10653,22 +10651,22 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139973624080391 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973625030087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625030087) {
-Obj x139973625030599 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625030631 = PRIM_EQ(sym_37global, x139973625030599);
-if (True == x139973625030631) {
-Obj x139973625031079 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625031111 = PRIM_ISCONS(x139973625031079);
-if (True == x139973625031111) {
-Obj x139973625031655 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625031687 = PRIM_CAR(x139973625031655);
-Obj x = x139973625031687;
-Obj x139973625032391 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625032519 = PRIM_CDR(x139973625032391);
-Obj x139973625032551 = PRIM_EQ(Nil, x139973625032519);
-if (True == x139973625032551) {
+Obj x139731070376423 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731070034983 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070034983) {
+Obj x139731070035559 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070035591 = PRIM_EQ(sym_37global, x139731070035559);
+if (True == x139731070035591) {
+Obj x139731070036103 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070036135 = PRIM_ISCONS(x139731070036103);
+if (True == x139731070036135) {
+Obj x139731070036711 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070036743 = PRIM_CAR(x139731070036711);
+Obj x = x139731070036743;
+Obj x139731070037415 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070037447 = PRIM_CDR(x139731070037415);
+Obj x139731070037479 = PRIM_EQ(Nil, x139731070037447);
+if (True == x139731070037479) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10676,7 +10674,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624080391;
+__arg0 = x139731070376423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10685,7 +10683,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624080391;
+__arg0 = x139731070376423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10694,7 +10692,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624080391;
+__arg0 = x139731070376423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10703,7 +10701,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624080391;
+__arg0 = x139731070376423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10714,22 +10712,22 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139973624081127 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973625787783 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625787783) {
-Obj x139973625788359 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625788391 = PRIM_EQ(sym_37builtin, x139973625788359);
-if (True == x139973625788391) {
-Obj x139973625789607 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625789639 = PRIM_ISCONS(x139973625789607);
-if (True == x139973625789639) {
-Obj x139973625790119 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625790151 = PRIM_CAR(x139973625790119);
-Obj op = x139973625790151;
-Obj x139973625029063 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625029095 = PRIM_CDR(x139973625029063);
-Obj x139973625029127 = PRIM_EQ(Nil, x139973625029095);
-if (True == x139973625029127) {
+Obj x139731070377159 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731070363015 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070363015) {
+Obj x139731070363623 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070363655 = PRIM_EQ(sym_37builtin, x139731070363623);
+if (True == x139731070363655) {
+Obj x139731070364295 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070364327 = PRIM_ISCONS(x139731070364295);
+if (True == x139731070364327) {
+Obj x139731070364871 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070364903 = PRIM_CAR(x139731070364871);
+Obj op = x139731070364903;
+Obj x139731070365639 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070365671 = PRIM_CDR(x139731070365639);
+Obj x139731070033927 = PRIM_EQ(Nil, x139731070365671);
+if (True == x139731070033927) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10737,7 +10735,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624081127;
+__arg0 = x139731070377159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10746,7 +10744,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081127;
+__arg0 = x139731070377159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10755,7 +10753,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081127;
+__arg0 = x139731070377159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10764,7 +10762,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081127;
+__arg0 = x139731070377159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10775,22 +10773,22 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139973624081863 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973625855655 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625855655) {
-Obj x139973625823335 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625823367 = PRIM_EQ(symquote, x139973625823335);
-if (True == x139973625823367) {
-Obj x139973625823943 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625823975 = PRIM_ISCONS(x139973625823943);
-if (True == x139973625823975) {
-Obj x139973625824391 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625824423 = PRIM_CAR(x139973625824391);
-Obj x = x139973625824423;
-Obj x139973625825191 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625825223 = PRIM_CDR(x139973625825191);
-Obj x139973625825287 = PRIM_EQ(Nil, x139973625825223);
-if (True == x139973625825287) {
+Obj x139731070377895 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731070374535 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070374535) {
+Obj x139731070375143 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070375175 = PRIM_EQ(symquote, x139731070375143);
+if (True == x139731070375175) {
+Obj x139731070375975 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070376007 = PRIM_ISCONS(x139731070375975);
+if (True == x139731070376007) {
+Obj x139731070377319 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070377351 = PRIM_CAR(x139731070377319);
+Obj x = x139731070377351;
+Obj x139731070361831 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070361863 = PRIM_CDR(x139731070361831);
+Obj x139731070361895 = PRIM_EQ(Nil, x139731070361863);
+if (True == x139731070361895) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10798,7 +10796,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624081863;
+__arg0 = x139731070377895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10807,7 +10805,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081863;
+__arg0 = x139731070377895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10816,7 +10814,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081863;
+__arg0 = x139731070377895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10825,7 +10823,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624081863;
+__arg0 = x139731070377895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10836,22 +10834,22 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973624000679 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
-Obj x139973625852039 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973625852039) {
-Obj x139973625852583 = PRIM_CAR(closureRef(co, 0));
-Obj x139973625852743 = PRIM_EQ(sym_37closure_45ref, x139973625852583);
-if (True == x139973625852743) {
-Obj x139973625853159 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625853191 = PRIM_ISCONS(x139973625853159);
-if (True == x139973625853191) {
-Obj x139973625853735 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625853799 = PRIM_CAR(x139973625853735);
-Obj __ = x139973625853799;
-Obj x139973625854567 = PRIM_CDR(closureRef(co, 0));
-Obj x139973625854695 = PRIM_CDR(x139973625854567);
-Obj x139973625854727 = PRIM_EQ(Nil, x139973625854695);
-if (True == x139973625854727) {
+Obj x139731070362247 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
+Obj x139731070514055 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731070514055) {
+Obj x139731070514663 = PRIM_CAR(closureRef(co, 0));
+Obj x139731070514695 = PRIM_EQ(sym_37closure_45ref, x139731070514663);
+if (True == x139731070514695) {
+Obj x139731070515367 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070515399 = PRIM_ISCONS(x139731070515367);
+if (True == x139731070515399) {
+Obj x139731070515879 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070515911 = PRIM_CAR(x139731070515879);
+Obj __ = x139731070515911;
+Obj x139731070516775 = PRIM_CDR(closureRef(co, 0));
+Obj x139731070516839 = PRIM_CDR(x139731070516775);
+Obj x139731070516871 = PRIM_EQ(Nil, x139731070516839);
+if (True == x139731070516871) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10859,7 +10857,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624000679;
+__arg0 = x139731070362247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10868,7 +10866,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624000679;
+__arg0 = x139731070362247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10877,7 +10875,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624000679;
+__arg0 = x139731070362247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10886,7 +10884,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624000679;
+__arg0 = x139731070362247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10897,7 +10895,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139973624001415 = makeNative(46, clofun7, 0, 0);
+Obj x139731070362983 = makeNative(46, clofun7, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = False;
@@ -10920,12 +10918,12 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139973624224167 = __arg1;
-Obj x139973624224199 = __arg2;
-Obj x139973624224583 = makeNative(48, clofun7, 0, 2, x139973624224167, x139973624224199);
-Obj x139973623686343 = PRIM_EQ(Nil, x139973624224167);
-if (True == x139973623686343) {
-Obj __ = x139973624224199;
+Obj x139731070516103 = __arg1;
+Obj x139731070516135 = __arg2;
+Obj x139731070516519 = makeNative(48, clofun7, 0, 2, x139731070516103, x139731070516135);
+Obj x139731068748039 = PRIM_EQ(Nil, x139731070516103);
+if (True == x139731068748039) {
+Obj __ = x139731070516135;
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10933,7 +10931,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624224583;
+__arg0 = x139731070516519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10944,15 +10942,15 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973624225127 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973623733831 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623733831) {
-Obj x139973623734087 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139973623734087;
-Obj x139973623685223 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139973623685223;
+Obj x139731070517063 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068820039 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068820039) {
+Obj x139731068820327 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731068820327;
+Obj x139731068820583 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731068820583;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 49, clofun7, 3, y, s2, x139973624225127);
+pushCont(co, 49, clofun7, 3, y, s2, x139731070517063);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -10964,7 +10962,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624225127;
+__arg0 = x139731070517063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10975,11 +10973,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973623685575 = __arg1;
+Obj x139731068820935 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624225127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139973623685575) {
+Obj x139731070517063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139731068820935) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
 __arg1 = y;
@@ -10991,7 +10989,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624225127;
+__arg0 = x139731070517063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11022,13 +11020,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139973624078439 = makeNative(2, clofun8, 0, 0);
-Obj x139973623732359 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973623732359) {
-Obj x139973623732615 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139973623732615;
-Obj x139973623732903 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139973623732903;
+Obj x139731070374471 = makeNative(2, clofun8, 0, 0);
+Obj x139731068818439 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068818439) {
+Obj x139731068818759 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731068818759;
+Obj x139731068819015 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731068819015;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 1, clofun8, 1, x);
 __nargs = 3;
@@ -11042,7 +11040,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624078439;
+__arg0 = x139731070374471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11053,11 +11051,11 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973623733383 = __arg1;
+Obj x139731068819591 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973623733415 = makeCons(x, x139973623733383);
+Obj x139731068819623 = makeCons(x, x139731068819591);
 __nargs = 2;
-__arg1 = x139973623733415;
+__arg1 = x139731068819623;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11077,12 +11075,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139973624377095 = __arg1;
-Obj x139973624377127 = __arg2;
-Obj x139973624221863 = makeNative(4, clofun8, 0, 2, x139973624377095, x139973624377127);
-Obj x139973623730983 = PRIM_EQ(Nil, x139973624377095);
-if (True == x139973623730983) {
-Obj s2 = x139973624377127;
+Obj x139731070513383 = __arg1;
+Obj x139731070513415 = __arg2;
+Obj x139731070513799 = makeNative(4, clofun8, 0, 2, x139731070513383, x139731070513415);
+Obj x139731068829287 = PRIM_EQ(Nil, x139731070513383);
+if (True == x139731068829287) {
+Obj s2 = x139731070513415;
 __nargs = 2;
 __arg1 = s2;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -11090,7 +11088,7 @@ if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624221863;
+__arg0 = x139731070513799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11101,15 +11099,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139973624222407 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139973624003751 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624003751) {
-Obj x139973624004039 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139973624004039;
-Obj x139973624004295 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139973624004295;
+Obj x139731070514343 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068827495 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068827495) {
+Obj x139731068827783 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731068827783;
+Obj x139731068828103 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731068828103;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 5, clofun8, 3, y, s2, x139973624222407);
+pushCont(co, 5, clofun8, 3, y, s2, x139731070514343);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -11121,7 +11119,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624222407;
+__arg0 = x139731070514343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11132,11 +11130,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139973623730215 = __arg1;
+Obj x139731068828455 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624222407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139973623730215) {
+Obj x139731070514343= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139731068828455) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
 __arg1 = y;
@@ -11148,7 +11146,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624222407;
+__arg0 = x139731070514343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11159,13 +11157,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139973624223175 = makeNative(8, clofun8, 0, 0);
-Obj x139973624002247 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139973624002247) {
-Obj x139973624002535 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139973624002535;
-Obj x139973624002823 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139973624002823;
+Obj x139731070515111 = makeNative(8, clofun8, 0, 0);
+Obj x139731068825927 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139731068825927) {
+Obj x139731068826215 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139731068826215;
+Obj x139731068826503 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139731068826503;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 7, clofun8, 1, x);
 __nargs = 3;
@@ -11179,7 +11177,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624223175;
+__arg0 = x139731070515111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11190,11 +11188,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139973624003335 = __arg1;
+Obj x139731068827015 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624003367 = makeCons(x, x139973624003335);
+Obj x139731068827047 = makeCons(x, x139731068827015);
 __nargs = 2;
-__arg1 = x139973624003367;
+__arg1 = x139731068827047;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11214,18 +11212,14 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139973624892103 = __arg1;
-Obj x139973624892135 = __arg2;
-Obj x139973624892167 = __arg3;
-Obj x139973624892199 = co->args[4];
-Obj x139973624892231 = co->args[5];
-Obj x139973624893095 = makeNative(13, clofun8, 0, 5, x139973624892103, x139973624892135, x139973624892167, x139973624892199, x139973624892231);
-Obj __ = x139973624892103;
-__ = x139973624892135;
-__ = x139973624892167;
-Obj globals = x139973624892199;
-Obj x = x139973624892231;
-pushCont(co, 10, clofun8, 2, x, x139973624893095);
+Obj x139731068834407 = __arg1;
+Obj x139731068834439 = __arg2;
+Obj x139731068834471 = __arg3;
+Obj x139731068835015 = makeNative(13, clofun8, 0, 3, x139731068834407, x139731068834439, x139731068834471);
+Obj __ = x139731068834407;
+Obj globals = x139731068834439;
+Obj x = x139731068834471;
+pushCont(co, 10, clofun8, 2, x, x139731068835015);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35number_63);
 __arg1 = x;
@@ -11238,21 +11232,21 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139973624225543 = __arg1;
+Obj x139731068853319 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624225543) {
+Obj x139731068835015= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731068853319) {
 if (True == True) {
-Obj x139973624078631 = makeCons(x, Nil);
-Obj x139973624078663 = makeCons(sym_37const, x139973624078631);
+Obj x139731068853767 = makeCons(x, Nil);
+Obj x139731068853799 = makeCons(sym_37const, x139731068853767);
 __nargs = 2;
-__arg1 = x139973624078663;
+__arg1 = x139731068853799;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893095;
+__arg0 = x139731068835015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11260,19 +11254,19 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj x139973624079047 = primIsString(x);
-if (True == x139973624079047) {
+Obj x139731068854247 = primIsString(x);
+if (True == x139731068854247) {
 if (True == True) {
-Obj x139973624079591 = makeCons(x, Nil);
-Obj x139973624079623 = makeCons(sym_37const, x139973624079591);
+Obj x139731068834183 = makeCons(x, Nil);
+Obj x139731068834215 = makeCons(sym_37const, x139731068834183);
 __nargs = 2;
-__arg1 = x139973624079623;
+__arg1 = x139731068834215;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893095;
+__arg0 = x139731068835015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11280,7 +11274,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 11, clofun8, 2, x, x139973624893095);
+pushCont(co, 11, clofun8, 2, x, x139731068835015);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35boolean_63);
 __arg1 = x;
@@ -11295,21 +11289,21 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139973624080039 = __arg1;
+Obj x139731068834695 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624080039) {
+Obj x139731068835015= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731068834695) {
 if (True == True) {
-Obj x139973624080583 = makeCons(x, Nil);
-Obj x139973624080615 = makeCons(sym_37const, x139973624080583);
+Obj x139731068835207 = makeCons(x, Nil);
+Obj x139731068835239 = makeCons(sym_37const, x139731068835207);
 __nargs = 2;
-__arg1 = x139973624080615;
+__arg1 = x139731068835239;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893095;
+__arg0 = x139731068835015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11317,7 +11311,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 12, clofun8, 2, x, x139973624893095);
+pushCont(co, 12, clofun8, 2, x, x139731068835015);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = x;
@@ -11331,21 +11325,21 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139973624081095 = __arg1;
+Obj x139731068835655 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624893095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624081095) {
+Obj x139731068835015= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139731068835655) {
 if (True == True) {
-Obj x139973624081543 = makeCons(x, Nil);
-Obj x139973624081575 = makeCons(sym_37const, x139973624081543);
+Obj x139731068836135 = makeCons(x, Nil);
+Obj x139731068836167 = makeCons(sym_37const, x139731068836135);
 __nargs = 2;
-__arg1 = x139973624081575;
+__arg1 = x139731068836167;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893095;
+__arg0 = x139731068835015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11354,16 +11348,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj x139973624082247 = makeCons(x, Nil);
-Obj x139973624082279 = makeCons(sym_37const, x139973624082247);
+Obj x139731068836775 = makeCons(x, Nil);
+Obj x139731068836807 = makeCons(sym_37const, x139731068836775);
 __nargs = 2;
-__arg1 = x139973624082279;
+__arg1 = x139731068836807;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624893095;
+__arg0 = x139731068835015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11375,26 +11369,24 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139973624845159 = makeNative(15, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068835783 = makeNative(15, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj __ = closureRef(co, 0);
-__ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624278343 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624278343) {
-Obj x139973624278791 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624278919 = PRIM_EQ(symquote, x139973624278791);
-if (True == x139973624278919) {
-Obj x139973624222023 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624222055 = PRIM_ISCONS(x139973624222023);
-if (True == x139973624222055) {
-Obj x139973624222599 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624222631 = PRIM_CAR(x139973624222599);
-Obj x = x139973624222631;
-Obj x139973624223271 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624223399 = PRIM_CDR(x139973624223271);
-Obj x139973624223431 = PRIM_EQ(Nil, x139973624223399);
-if (True == x139973624223431) {
+Obj globals = closureRef(co, 1);
+Obj x139731068889799 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068889799) {
+Obj x139731068890247 = PRIM_CAR(closureRef(co, 2));
+Obj x139731068890279 = PRIM_EQ(symquote, x139731068890247);
+if (True == x139731068890279) {
+Obj x139731068890759 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068890791 = PRIM_ISCONS(x139731068890759);
+if (True == x139731068890791) {
+Obj x139731068850311 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068850343 = PRIM_CAR(x139731068850311);
+Obj x = x139731068850343;
+Obj x139731068851079 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068851111 = PRIM_CDR(x139731068851079);
+Obj x139731068851143 = PRIM_EQ(Nil, x139731068851111);
+if (True == x139731068851143) {
 pushCont(co, 14, clofun8, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
@@ -11407,7 +11399,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624845159;
+__arg0 = x139731068835783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11416,7 +11408,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624845159;
+__arg0 = x139731068835783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11425,7 +11417,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624845159;
+__arg0 = x139731068835783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11434,7 +11426,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624845159;
+__arg0 = x139731068835783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11445,12 +11437,12 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139973624223719 = __arg1;
+Obj x139731068851495 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624224135 = makeCons(x, Nil);
-Obj x139973624224327 = makeCons(sym_37const, x139973624224135);
+Obj x139731068852007 = makeCons(x, Nil);
+Obj x139731068852039 = makeCons(sym_37const, x139731068852007);
 __nargs = 2;
-__arg1 = x139973624224327;
+__arg1 = x139731068852039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11458,14 +11450,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj x139973624846791 = makeNative(18, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068836967 = makeNative(18, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x = closureRef(co, 4);
-Obj x139973624276551 = primIsSymbol(x);
-if (True == x139973624276551) {
+Obj globals = closureRef(co, 1);
+Obj x = closureRef(co, 2);
+Obj x139731068887975 = primIsSymbol(x);
+if (True == x139731068887975) {
 pushCont(co, 16, clofun8, 2, globals, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -11478,7 +11468,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624846791;
+__arg0 = x139731068836967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11489,10 +11479,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139973624276839 = __arg1;
+Obj x139731068888359 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139973624276839) {
+if (True == x139731068888359) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -11514,12 +11504,12 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139973624277191 = __arg1;
+Obj x139731068888711 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624277607 = makeCons(x, Nil);
-Obj x139973624277671 = makeCons(sym_37global, x139973624277607);
+Obj x139731068889191 = makeCons(x, Nil);
+Obj x139731068889223 = makeCons(sym_37global, x139731068889191);
 __nargs = 2;
-__arg1 = x139973624277671;
+__arg1 = x139731068889223;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11527,36 +11517,34 @@ goto *jumpTable[co->ctx.pc.label];
 
 label18:
 {
-Obj x139973624848007 = makeNative(21, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068837735 = makeNative(21, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624376583 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624376583) {
-Obj x139973624377031 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624377063 = PRIM_EQ(symlambda, x139973624377031);
-if (True == x139973624377063) {
-Obj x139973624340679 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624340711 = PRIM_ISCONS(x139973624340679);
-if (True == x139973624340711) {
-Obj x139973624341191 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624341223 = PRIM_CAR(x139973624341191);
-Obj args = x139973624341223;
-Obj x139973624341863 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624341895 = PRIM_CDR(x139973624341863);
-Obj x139973624341927 = PRIM_ISCONS(x139973624341895);
-if (True == x139973624341927) {
-Obj x139973624342535 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624342599 = PRIM_CDR(x139973624342535);
-Obj x139973624342631 = PRIM_CAR(x139973624342599);
-Obj body = x139973624342631;
-Obj x139973624343463 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624343495 = PRIM_CDR(x139973624343463);
-Obj x139973624343527 = PRIM_CDR(x139973624343495);
-Obj x139973624343559 = PRIM_EQ(Nil, x139973624343527);
-if (True == x139973624343559) {
-pushCont(co, 19, clofun8, 5, ns, import, globals, body, args);
+Obj globals = closureRef(co, 1);
+Obj x139731068898215 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068898215) {
+Obj x139731068898695 = PRIM_CAR(closureRef(co, 2));
+Obj x139731068898727 = PRIM_EQ(symlambda, x139731068898695);
+if (True == x139731068898727) {
+Obj x139731068899239 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068899271 = PRIM_ISCONS(x139731068899239);
+if (True == x139731068899271) {
+Obj x139731068891495 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068891527 = PRIM_CAR(x139731068891495);
+Obj args = x139731068891527;
+Obj x139731068892135 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068892167 = PRIM_CDR(x139731068892135);
+Obj x139731068892199 = PRIM_ISCONS(x139731068892167);
+if (True == x139731068892199) {
+Obj x139731068892807 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068892839 = PRIM_CDR(x139731068892807);
+Obj x139731068892871 = PRIM_CAR(x139731068892839);
+Obj body = x139731068892871;
+Obj x139731068893735 = PRIM_CDR(closureRef(co, 2));
+Obj x139731068893767 = PRIM_CDR(x139731068893735);
+Obj x139731068893799 = PRIM_CDR(x139731068893767);
+Obj x139731068893831 = PRIM_EQ(Nil, x139731068893799);
+if (True == x139731068893831) {
+pushCont(co, 19, clofun8, 3, globals, body, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
 __arg1 = args;
@@ -11568,7 +11556,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624848007;
+__arg0 = x139731068837735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11577,7 +11565,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848007;
+__arg0 = x139731068837735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11586,7 +11574,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848007;
+__arg0 = x139731068837735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11595,7 +11583,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848007;
+__arg0 = x139731068837735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11604,7 +11592,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624848007;
+__arg0 = x139731068837735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11615,20 +11603,16 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139973624274951 = __arg1;
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x139731068894791 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 20, clofun8, 1, args);
-__nargs = 6;
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139973624274951;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = body;
+__arg1 = x139731068894791;
+__arg2 = globals;
+__arg3 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11638,13 +11622,13 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139973624275111 = __arg1;
+Obj x139731068894887 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624275175 = makeCons(x139973624275111, Nil);
-Obj x139973624275207 = makeCons(args, x139973624275175);
-Obj x139973624275239 = makeCons(symlambda, x139973624275207);
+Obj x139731068894983 = makeCons(x139731068894887, Nil);
+Obj x139731068895015 = makeCons(args, x139731068894983);
+Obj x139731068895047 = makeCons(symlambda, x139731068895015);
 __nargs = 2;
-__arg1 = x139973624275239;
+__arg1 = x139731068895047;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11652,25 +11636,21 @@ goto *jumpTable[co->ctx.pc.label];
 
 label21:
 {
-Obj x139973624686023 = makeNative(24, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068826855 = makeNative(24, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624373959 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624373959) {
-Obj x139973624374439 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624374471 = PRIM_EQ(symif, x139973624374439);
-if (True == x139973624374471) {
-Obj x139973624374791 = PRIM_CDR(closureRef(co, 4));
-Obj args = x139973624374791;
+Obj globals = closureRef(co, 1);
+Obj x139731068895431 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068895431) {
+Obj x139731068896615 = PRIM_CAR(closureRef(co, 2));
+Obj x139731068896647 = PRIM_EQ(symif, x139731068896615);
+if (True == x139731068896647) {
+Obj x139731068896903 = PRIM_CDR(closureRef(co, 2));
+Obj args = x139731068896903;
 pushCont(co, 22, clofun8, 1, args);
-__nargs = 5;
+__nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
+__arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11678,7 +11658,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624686023;
+__arg0 = x139731068826855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11687,7 +11667,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624686023;
+__arg0 = x139731068826855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11698,12 +11678,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139973624375623 = __arg1;
+Obj x139731068897479 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 23, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973624375623;
+__arg1 = x139731068897479;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -11714,10 +11694,10 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139973624375719 = __arg1;
-Obj x139973624375751 = makeCons(symif, x139973624375719);
+Obj x139731068897543 = __arg1;
+Obj x139731068897575 = makeCons(symif, x139731068897543);
 __nargs = 2;
-__arg1 = x139973624375751;
+__arg1 = x139731068897575;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11725,69 +11705,39 @@ goto *jumpTable[co->ctx.pc.label];
 
 label24:
 {
-Obj x139973624687431 = makeNative(27, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068827815 = makeNative(27, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624529959 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624529959) {
-Obj x139973624530407 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624530439 = PRIM_EQ(symdo, x139973624530407);
-if (True == x139973624530439) {
-Obj x139973624530855 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624530887 = PRIM_ISCONS(x139973624530855);
-if (True == x139973624530887) {
-Obj x139973624531463 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624531495 = PRIM_CAR(x139973624531463);
-Obj x139973624531527 = PRIM_ISCONS(x139973624531495);
-if (True == x139973624531527) {
-Obj x139973624532295 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624532327 = PRIM_CAR(x139973624532295);
-Obj x139973624532359 = PRIM_CAR(x139973624532327);
-Obj x139973624532391 = PRIM_EQ(symimport, x139973624532359);
-if (True == x139973624532391) {
-Obj x139973624516743 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624516775 = PRIM_CAR(x139973624516743);
-Obj x139973624516807 = PRIM_CDR(x139973624516775);
-Obj x139973624516839 = PRIM_ISCONS(x139973624516807);
-if (True == x139973624516839) {
-Obj x139973624517575 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624517607 = PRIM_CAR(x139973624517575);
-Obj x139973624517639 = PRIM_CDR(x139973624517607);
-Obj x139973624517671 = PRIM_CAR(x139973624517639);
-Obj pkg = x139973624517671;
-Obj x139973624518599 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624518631 = PRIM_CAR(x139973624518599);
-Obj x139973624518663 = PRIM_CDR(x139973624518631);
-Obj x139973624518695 = PRIM_CDR(x139973624518663);
-Obj x139973624518727 = PRIM_EQ(Nil, x139973624518695);
-if (True == x139973624518727) {
-Obj x139973624519399 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624519431 = PRIM_CDR(x139973624519399);
-Obj x139973624519463 = PRIM_ISCONS(x139973624519431);
-if (True == x139973624519463) {
-Obj x139973624520071 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624520103 = PRIM_CDR(x139973624520071);
-Obj x139973624520135 = PRIM_CAR(x139973624520103);
-Obj y = x139973624520135;
-Obj x139973624414439 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624414471 = PRIM_CDR(x139973624414439);
-Obj x139973624414503 = PRIM_CDR(x139973624414471);
-Obj x139973624414535 = PRIM_EQ(Nil, x139973624414503);
-if (True == x139973624414535) {
-Obj x139973624414855 = primIsString(pkg);
-if (True == x139973624414855) {
-Obj x139973624416007 = makeCons(pkg, Nil);
-Obj x139973624416039 = makeCons(symimport, x139973624416007);
-pushCont(co, 25, clofun8, 6, pkg, import, env, ns, globals, y);
-__nargs = 6;
+Obj globals = closureRef(co, 1);
+Obj x139731069389383 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731069389383) {
+Obj x139731069389831 = PRIM_CAR(closureRef(co, 2));
+Obj x139731069389863 = PRIM_EQ(symdo, x139731069389831);
+if (True == x139731069389863) {
+Obj x139731069390279 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069390311 = PRIM_ISCONS(x139731069390279);
+if (True == x139731069390311) {
+Obj x139731069390727 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069390759 = PRIM_CAR(x139731069390727);
+Obj x = x139731069390759;
+Obj x139731069043175 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069043207 = PRIM_CDR(x139731069043175);
+Obj x139731069043239 = PRIM_ISCONS(x139731069043207);
+if (True == x139731069043239) {
+Obj x139731069043815 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069043847 = PRIM_CDR(x139731069043815);
+Obj x139731069043879 = PRIM_CAR(x139731069043847);
+Obj y = x139731069043879;
+Obj x139731069044647 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069044679 = PRIM_CDR(x139731069044647);
+Obj x139731069044711 = PRIM_CDR(x139731069044679);
+Obj x139731069044743 = PRIM_EQ(Nil, x139731069044711);
+if (True == x139731069044743) {
+pushCont(co, 25, clofun8, 3, env, globals, y);
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = x139973624416039;
+__arg2 = globals;
+__arg3 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11795,16 +11745,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624687431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624687431;
+__arg0 = x139731068827815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11813,7 +11754,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687431;
+__arg0 = x139731068827815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11822,7 +11763,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687431;
+__arg0 = x139731068827815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11831,7 +11772,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687431;
+__arg0 = x139731068827815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11840,43 +11781,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624687431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624687431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624687431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624687431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624687431;
+__arg0 = x139731068827815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11887,22 +11792,16 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139973624416071 = __arg1;
-Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139973624416839 = makeCons(pkg, import);
-pushCont(co, 26, clofun8, 1, x139973624416071);
-__nargs = 6;
+Obj x139731069045351 = __arg1;
+Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 26, clofun8, 1, x139731069045351);
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = x139973624416839;
-co->args[4] = globals;
-co->args[5] = y;
+__arg2 = globals;
+__arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11912,13 +11811,13 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139973624416935 = __arg1;
-Obj x139973624416071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624416999 = makeCons(x139973624416935, Nil);
-Obj x139973624417031 = makeCons(x139973624416071, x139973624416999);
-Obj x139973624417095 = makeCons(symdo, x139973624417031);
+Obj x139731069045799 = __arg1;
+Obj x139731069045351= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069045863 = makeCons(x139731069045799, Nil);
+Obj x139731069045895 = makeCons(x139731069045351, x139731069045863);
+Obj x139731069045927 = makeCons(symdo, x139731069045895);
 __nargs = 2;
-__arg1 = x139973624417095;
+__arg1 = x139731069045927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11926,43 +11825,50 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x139973624640551 = makeNative(30, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068829223 = makeNative(30, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624687463 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624687463) {
-Obj x139973624687943 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624687975 = PRIM_EQ(symdo, x139973624687943);
-if (True == x139973624687975) {
-Obj x139973624688391 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624688455 = PRIM_ISCONS(x139973624688391);
-if (True == x139973624688455) {
-Obj x139973624639719 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624639751 = PRIM_CAR(x139973624639719);
-Obj x = x139973624639751;
-Obj x139973624640359 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624640391 = PRIM_CDR(x139973624640359);
-Obj x139973624640423 = PRIM_ISCONS(x139973624640391);
-if (True == x139973624640423) {
-Obj x139973624641063 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624641095 = PRIM_CDR(x139973624641063);
-Obj x139973624641127 = PRIM_CAR(x139973624641095);
-Obj y = x139973624641127;
-Obj x139973624641927 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624641959 = PRIM_CDR(x139973624641927);
-Obj x139973624641991 = PRIM_CDR(x139973624641959);
-Obj x139973624642023 = PRIM_EQ(Nil, x139973624641991);
-if (True == x139973624642023) {
-pushCont(co, 28, clofun8, 5, env, ns, import, globals, y);
-__nargs = 6;
+Obj globals = closureRef(co, 1);
+Obj x139731069930023 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731069930023) {
+Obj x139731069930503 = PRIM_CAR(closureRef(co, 2));
+Obj x139731069930535 = PRIM_EQ(symlet, x139731069930503);
+if (True == x139731069930535) {
+Obj x139731069930951 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069930983 = PRIM_ISCONS(x139731069930951);
+if (True == x139731069930983) {
+Obj x139731069931399 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069931431 = PRIM_CAR(x139731069931399);
+Obj a = x139731069931431;
+Obj x139731069551111 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069551143 = PRIM_CDR(x139731069551111);
+Obj x139731069551175 = PRIM_ISCONS(x139731069551143);
+if (True == x139731069551175) {
+Obj x139731069551751 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069551783 = PRIM_CDR(x139731069551751);
+Obj x139731069551815 = PRIM_CAR(x139731069551783);
+Obj b = x139731069551815;
+Obj x139731069552551 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069552583 = PRIM_CDR(x139731069552551);
+Obj x139731069552615 = PRIM_CDR(x139731069552583);
+Obj x139731069552647 = PRIM_ISCONS(x139731069552615);
+if (True == x139731069552647) {
+Obj x139731069553383 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069553415 = PRIM_CDR(x139731069553383);
+Obj x139731069553447 = PRIM_CDR(x139731069553415);
+Obj x139731069553479 = PRIM_CAR(x139731069553447);
+Obj c = x139731069553479;
+Obj x139731069554407 = PRIM_CDR(closureRef(co, 2));
+Obj x139731069554439 = PRIM_CDR(x139731069554407);
+Obj x139731069554471 = PRIM_CDR(x139731069554439);
+Obj x139731069554503 = PRIM_CDR(x139731069554471);
+Obj x139731069554535 = PRIM_EQ(Nil, x139731069554503);
+if (True == x139731069554535) {
+pushCont(co, 28, clofun8, 4, env, globals, c, a);
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = x;
+__arg2 = globals;
+__arg3 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11970,16 +11876,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624640551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624640551;
+__arg0 = x139731068829223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11988,7 +11885,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640551;
+__arg0 = x139731068829223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11997,7 +11894,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640551;
+__arg0 = x139731068829223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12006,7 +11903,25 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973624640551;
+__arg0 = x139731068829223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731068829223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139731068829223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12017,20 +11932,18 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139973624642759 = __arg1;
+Obj x139731069387399 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 29, clofun8, 1, x139973624642759);
-__nargs = 6;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139731069387975 = makeCons(a, env);
+pushCont(co, 29, clofun8, 2, x139731069387399, a);
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = y;
+__arg1 = x139731069387975;
+__arg2 = globals;
+__arg3 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12040,13 +11953,15 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139973624643303 = __arg1;
-Obj x139973624642759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624643367 = makeCons(x139973624643303, Nil);
-Obj x139973624643399 = makeCons(x139973624642759, x139973624643367);
-Obj x139973624643431 = makeCons(symdo, x139973624643399);
+Obj x139731069388071 = __arg1;
+Obj x139731069387399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139731069388135 = makeCons(x139731069388071, Nil);
+Obj x139731069388167 = makeCons(x139731069387399, x139731069388135);
+Obj x139731069388199 = makeCons(a, x139731069388167);
+Obj x139731069388231 = makeCons(symlet, x139731069388199);
 __nargs = 2;
-__arg1 = x139973624643431;
+__arg1 = x139731069388231;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -12054,170 +11969,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label30:
 {
-Obj x139973624642407 = makeNative(33, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj x139731068818567 = makeNative(38, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973624890823 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973624890823) {
-Obj x139973624891335 = PRIM_CAR(closureRef(co, 4));
-Obj x139973624891367 = PRIM_EQ(symlet, x139973624891335);
-if (True == x139973624891367) {
-Obj x139973624891815 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624891847 = PRIM_ISCONS(x139973624891815);
-if (True == x139973624891847) {
-Obj x139973624892423 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624892487 = PRIM_CAR(x139973624892423);
-Obj a = x139973624892487;
-Obj x139973624893127 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624893159 = PRIM_CDR(x139973624893127);
-Obj x139973624893191 = PRIM_ISCONS(x139973624893159);
-if (True == x139973624893191) {
-Obj x139973624844679 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624844711 = PRIM_CDR(x139973624844679);
-Obj x139973624844743 = PRIM_CAR(x139973624844711);
-Obj b = x139973624844743;
-Obj x139973624845671 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624845703 = PRIM_CDR(x139973624845671);
-Obj x139973624845735 = PRIM_CDR(x139973624845703);
-Obj x139973624845767 = PRIM_ISCONS(x139973624845735);
-if (True == x139973624845767) {
-Obj x139973624846663 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624846695 = PRIM_CDR(x139973624846663);
-Obj x139973624846727 = PRIM_CDR(x139973624846695);
-Obj x139973624846759 = PRIM_CAR(x139973624846727);
-Obj c = x139973624846759;
-Obj x139973624847783 = PRIM_CDR(closureRef(co, 4));
-Obj x139973624847815 = PRIM_CDR(x139973624847783);
-Obj x139973624847847 = PRIM_CDR(x139973624847815);
-Obj x139973624847879 = PRIM_CDR(x139973624847847);
-Obj x139973624847911 = PRIM_EQ(Nil, x139973624847879);
-if (True == x139973624847911) {
-pushCont(co, 31, clofun8, 6, env, ns, import, globals, c, a);
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139973624642407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label31:
-{
-Obj x139973624685031 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139973624685671 = makeCons(a, env);
-pushCont(co, 32, clofun8, 2, x139973624685031, a);
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139973624685671;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x139973624685863 = __arg1;
-Obj x139973624685031= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624685927 = makeCons(x139973624685863, Nil);
-Obj x139973624685959 = makeCons(x139973624685031, x139973624685927);
-Obj x139973624685991 = makeCons(a, x139973624685959);
-Obj x139973624686055 = makeCons(symlet, x139973624685991);
-__nargs = 2;
-__arg1 = x139973624686055;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label33:
-{
-Obj x139973624374151 = makeNative(41, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj x139973625014983 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139973625014983) {
-Obj x139973625015335 = PRIM_CAR(closureRef(co, 4));
-Obj op = x139973625015335;
-Obj x139973625015687 = PRIM_CDR(closureRef(co, 4));
-Obj args = x139973625015687;
-pushCont(co, 34, clofun8, 7, op, args, env, ns, import, globals, x139973624374151);
+Obj globals = closureRef(co, 1);
+Obj x139731069960455 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731069960455) {
+Obj x139731069960711 = PRIM_CAR(closureRef(co, 2));
+Obj op = x139731069960711;
+Obj x139731069960999 = PRIM_CDR(closureRef(co, 2));
+Obj args = x139731069960999;
+pushCont(co, 31, clofun8, 5, op, args, env, globals, x139731068818567);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
 __arg1 = op;
@@ -12228,7 +11989,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624374151;
+__arg0 = x139731068818567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12237,18 +11998,16 @@ goto *jumpTable[ps.label];
 }
 }
 
-label34:
+label31:
 {
-Obj x139973625015975 = __arg1;
+Obj x139731069961351 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139973624374151= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-if (True == x139973625015975) {
-pushCont(co, 35, clofun8, 6, op, args, env, ns, import, globals);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139731068818567= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+if (True == x139731069961351) {
+pushCont(co, 32, clofun8, 4, op, args, env, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
 __arg1 = op;
@@ -12259,7 +12018,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624374151;
+__arg0 = x139731068818567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12268,17 +12027,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label35:
+label32:
 {
-Obj x139973625016295 = __arg1;
+Obj x139731069961639 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj required = x139973625016295;
-pushCont(co, 36, clofun8, 7, required, op, args, env, ns, import, globals);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj required = x139731069961639;
+pushCont(co, 33, clofun8, 5, required, op, args, env, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = args;
@@ -12289,41 +12046,37 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label36:
+label33:
 {
-Obj x139973624914183 = __arg1;
+Obj x139731069961927 = __arg1;
 Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-Obj provided = x139973624914183;
-Obj x139973624914471 = PRIM_EQ(required, provided);
-if (True == x139973624914471) {
-Obj x139973624915111 = makeCons(op, Nil);
-Obj x139973624915143 = makeCons(sym_37builtin, x139973624915111);
-pushCont(co, 39, clofun8, 2, args, x139973624915143);
-__nargs = 5;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj provided = x139731069961927;
+Obj x139731069962311 = PRIM_EQ(required, provided);
+if (True == x139731069962311) {
+Obj x139731069962951 = makeCons(op, Nil);
+Obj x139731069962983 = makeCons(sym_37builtin, x139731069962951);
+pushCont(co, 36, clofun8, 2, args, x139731069962983);
+__nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
+__arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139973624916263 = PRIM_GT(required, provided);
-if (True == x139973624916263) {
-Obj x139973624916775 = PRIM_SUB(required, provided);
-pushCont(co, 37, clofun8, 6, op, args, env, ns, import, globals);
+Obj x139731069963815 = PRIM_GT(required, provided);
+if (True == x139731069963815) {
+Obj x139731069927623 = PRIM_SUB(required, provided);
+pushCont(co, 34, clofun8, 4, op, args, env, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139973624916775;
+__arg1 = x139731069927623;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12343,21 +12096,19 @@ goto *jumpTable[ps.label];
 }
 }
 
-label37:
+label34:
 {
-Obj x139973624916839 = __arg1;
+Obj x139731069927687 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj tmp = x139973624916839;
-Obj x139973624889543 = makeCons(op, args);
-pushCont(co, 38, clofun8, 5, tmp, env, ns, import, globals);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj tmp = x139731069927687;
+Obj x139731069928999 = makeCons(op, args);
+pushCont(co, 35, clofun8, 3, tmp, env, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
-__arg1 = x139973624889543;
+__arg1 = x139731069928999;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12366,24 +12117,67 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label38:
+label35:
 {
-Obj x139973624889607 = __arg1;
+Obj x139731069929063 = __arg1;
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139973624889671 = makeCons(x139973624889607, Nil);
-Obj x139973624889735 = makeCons(tmp, x139973624889671);
-Obj x139973624889767 = makeCons(symlambda, x139973624889735);
-__nargs = 6;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139731069929127 = makeCons(x139731069929063, Nil);
+Obj x139731069929191 = makeCons(tmp, x139731069929127);
+Obj x139731069929223 = makeCons(symlambda, x139731069929191);
+__nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
-co->args[5] = x139973624889767;
+__arg2 = globals;
+__arg3 = x139731069929223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x139731069963431 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069962983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 37, clofun8, 1, x139731069962983);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139731069963431;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x139731069963495 = __arg1;
+Obj x139731069962983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731069963527 = makeCons(x139731069962983, x139731069963495);
+__nargs = 2;
+__arg1 = x139731069963527;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label38:
+{
+Obj x139731068819559 = makeNative(40, clofun8, 0, 0);
+Obj env = closureRef(co, 0);
+Obj globals = closureRef(co, 1);
+Obj ls = closureRef(co, 2);
+pushCont(co, 39, clofun8, 1, ls);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = env;
+__arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12393,14 +12187,12 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139973624915815 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624915143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 40, clofun8, 1, x139973624915143);
+Obj x139731070037863 = __arg1;
+Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973624915815;
-__arg2 = args;
+__arg1 = x139731070037863;
+__arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12410,31 +12202,9 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139973624915911 = __arg1;
-Obj x139973624915143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139973624915943 = makeCons(x139973624915143, x139973624915911);
 __nargs = 2;
-__arg1 = x139973624915943;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label41:
-{
-Obj x139973624375591 = makeNative(43, clofun8, 0, 0);
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj globals = closureRef(co, 3);
-Obj ls = closureRef(co, 4);
-pushCont(co, 42, clofun8, 1, ls);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = globals;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12442,14 +12212,42 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label41:
+{
+Obj x139731068852487 = __arg1;
+Obj x139731068852519 = __arg2;
+Obj x139731068852903 = makeNative(42, clofun8, 0, 2, x139731068852487, x139731068852519);
+Obj x139731070034919 = PRIM_EQ(MAKE_NUMBER(0), x139731068852487);
+if (True == x139731070034919) {
+Obj res = x139731068852519;
+__nargs = 2;
+__arg1 = res;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139731068852903;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label42:
 {
-Obj x139973625014343 = __arg1;
-Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139731068853447 = makeNative(43, clofun8, 0, 0);
+Obj n = closureRef(co, 0);
+Obj res = closureRef(co, 1);
+Obj x139731070034119 = PRIM_SUB(n, MAKE_NUMBER(1));
+Obj x139731070034535 = primGenSym();
+Obj x139731070034599 = makeCons(x139731070034535, res);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139973625014343;
-__arg2 = ls;
+__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
+__arg1 = x139731070034119;
+__arg2 = x139731070034599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12471,40 +12269,27 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139973624917639 = __arg1;
-Obj x139973624917671 = __arg2;
-Obj x139973624889383 = makeNative(45, clofun8, 0, 2, x139973624917639, x139973624917671);
-Obj x139973625031527 = PRIM_EQ(MAKE_NUMBER(0), x139973624917639);
-if (True == x139973625031527) {
-Obj res = x139973624917671;
-__nargs = 2;
-__arg1 = res;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139973624889383;
+Obj x = __arg1;
+PUSH_CONT_0(co, 45, clofun8);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35assq);
+__arg1 = x;
+__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
 
 label45:
 {
-Obj x139973624889927 = makeNative(46, clofun8, 0, 0);
-Obj n = closureRef(co, 0);
-Obj res = closureRef(co, 1);
-Obj x139973625030791 = PRIM_SUB(n, MAKE_NUMBER(1));
-Obj x139973625031143 = primGenSym();
-Obj x139973625031207 = makeCons(x139973625031143, res);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139973625030791;
-__arg2 = x139973625031207;
+Obj x139731070363815 = __arg1;
+Obj find = x139731070363815;
+pushCont(co, 46, clofun8, 1, find);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35null_63);
+__arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12514,14 +12299,24 @@ goto *jumpTable[ps.label];
 
 label46:
 {
+Obj x139731070364167 = __arg1;
+Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139731070364167) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg1 = makeCString("ERROR");
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35cadr);
+__arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label47:
@@ -12541,8 +12336,8 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139973625028807 = __arg1;
-Obj find = x139973625028807;
+Obj x139731070362343 = __arg1;
+Obj find = x139731070362343;
 pushCont(co, 49, clofun8, 1, find);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -12556,9 +12351,9 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139973625029159 = __arg1;
+Obj x139731070362823 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139973625029159) {
+if (True == x139731070362823) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -12566,7 +12361,7 @@ if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35cadr);
+__arg0 = globalRef(symcora_47init_35caddr);
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12592,7 +12387,7 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19};
 
 goto *jumpTable[co->ctx.pc.label];
 
@@ -12613,12 +12408,11 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139973625789575 = __arg1;
-Obj find = x139973625789575;
-pushCont(co, 2, clofun9, 1, find);
+Obj x139731070361607 = __arg1;
+PUSH_CONT_0(co, 2, clofun9);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = find;
+__arg1 = x139731070361607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12628,74 +12422,23 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139973625789831 = __arg1;
-Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139973625789831) {
+Obj x139731070361639 = __arg1;
+Obj x139731070361671 = primNot(x139731070361639);
 __nargs = 2;
-__arg1 = makeCString("ERROR");
+__arg1 = x139731070361671;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35caddr);
-__arg1 = find;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label3:
 {
-Obj x = __arg1;
-PUSH_CONT_0(co, 4, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x139973625788103 = __arg1;
-PUSH_CONT_0(co, 5, clofun9);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x139973625788103;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj x139973625788135 = __arg1;
-Obj x139973625788167 = primNot(x139973625788135);
-__nargs = 2;
-__arg1 = x139973625788167;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj x139973624915751 = __arg1;
-Obj x139973624915783 = __arg2;
-Obj x139973624916167 = makeNative(7, clofun9, 0, 2, x139973624915751, x139973624915783);
-Obj x = x139973624915751;
-Obj x139973624277639 = PRIM_EQ(Nil, x139973624915783);
-if (True == x139973624277639) {
+Obj x139731068850599 = __arg1;
+Obj x139731068850631 = __arg2;
+Obj x139731068851015 = makeNative(4, clofun9, 0, 2, x139731068850599, x139731068850631);
+Obj x = x139731068850599;
+Obj x139731068819911 = PRIM_EQ(Nil, x139731068850631);
+if (True == x139731068819911) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -12703,7 +12446,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624916167;
+__arg0 = x139731068851015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12712,17 +12455,17 @@ goto *jumpTable[ps.label];
 }
 }
 
-label7:
+label4:
 {
-Obj x139973624916711 = makeNative(9, clofun9, 0, 0);
+Obj x139731068851559 = makeNative(6, clofun9, 0, 0);
 Obj x = closureRef(co, 0);
-Obj x139973624275943 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973624275943) {
-Obj x139973624276199 = PRIM_CAR(closureRef(co, 1));
-Obj hd = x139973624276199;
-Obj x139973624276455 = PRIM_CDR(closureRef(co, 1));
-Obj tl = x139973624276455;
-pushCont(co, 8, clofun9, 2, x, tl);
+Obj x139731068818151 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731068818151) {
+Obj x139731068818407 = PRIM_CAR(closureRef(co, 1));
+Obj hd = x139731068818407;
+Obj x139731068818695 = PRIM_CDR(closureRef(co, 1));
+Obj tl = x139731068818695;
+pushCont(co, 5, clofun9, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
 __arg1 = x;
@@ -12734,7 +12477,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624916711;
+__arg0 = x139731068851559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12743,13 +12486,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label5:
 {
-Obj x139973624276903 = __arg1;
+Obj x139731068819143 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139973624276967 = PRIM_LT(x139973624276903, MAKE_NUMBER(0));
-if (True == x139973624276967) {
+Obj x139731068819207 = PRIM_LT(x139731068819143, MAKE_NUMBER(0));
+if (True == x139731068819207) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
 __arg1 = x;
@@ -12768,7 +12511,7 @@ goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label9:
+label6:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -12780,7 +12523,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label7:
 {
 Obj x = __arg1;
 Obj l = __arg2;
@@ -12796,16 +12539,16 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label8:
 {
-Obj x139973625014631 = __arg1;
-Obj x139973625014663 = __arg2;
-Obj x139973625014695 = __arg3;
-Obj x139973625015239 = makeNative(12, clofun9, 0, 3, x139973625014631, x139973625014663, x139973625014695);
-Obj __ = x139973625014631;
-Obj x = x139973625014663;
-Obj x139973624343783 = PRIM_EQ(Nil, x139973625014695);
-if (True == x139973624343783) {
+Obj x139731068888039 = __arg1;
+Obj x139731068888071 = __arg2;
+Obj x139731068888103 = __arg3;
+Obj x139731068888647 = makeNative(9, clofun9, 0, 3, x139731068888039, x139731068888071, x139731068888103);
+Obj __ = x139731068888039;
+Obj x = x139731068888071;
+Obj x139731068828615 = PRIM_EQ(Nil, x139731068888103);
+if (True == x139731068828615) {
 __nargs = 2;
 __arg1 = MAKE_NUMBER(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -12813,7 +12556,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625015239;
+__arg0 = x139731068888647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12822,19 +12565,19 @@ goto *jumpTable[ps.label];
 }
 }
 
-label12:
+label9:
 {
-Obj x139973625016007 = makeNative(13, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139731068889415 = makeNative(10, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj x139973624342311 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973624342311) {
-Obj x139973624342567 = PRIM_CAR(closureRef(co, 2));
-Obj a = x139973624342567;
-Obj x139973624342823 = PRIM_CDR(closureRef(co, 2));
-Obj b = x139973624342823;
-Obj x139973624343111 = PRIM_EQ(x, a);
-if (True == x139973624343111) {
+Obj x139731068827079 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068827079) {
+Obj x139731068827367 = PRIM_CAR(closureRef(co, 2));
+Obj a = x139731068827367;
+Obj x139731068827623 = PRIM_CDR(closureRef(co, 2));
+Obj b = x139731068827623;
+Obj x139731068827943 = PRIM_EQ(x, a);
+if (True == x139731068827943) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -12842,7 +12585,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625016007;
+__arg0 = x139731068889415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12851,7 +12594,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625016007;
+__arg0 = x139731068889415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12860,21 +12603,21 @@ goto *jumpTable[ps.label];
 }
 }
 
-label13:
+label10:
 {
-Obj x139973624914599 = makeNative(14, clofun9, 0, 0);
+Obj x139731068890407 = makeNative(11, clofun9, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj x139973624340839 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973624340839) {
-Obj x139973624341095 = PRIM_CAR(closureRef(co, 2));
-Obj a = x139973624341095;
-Obj x139973624341351 = PRIM_CDR(closureRef(co, 2));
-Obj b = x139973624341351;
-Obj x139973624341735 = PRIM_ADD(pos, MAKE_NUMBER(1));
+Obj x139731068837863 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068837863) {
+Obj x139731068825831 = PRIM_CAR(closureRef(co, 2));
+Obj a = x139731068825831;
+Obj x139731068826087 = PRIM_CDR(closureRef(co, 2));
+Obj b = x139731068826087;
+Obj x139731068826471 = PRIM_ADD(pos, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = x139973624341735;
+__arg1 = x139731068826471;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
@@ -12884,7 +12627,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973624914599;
+__arg0 = x139731068890407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12893,7 +12636,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label14:
+label11:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -12905,16 +12648,16 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label12:
 {
-Obj x139973625032423 = __arg1;
-Obj x139973625032455 = __arg2;
-Obj x139973625032487 = __arg3;
-Obj x139973625012551 = makeNative(16, clofun9, 0, 3, x139973625032423, x139973625032455, x139973625032487);
-Obj f = x139973625032423;
-Obj acc = x139973625032455;
-Obj x139973624376231 = PRIM_EQ(Nil, x139973625032487);
-if (True == x139973624376231) {
+Obj x139731068893543 = __arg1;
+Obj x139731068893575 = __arg2;
+Obj x139731068893607 = __arg3;
+Obj x139731068894151 = makeNative(13, clofun9, 0, 3, x139731068893543, x139731068893575, x139731068893607);
+Obj f = x139731068893543;
+Obj acc = x139731068893575;
+Obj x139731068836391 = PRIM_EQ(Nil, x139731068893607);
+if (True == x139731068836391) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -12922,7 +12665,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625012551;
+__arg0 = x139731068894151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12931,18 +12674,18 @@ goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label13:
 {
-Obj x139973625013319 = makeNative(18, clofun9, 0, 0);
+Obj x139731068894919 = makeNative(15, clofun9, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj x139973624374567 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139973624374567) {
-Obj x139973624374855 = PRIM_CAR(closureRef(co, 2));
-Obj x = x139973624374855;
-Obj x139973624375207 = PRIM_CDR(closureRef(co, 2));
-Obj y = x139973624375207;
-pushCont(co, 17, clofun9, 2, f, y);
+Obj x139731068834823 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139731068834823) {
+Obj x139731068835111 = PRIM_CAR(closureRef(co, 2));
+Obj x = x139731068835111;
+Obj x139731068835367 = PRIM_CDR(closureRef(co, 2));
+Obj y = x139731068835367;
+pushCont(co, 14, clofun9, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -12954,7 +12697,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625013319;
+__arg0 = x139731068894919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12963,15 +12706,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label17:
+label14:
 {
-Obj x139973624375655 = __arg1;
+Obj x139731068835815 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = f;
-__arg2 = x139973624375655;
+__arg2 = x139731068835815;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12980,7 +12723,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label15:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
@@ -12992,14 +12735,14 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label16:
 {
-Obj x139973625029479 = __arg1;
-Obj x139973625029511 = __arg2;
-Obj x139973625029895 = makeNative(20, clofun9, 0, 2, x139973625029479, x139973625029511);
-Obj var = x139973625029479;
-Obj x139973624373255 = PRIM_EQ(Nil, x139973625029511);
-if (True == x139973624373255) {
+Obj x139731068898791 = __arg1;
+Obj x139731068898823 = __arg2;
+Obj x139731068899207 = makeNative(17, clofun9, 0, 2, x139731068898791, x139731068898823);
+Obj var = x139731068898791;
+Obj x139731068853927 = PRIM_EQ(Nil, x139731068898823);
+if (True == x139731068853927) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13007,7 +12750,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625029895;
+__arg0 = x139731068899207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13016,34 +12759,34 @@ goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label17:
 {
-Obj x139973625030439 = makeNative(21, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139731068891559 = makeNative(18, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj x139973624415463 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973624415463) {
-Obj x139973624415879 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624415911 = PRIM_ISCONS(x139973624415879);
-if (True == x139973624415911) {
-Obj x139973624416327 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624416359 = PRIM_CAR(x139973624416327);
-Obj x = x139973624416359;
-Obj x139973624416775 = PRIM_CAR(closureRef(co, 1));
-Obj x139973624416807 = PRIM_CDR(x139973624416775);
-Obj y = x139973624416807;
-Obj x139973624417063 = PRIM_CDR(closureRef(co, 1));
-Obj __ = x139973624417063;
-Obj x139973624417351 = PRIM_EQ(var, x);
-if (True == x139973624417351) {
-Obj x139973624417575 = makeCons(x, y);
+Obj x139731068850887 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731068850887) {
+Obj x139731068851335 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068851367 = PRIM_ISCONS(x139731068851335);
+if (True == x139731068851367) {
+Obj x139731068851815 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068851847 = PRIM_CAR(x139731068851815);
+Obj x = x139731068851847;
+Obj x139731068852263 = PRIM_CAR(closureRef(co, 1));
+Obj x139731068852295 = PRIM_CDR(x139731068852263);
+Obj y = x139731068852295;
+Obj x139731068852615 = PRIM_CDR(closureRef(co, 1));
+Obj __ = x139731068852615;
+Obj x139731068852935 = PRIM_EQ(var, x);
+if (True == x139731068852935) {
+Obj x139731068853159 = makeCons(x, y);
 __nargs = 2;
-__arg1 = x139973624417575;
+__arg1 = x139731068853159;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625030439;
+__arg0 = x139731068891559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13052,7 +12795,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030439;
+__arg0 = x139731068891559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13061,7 +12804,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139973625030439;
+__arg0 = x139731068891559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13070,16 +12813,16 @@ goto *jumpTable[ps.label];
 }
 }
 
-label21:
+label18:
 {
-Obj x139973625031431 = makeNative(22, clofun9, 0, 0);
+Obj x139731068892551 = makeNative(19, clofun9, 0, 0);
 Obj var = closureRef(co, 0);
-Obj x139973624414311 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139973624414311) {
-Obj x139973624414567 = PRIM_CAR(closureRef(co, 1));
-Obj __ = x139973624414567;
-Obj x139973624414823 = PRIM_CDR(closureRef(co, 1));
-Obj y = x139973624414823;
+Obj x139731068890631 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139731068890631) {
+Obj x139731068890887 = PRIM_CAR(closureRef(co, 1));
+Obj __ = x139731068890887;
+Obj x139731068850183 = PRIM_CDR(closureRef(co, 1));
+Obj y = x139731068850183;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = var;
@@ -13091,7 +12834,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139973625031431;
+__arg0 = x139731068892551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13100,7 +12843,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label22:
+label19:
 {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -51,27 +51,26 @@
 	0 res => res
 	n res => (temp-list (- n 1) (cons (gensym) res)))
 
-  (defun var-with-ns (var ns)
-    (cond
-     ((= ns "") var)
-     ((symbol-cooked? var) var)
-     (true (intern (string-append ns (string-append "#" (symbol->string var)))))))
+  ;; (defun var-with-ns (var ns)
+  ;;   (cond
+  ;;    ((= ns "") var)
+  ;;    ((symbol-cooked? var) var)
+  ;;    (true (intern (string-append ns (string-append "#" (symbol->string var)))))))
 
-  (func lookup-var
-	s ns [] => (var-with-ns s ns)
-	s ns [import . more] => (let export (value-or (intern (string-append import "#*ns-export*")) ())
-				  (if (elem? s export)
-				      (intern (string-append import (string-append "#" (symbol->string s))))
-				      (lookup-var s ns more))))
+  ;; (func lookup-var
+  ;; 	s ns [] => (var-with-ns s ns)
+  ;; 	s ns [import . more] => (let export (value-or (intern (string-append import "#*ns-export*")) ())
+  ;; 				  (if (elem? s export)
+  ;; 				      (intern (string-append import (string-append "#" (symbol->string s))))
+  ;; 				      (lookup-var s ns more))))
 
   (func parse
 	_ _ _ globals x => ['%const x] where (or (number? x) (string? x) (boolean? x) (null? x))
 	_ _ _ globals ['quote x] => (begin (add-symbol-to-list x globals) ['%const x])
 	env ns import globals x => (if (elem? x env) x
-				       (let v (lookup-var x ns import)
-					    (begin
-					     (add-symbol-to-list v globals)
-					     ['%global v]))) where (symbol? x)
+				       (begin
+					 (add-symbol-to-list x globals)
+					 ['%global x])) where (symbol? x)
 	env ns import globals ['lambda args body] => ['lambda args (parse (append args env) ns import globals body)]
 	env ns import  globals ['if . args] => ['if . (map (parse env ns import globals) args)]
 	env ns import globals ['do ['import pkg] y] => ['do (parse env ns import globals ['import pkg])
@@ -79,11 +78,6 @@
 	    						    	  where (string? pkg)
 	env ns import globals ['do x y] => ['do (parse env ns import globals x) (parse env ns import globals y)]
 	env ns import globals ['let a b c] => ['let a (parse env ns import globals b) (parse (cons a env) ns import globals c)]
-	env _ _ globals ['ns path import body] => (parse env path import globals body)
-	env ns import globals ['def var val] => (let var1 (var-with-ns var ns)
-						     (begin
-						      (add-symbol-to-list var1 globals)
-						      [['%builtin 'set] ['%const var1] (parse env ns import globals val)]))
 	env ns import globals [op . args] => (let required (builtin->args op)
 					  provided (length args)
 					  (cond

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -65,31 +65,28 @@
   ;; 				      (lookup-var s ns more))))
 
   (func parse
-	_ _ _ globals x => ['%const x] where (or (number? x) (string? x) (boolean? x) (null? x))
-	_ _ _ globals ['quote x] => (begin (add-symbol-to-list x globals) ['%const x])
-	env ns import globals x => (if (elem? x env) x
-				       (begin
-					 (add-symbol-to-list x globals)
-					 ['%global x])) where (symbol? x)
-	env ns import globals ['lambda args body] => ['lambda args (parse (append args env) ns import globals body)]
-	env ns import  globals ['if . args] => ['if . (map (parse env ns import globals) args)]
-	env ns import globals ['do ['import pkg] y] => ['do (parse env ns import globals ['import pkg])
-	       	      	      	   	    	       	    (parse env ns (cons pkg import) globals y)]
-	    						    	  where (string? pkg)
-	env ns import globals ['do x y] => ['do (parse env ns import globals x) (parse env ns import globals y)]
-	env ns import globals ['let a b c] => ['let a (parse env ns import globals b) (parse (cons a env) ns import globals c)]
-	env ns import globals [op . args] => (let required (builtin->args op)
+	_ globals x => ['%const x] where (or (number? x) (string? x) (boolean? x) (null? x))
+	_ globals ['quote x] => (begin (add-symbol-to-list x globals) ['%const x])
+	env globals x => (if (elem? x env) x
+			     (begin
+			       (add-symbol-to-list x globals)
+			       ['%global x])) where (symbol? x)
+	env globals ['lambda args body] => ['lambda args (parse (append args env) globals body)]
+	env globals ['if . args] => ['if . (map (parse env globals) args)]
+	env globals ['do x y] => ['do (parse env globals x) (parse env globals y)]
+	env globals ['let a b c] => ['let a (parse env globals b) (parse (cons a env) globals c)]
+	env globals [op . args] => (let required (builtin->args op)
 					  provided (length args)
 					  (cond
-					    ((= required provided)  [['%builtin op] . (map (parse env ns import globals) args)])
+					    ((= required provided)  [['%builtin op] . (map (parse env globals) args)])
 					    ((> required provided)
 					     ;; rewrite partial apply of primitives
 					     ;; (+ x) => (lambda (tmp) (+ x tmp))
 					     (let tmp (temp-list (- required provided) ())
-						  (parse env ns import globals ['lambda tmp (append [op . args] tmp)])))
+						  (parse env globals ['lambda tmp (append [op . args] tmp)])))
 					    (true (error "primitive call mismatch"))))
 	where (builtin? op)
-	env ns import globals ls => (map (parse env ns import globals) ls))
+	env globals ls => (map (parse env globals) ls))
 
   (func union
 	[] s2 => s2
@@ -434,7 +431,7 @@
 			   (display "\n")))
 
   (defun parse-pass (globals exp)
-    (parse [] "" [] globals exp))
+    (parse [] globals exp))
 
   (defun closure-convert-pass (exp)
     (closure-convert [] exp))

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -51,19 +51,6 @@
 	0 res => res
 	n res => (temp-list (- n 1) (cons (gensym) res)))
 
-  ;; (defun var-with-ns (var ns)
-  ;;   (cond
-  ;;    ((= ns "") var)
-  ;;    ((symbol-cooked? var) var)
-  ;;    (true (intern (string-append ns (string-append "#" (symbol->string var)))))))
-
-  ;; (func lookup-var
-  ;; 	s ns [] => (var-with-ns s ns)
-  ;; 	s ns [import . more] => (let export (value-or (intern (string-append import "#*ns-export*")) ())
-  ;; 				  (if (elem? s export)
-  ;; 				      (intern (string-append import (string-append "#" (symbol->string s))))
-  ;; 				      (lookup-var s ns more))))
-
   (func parse
 	_ globals x => ['%const x] where (or (number? x) (string? x) (boolean? x) (null? x))
 	_ globals ['quote x] => (begin (add-symbol-to-list x globals) ['%const x])

--- a/lib/toc/internal.c
+++ b/lib/toc/internal.c
@@ -74,20 +74,6 @@ builtinEscapeStr(struct Cora *co) {
 	coraReturn(co, ret);
 }
 
-static void
-builtinSymbolCooked(struct Cora *co) {
-	Obj sym = co->args[1];
-	char dst[256];
-	symbolStr(sym, dst, 256);
-	for (char *s=dst; *s != 0; s++) {
-		if (*s == '#') {
-			coraReturn(co, True);
-			return;
-		}
-	}
-	coraReturn(co, False);
-}
-
 static struct registerModule module = {
   NULL,
   {
@@ -95,7 +81,6 @@ static struct registerModule module = {
     {"generate-sym", builtinGenerateSym, 2},
     {"generate-num", builtinGenerateNum, 2},
     {"escape-str", builtinEscapeStr, 1},
-    {"symbol-cooked?", builtinSymbolCooked, 1},
     {NULL, NULL, 0},
   }
 };

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -807,6 +807,20 @@ builtinStringAppend(struct Cora *co) {
 	coraReturn(co, val);
 }
 
+static void
+builtinSymbolCooked(struct Cora *co) {
+	Obj sym = co->args[1];
+	char dst[256];
+	symbolStr(sym, dst, 256);
+	for (char *s=dst; *s != 0; s++) {
+		if (*s == '#') {
+			coraReturn(co, True);
+			return;
+		}
+	}
+	coraReturn(co, False);
+}
+
 void
 registerAPI(struct Cora *co, struct registerModule *m, str pkg) {
 	if (m->init != NULL) {
@@ -877,6 +891,7 @@ coraInit(uintptr_t *mark) {
 	primSet(co, intern("try"), makeNative(0, builtinTryCatch, 2, 0));
 	primSet(co, intern("throw"), makeNative(0, builtinThrow, 1, 0));
 	primSet(co, intern("cora/init#*imported*"), Nil);
+	primSet(co, intern("symbol-cooked?"), makeNative(0, builtinSymbolCooked, 1, 0));
 	return co;
 }
 

--- a/src/types.c
+++ b/src/types.c
@@ -225,7 +225,7 @@ symbolStr(Obj sym, char *dest, size_t sz) {
 		return 0;
 	} else if (tag(sym) == TAG_PTR &&
 		   ((scmHead *) ptr(sym))->type == scmHeadSymbol) {
-		snprintf(dest, sz, "%p", ptr(sym));
+		snprintf(dest, sz, "x%ld", sym);
 		return 0;
 	}
 	assert(false);


### PR DESCRIPTION
Remove `ns` and `def` from the kernel lambda
They are added by https://github.com/tiancaiamao/cora/pull/76
kernel lambda shoud be as simple as possible