### PR TITLE
eval,runtime: support mixed using interpreted (lambda ..) and compiled code

### DIFF
--- a/lib/eval.cora
+++ b/lib/eval.cora
@@ -35,22 +35,6 @@
 	s [] => ['fail]
 	s [[a . b] . more] => (if (= s a) ['ok b] (lookup s more)))
 
-  (func extend
-	params [] env k => (k params [] env)
-	[] args env k => (k [] args env)
-	[a . params] [b . args] env k => (extend params args (cons (cons a b) env) k))
-
-  (func apply-h 
-	['lambda params body . env1] args =>
-	(extend params args env1
-		(lambda (p a env2)
-		  (cond
-		   ((and (null? p) (null? a)) (eval body env2))
-		   ((null? a) ['lambda p body . env2])
-		   ((null? p) (let f2 (eval body env2)
-				(apply-h f2 a))))))
-	f args => (apply f args))
-
   (func eval
 	exp env => exp where (or (string? exp) (number? exp) (boolean? exp) (null? exp))
 	exp env => (match (lookup exp env)
@@ -62,6 +46,6 @@
 	['do a b] env => (do (eval a env) (eval b env))
 	['def var val] env => (set var (eval val env))
 	['let a b c] env => (eval c (cons (cons a (eval b env)) env))
-	['lambda params body] env => ['lambda params body . env]
-	[f . args] env => (apply-h (eval f env) (map (lambda (x) (eval x env)) args)))
+	['lambda params body] env => (make-closure-for-eval params body env)
+	[f . args] env => (apply (eval f env) (map (lambda (x) (eval x env)) args)))
   )


### PR DESCRIPTION
At the very beginning, after compile to C is support,
I got the idea to implement a interpreter in cora, and compile that interpreter to c, 
then I can get an interpreter almost for free to support REPL.
But later I realized that the performance is not good enough.

> Peformance of inspect.cora is bad, so codegen a interpreter written in cora maybe not the best solution.

Then I turn to another way to support REPL in https://github.com/tiancaiamao/cora/pull/27
`eval0` is introduced and it only support symbol, const, and calling compiled code.

Later I found that without `(lambda ...)`, the REPL is inconvenient
So it's added in https://github.com/tiancaiamao/cora/pull/81/
But it's a flawed implementation with a limitation: compiled code can not invoke `(lambda ...)` expression provided from the interpreter.

This commit solve that problem and now there is no such limitation any more.
It's free to mix interpreted code and compiled code, although the performance for the prior case is poor.
