### PR TITLE
*: support partial evaluation for macro writer's bill of rights

### DIFF
--- a/init.c
+++ b/init.c
@@ -6,7 +6,6 @@ static void clofun1(struct Cora* co);
 static void clofun2(struct Cora* co);
 static void clofun3(struct Cora* co);
 static void clofun4(struct Cora* co);
-static void clofun5(struct Cora* co);
 
 
 static Obj symcora_47init_35assq;
@@ -66,6 +65,7 @@ static Obj symcora_47init_35builtin_63;
 static Obj symassq;
 static Obj symstring_63;
 static Obj syminteger_63;
+static Obj symnot;
 static Obj symsymbol_63;
 static Obj symgensym;
 static Obj sym_60;
@@ -98,11 +98,9 @@ static Obj symcora_47init_35rewrite_45backquote;
 static Obj symbegin;
 static Obj symdo;
 static Obj symcora_47init_35rewrite_45begin;
+static Obj symcora_47init_35peval;
 static Obj symcora_47init_35parse;
 static Obj symcora_47init_35rewrite_45namespace;
-static Obj symcora_47init_35propagate_45boolean;
-static Obj symnot;
-static Obj symcora_47init_35propagate_45boolean0;
 static Obj symfunc;
 static Obj symcora_47init_35gen_45paramenters;
 static Obj symcora_47init_35rules_45arg_45count;
@@ -228,6 +226,7 @@ symcora_47init_35builtin_63 = intern("cora/init#builtin?");
 symassq = intern("assq");
 symstring_63 = intern("string?");
 syminteger_63 = intern("integer?");
+symnot = intern("not");
 symsymbol_63 = intern("symbol?");
 symgensym = intern("gensym");
 sym_60 = intern("<");
@@ -260,11 +259,9 @@ symcora_47init_35rewrite_45backquote = intern("cora/init#rewrite-backquote");
 symbegin = intern("begin");
 symdo = intern("do");
 symcora_47init_35rewrite_45begin = intern("cora/init#rewrite-begin");
+symcora_47init_35peval = intern("cora/init#peval");
 symcora_47init_35parse = intern("cora/init#parse");
 symcora_47init_35rewrite_45namespace = intern("cora/init#rewrite-namespace");
-symcora_47init_35propagate_45boolean = intern("cora/init#propagate-boolean");
-symnot = intern("not");
-symcora_47init_35propagate_45boolean0 = intern("cora/init#propagate-boolean0");
 symfunc = intern("func");
 symcora_47init_35gen_45paramenters = intern("cora/init#gen-paramenters");
 symcora_47init_35rules_45arg_45count = intern("cora/init#rules-arg-count");
@@ -347,17 +344,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140663454886791 = primSet(co, symnull_63, makeNative(39, clofun5, 1, 0));
-Obj x140663454887527 = primSet(co, symcadr, makeNative(38, clofun5, 1, 0));
-Obj x140663454601543 = primSet(co, symcaar, makeNative(37, clofun5, 1, 0));
-Obj x140663454602279 = primSet(co, symcdar, makeNative(36, clofun5, 1, 0));
-Obj x140663454603015 = primSet(co, symcddr, makeNative(35, clofun5, 1, 0));
-Obj x140663454603943 = primSet(co, symcaddr, makeNative(34, clofun5, 1, 0));
-Obj x140663454605063 = primSet(co, symcadddr, makeNative(33, clofun5, 1, 0));
-Obj x140663454581415 = primSet(co, symcdddr, makeNative(32, clofun5, 1, 0));
-Obj x140663454583271 = primSet(co, symrcons, makeNative(30, clofun5, 1, 0));
-Obj x140663454583815 = primSet(co, sympair_63, makeNative(29, clofun5, 1, 0));
-Obj x140663454540167 = primSet(co, symcora_47init_35reverse_45h, makeNative(28, clofun5, 2, 0));
+Obj x139886475982631 = primSet(co, symnull_63, makeNative(20, clofun4, 1, 0));
+Obj x139886475983047 = primSet(co, symcadr, makeNative(19, clofun4, 1, 0));
+Obj x139886475983463 = primSet(co, symcaar, makeNative(18, clofun4, 1, 0));
+Obj x139886475983879 = primSet(co, symcdar, makeNative(17, clofun4, 1, 0));
+Obj x139886475984295 = primSet(co, symcddr, makeNative(16, clofun4, 1, 0));
+Obj x139886475984807 = primSet(co, symcaddr, makeNative(15, clofun4, 1, 0));
+Obj x139886475596327 = primSet(co, symcadddr, makeNative(14, clofun4, 1, 0));
+Obj x139886475596839 = primSet(co, symcdddr, makeNative(13, clofun4, 1, 0));
+Obj x139886475597799 = primSet(co, symrcons, makeNative(11, clofun4, 1, 0));
+Obj x139886475598119 = primSet(co, sympair_63, makeNative(10, clofun4, 1, 0));
+Obj x139886475598855 = primSet(co, symcora_47init_35reverse_45h, makeNative(9, clofun4, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
@@ -371,19 +368,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140663454540615 = __arg1;
-Obj x140663454540647 = primSet(co, symreverse, x140663454540615);
-Obj x140663454542439 = primSet(co, symmap_45h, makeNative(26, clofun5, 3, 0));
-Obj x140663454543015 = primSet(co, symmap, makeNative(25, clofun5, 2, 0));
-Obj x140663454543303 = primSet(co, sym_42macros_42, Nil);
-Obj x140663454543719 = primGenSym();
-Obj x140663454543751 = primSet(co, sym_42protect_45symbol_42, x140663454543719);
-Obj x140663454499719 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(24, clofun5, 2, 0));
-Obj x140663453988519 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(22, clofun5, 2, 0));
-Obj x140663453989063 = primSet(co, symcora_47init_35macroexpand1, makeNative(21, clofun5, 1, 0));
-Obj x140663453949127 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(15, clofun5, 1, 0));
-Obj x140663453949447 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj x140663453911143 = primSet(co, symdefmacro_45macro, makeNative(11, clofun5, 1, 0));
+Obj x139886475599079 = __arg1;
+Obj x139886475599111 = primSet(co, symreverse, x139886475599079);
+Obj x139886475567239 = primSet(co, symmap_45h, makeNative(7, clofun4, 3, 0));
+Obj x139886475567527 = primSet(co, symmap, makeNative(6, clofun4, 2, 0));
+Obj x139886475567687 = primSet(co, sym_42macros_42, Nil);
+Obj x139886475567911 = primGenSym();
+Obj x139886475567943 = primSet(co, sym_42protect_45symbol_42, x139886475567911);
+Obj x139886475568455 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(5, clofun4, 2, 0));
+Obj x139886475570343 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(2, clofun4, 2, 0));
+Obj x139886475570631 = primSet(co, symcora_47init_35macroexpand1, makeNative(1, clofun4, 1, 0));
+Obj x139886475507879 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(45, clofun3, 1, 0));
+Obj x139886475508039 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
+Obj x139886475509223 = primSet(co, symdefmacro_45macro, makeNative(41, clofun3, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -398,12 +395,12 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140663453911463 = __arg1;
+Obj x139886475509575 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlist;
-__arg2 = makeNative(10, clofun5, 1, 0);
+__arg2 = makeNative(40, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -413,12 +410,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140663453912423 = __arg1;
+Obj x139886475468999 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symdefun;
-__arg2 = makeNative(6, clofun5, 1, 0);
+__arg2 = makeNative(36, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -428,15 +425,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140663453906567 = __arg1;
-Obj x140663454973959 = primSet(co, symelem_63, makeNative(5, clofun5, 2, 0));
-Obj x140663454974695 = primSet(co, symatom_63, makeNative(4, clofun5, 1, 0));
-Obj x140663454977351 = primSet(co, symcora_47init_35rewrite_45let, makeNative(49, clofun4, 1, 0));
+Obj x139886475470087 = __arg1;
+Obj x139886475470887 = primSet(co, symelem_63, makeNative(35, clofun3, 2, 0));
+Obj x139886475471303 = primSet(co, symatom_63, makeNative(34, clofun3, 1, 0));
+Obj x139886475472647 = primSet(co, symcora_47init_35rewrite_45let, makeNative(29, clofun3, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlet;
-__arg2 = makeNative(48, clofun4, 1, 0);
+__arg2 = makeNative(28, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -446,12 +443,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140663454945287 = __arg1;
+Obj x139886475460743 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symcond;
-__arg2 = makeNative(44, clofun4, 1, 0);
+__arg2 = makeNative(24, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -461,13 +458,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140663454948519 = __arg1;
-Obj x140663454918727 = primSet(co, symcora_47init_35rewrite_45or, makeNative(42, clofun4, 1, 0));
+Obj x139886476186343 = __arg1;
+Obj x139886476188199 = primSet(co, symcora_47init_35rewrite_45or, makeNative(22, clofun3, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symor;
-__arg2 = makeNative(41, clofun4, 1, 0);
+__arg2 = makeNative(21, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -477,13 +474,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x140663454919431 = __arg1;
-Obj x140663454897799 = primSet(co, symcora_47init_35rewrite_45and, makeNative(39, clofun4, 1, 0));
+Obj x139886476188615 = __arg1;
+Obj x139886476145159 = primSet(co, symcora_47init_35rewrite_45and, makeNative(19, clofun3, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symand;
-__arg2 = makeNative(38, clofun4, 1, 0);
+__arg2 = makeNative(18, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -493,14 +490,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x140663454898503 = __arg1;
-Obj x140663454899431 = primSet(co, symboolean_63, makeNative(37, clofun4, 1, 0));
-Obj x140663454885319 = primSet(co, symcora_47init_35rcons1, makeNative(34, clofun4, 1, 0));
+Obj x139886476145543 = __arg1;
+Obj x139886476146151 = primSet(co, symboolean_63, makeNative(17, clofun3, 1, 0));
+Obj x139886476147303 = primSet(co, symcora_47init_35rcons1, makeNative(14, clofun3, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symlist_45rest;
-__arg2 = makeNative(33, clofun4, 1, 0);
+__arg2 = makeNative(13, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -510,17 +507,17 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x140663454886023 = __arg1;
-Obj x140663454500455 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(15, clofun4, 4, 0));
-Obj x140663453909063 = primSet(co, symcora_47init_35match1, makeNative(9, clofun4, 4, 0));
-Obj x140663453880583 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(1, clofun4, 2, 0));
-Obj x140663454974279 = primSet(co, symcora_47init_35match_45helper, makeNative(35, clofun3, 2, 0));
-Obj x140663454949191 = primSet(co, symcora_47init_35rewrite_45match, makeNative(28, clofun3, 1, 0));
+Obj x139886476147687 = __arg1;
+Obj x139886476107111 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(4, clofun3, 4, 0));
+Obj x139886476082503 = primSet(co, symcora_47init_35match1, makeNative(48, clofun2, 4, 0));
+Obj x139886475982151 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(43, clofun2, 2, 0));
+Obj x139886475597159 = primSet(co, symcora_47init_35match_45helper, makeNative(34, clofun2, 2, 0));
+Obj x139886475567367 = primSet(co, symcora_47init_35rewrite_45match, makeNative(28, clofun2, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symmatch;
-__arg2 = makeNative(27, clofun3, 1, 0);
+__arg2 = makeNative(27, clofun2, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -530,22 +527,22 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x140663454916999 = __arg1;
-Obj x140663454582471 = primSet(co, symcora_47init_35extract_45rules1, makeNative(20, clofun3, 3, 0));
-Obj x140663454583143 = primSet(co, symcora_47init_35extract_45rules, makeNative(19, clofun3, 1, 0));
-Obj x140663454540231 = primSet(co, symcora_47init_35rules_45patterns, makeNative(16, clofun3, 2, 0));
-Obj x140663454541831 = primSet(co, symcora_47init_35length_45h, makeNative(15, clofun3, 2, 0));
-Obj x140663454542567 = primSet(co, symlength, makeNative(14, clofun3, 1, 0));
-Obj x140663454500711 = primSet(co, symcora_47init_35filter_45h, makeNative(12, clofun3, 3, 0));
-Obj x140663454501383 = primSet(co, symfilter, makeNative(11, clofun3, 2, 0));
-Obj x140663453987367 = primSet(co, symappend, makeNative(9, clofun3, 2, 0));
-Obj x140663453947175 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(2, clofun3, 1, 0));
-Obj x140663453949511 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(0, clofun3, 1, 0));
+Obj x139886475567719 = __arg1;
+Obj x139886475471687 = primSet(co, symcora_47init_35extract_45rules1, makeNative(22, clofun2, 3, 0));
+Obj x139886475472103 = primSet(co, symcora_47init_35extract_45rules, makeNative(21, clofun2, 1, 0));
+Obj x139886475460935 = primSet(co, symcora_47init_35rules_45patterns, makeNative(18, clofun2, 2, 0));
+Obj x139886475461735 = primSet(co, symcora_47init_35length_45h, makeNative(17, clofun2, 2, 0));
+Obj x139886475462535 = primSet(co, symlength, makeNative(16, clofun2, 1, 0));
+Obj x139886475463751 = primSet(co, symcora_47init_35filter_45h, makeNative(14, clofun2, 3, 0));
+Obj x139886475464039 = primSet(co, symfilter, makeNative(13, clofun2, 2, 0));
+Obj x139886475382887 = primSet(co, symappend, makeNative(11, clofun2, 2, 0));
+Obj x139886475384615 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(4, clofun2, 1, 0));
+Obj x139886475385383 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(2, clofun2, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symfunc;
-__arg2 = makeNative(44, clofun2, 1, 0);
+__arg2 = makeNative(46, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -555,17 +552,16 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x140663453912807 = __arg1;
-Obj x140663453668455 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(32, clofun2, 1, 0));
-Obj x140663453989479 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(9, clofun2, 1, 0));
-Obj x140663453990599 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(8, clofun2, 1, 0));
-Obj x140663453947111 = primSet(co, symmacroexpand, makeNative(5, clofun2, 1, 0));
-Obj x140663453882183 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(0, clofun2, 1, 0));
+Obj x139886475329607 = __arg1;
+Obj x139886475329895 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(45, clofun1, 1, 0));
+Obj x139886475330119 = primSet(co, symcora_47init_35peval, makeNative(44, clofun1, 1, 0));
+Obj x139886475330599 = primSet(co, symmacroexpand, makeNative(41, clofun1, 1, 0));
+Obj x139886476186599 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(37, clofun1, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symbegin;
-__arg2 = makeNative(49, clofun1, 1, 0);
+__arg2 = makeNative(36, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -575,13 +571,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x140663453883239 = __arg1;
-Obj x140663453668359 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(43, clofun1, 1, 0));
+Obj x139886476187207 = __arg1;
+Obj x139886476146471 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(33, clofun1, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symbackquote;
-__arg2 = makeNative(41, clofun1, 1, 0);
+__arg2 = makeNative(31, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -591,13 +587,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x140663453669191 = __arg1;
-Obj x140663453640135 = primSet(co, symcora_47init_35rewrite_45fold_45apply, makeNative(36, clofun1, 2, 0));
+Obj x139886476146983 = __arg1;
+Obj x139886476104455 = primSet(co, symcora_47init_35rewrite_45fold_45apply, makeNative(26, clofun1, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = symfold_45apply;
-__arg2 = makeNative(33, clofun1, 1, 0);
+__arg2 = makeNative(23, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -607,14 +603,14 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x140663453641415 = __arg1;
-Obj x140663453333319 = primSet(co, symcora_47init_35parse_45package_45h, makeNative(28, clofun1, 4, 0));
-Obj x140663453333927 = primSet(co, symcora_47init_35parse_45package, makeNative(27, clofun1, 2, 0));
+Obj x139886476105319 = __arg1;
+Obj x139886475981031 = primSet(co, symcora_47init_35parse_45package_45h, makeNative(19, clofun1, 4, 0));
+Obj x139886475981415 = primSet(co, symcora_47init_35parse_45package, makeNative(18, clofun1, 2, 0));
 PUSH_CONT_0(co, 15, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = sympackage;
-__arg2 = makeNative(19, clofun1, 1, 0);
+__arg2 = makeNative(10, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -624,159 +620,159 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x140663455197799 = __arg1;
-Obj x140663455162631 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(14, clofun1, 2, 0));
-Obj x140663455146695 = primSet(co, symcora_47init_35lookup_45var, makeNative(4, clofun1, 3, 0));
-Obj x140663455147719 = makeCons(makeCString("primSet"), Nil);
-Obj x140663455147751 = makeCons(MAKE_NUMBER(2), x140663455147719);
-Obj x140663455147783 = makeCons(symset, x140663455147751);
-Obj x140663455148583 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x140663455148615 = makeCons(MAKE_NUMBER(1), x140663455148583);
-Obj x140663455148647 = makeCons(symcar, x140663455148615);
-Obj x140663455149447 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x140663455149479 = makeCons(MAKE_NUMBER(1), x140663455149447);
-Obj x140663455149511 = makeCons(symcdr, x140663455149479);
-Obj x140663455138023 = makeCons(makeCString("makeCons"), Nil);
-Obj x140663455138055 = makeCons(MAKE_NUMBER(2), x140663455138023);
-Obj x140663455138087 = makeCons(symcons, x140663455138055);
-Obj x140663455138887 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x140663455138919 = makeCons(MAKE_NUMBER(1), x140663455138887);
-Obj x140663455138951 = makeCons(symcons_63, x140663455138919);
-Obj x140663455139751 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x140663455139783 = makeCons(MAKE_NUMBER(2), x140663455139751);
-Obj x140663455139815 = makeCons(sym_43, x140663455139783);
-Obj x140663455140615 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x140663455140647 = makeCons(MAKE_NUMBER(2), x140663455140615);
-Obj x140663455140679 = makeCons(sym_45, x140663455140647);
-Obj x140663455141479 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x140663455195143 = makeCons(MAKE_NUMBER(2), x140663455141479);
-Obj x140663455195175 = makeCons(sym_42, x140663455195143);
-Obj x140663455195975 = makeCons(makeCString("primDiv"), Nil);
-Obj x140663455196007 = makeCons(MAKE_NUMBER(2), x140663455195975);
-Obj x140663455196039 = makeCons(sym_47, x140663455196007);
-Obj x140663455196935 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x140663455196967 = makeCons(MAKE_NUMBER(2), x140663455196935);
-Obj x140663455196999 = makeCons(sym_61, x140663455196967);
-Obj x140663455198215 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x140663455198247 = makeCons(MAKE_NUMBER(2), x140663455198215);
-Obj x140663455198279 = makeCons(sym_62, x140663455198247);
-Obj x140663455199143 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x140663455199175 = makeCons(MAKE_NUMBER(2), x140663455199143);
-Obj x140663455199207 = makeCons(sym_60, x140663455199175);
-Obj x140663455163271 = makeCons(makeCString("primGenSym"), Nil);
-Obj x140663455163303 = makeCons(MAKE_NUMBER(0), x140663455163271);
-Obj x140663455163335 = makeCons(symgensym, x140663455163303);
-Obj x140663455164199 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x140663455164231 = makeCons(MAKE_NUMBER(1), x140663455164199);
-Obj x140663455164295 = makeCons(symsymbol_63, x140663455164231);
-Obj x140663455165191 = makeCons(makeCString("primNot"), Nil);
-Obj x140663455165223 = makeCons(MAKE_NUMBER(1), x140663455165191);
-Obj x140663455165287 = makeCons(symnot, x140663455165223);
-Obj x140663455166183 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x140663455166215 = makeCons(MAKE_NUMBER(1), x140663455166183);
-Obj x140663455166247 = makeCons(syminteger_63, x140663455166215);
-Obj x140663455146599 = makeCons(makeCString("primIsString"), Nil);
-Obj x140663455146631 = makeCons(MAKE_NUMBER(1), x140663455146599);
-Obj x140663455146663 = makeCons(symstring_63, x140663455146631);
-Obj x140663455146759 = makeCons(x140663455146663, Nil);
-Obj x140663455146791 = makeCons(x140663455166247, x140663455146759);
-Obj x140663455146823 = makeCons(x140663455165287, x140663455146791);
-Obj x140663455146855 = makeCons(x140663455164295, x140663455146823);
-Obj x140663455146887 = makeCons(x140663455163335, x140663455146855);
-Obj x140663455146919 = makeCons(x140663455199207, x140663455146887);
-Obj x140663455146951 = makeCons(x140663455198279, x140663455146919);
-Obj x140663455146983 = makeCons(x140663455196999, x140663455146951);
-Obj x140663455147015 = makeCons(x140663455196039, x140663455146983);
-Obj x140663455147047 = makeCons(x140663455195175, x140663455147015);
-Obj x140663455147079 = makeCons(x140663455140679, x140663455147047);
-Obj x140663455147111 = makeCons(x140663455139815, x140663455147079);
-Obj x140663455147143 = makeCons(x140663455138951, x140663455147111);
-Obj x140663455147175 = makeCons(x140663455138087, x140663455147143);
-Obj x140663455147207 = makeCons(x140663455149511, x140663455147175);
-Obj x140663455147239 = makeCons(x140663455148647, x140663455147207);
-Obj x140663455147271 = makeCons(x140663455147783, x140663455147239);
-Obj x140663455147303 = primSet(co, symcora_47init_35_42builtin_45prims_42, x140663455147271);
-Obj x140663454974599 = primSet(co, symassq, makeNative(0, clofun1, 2, 0));
-Obj x140663454976135 = primSet(co, symcora_47init_35builtin_63, makeNative(47, clofun0, 1, 0));
-Obj x140663455354983 = primSet(co, symcora_47init_35parse, makeNative(16, clofun0, 4, 0));
-Obj x140663455366471 = makeCons(symappend, Nil);
-Obj x140663455366503 = makeCons(symfilter, x140663455366471);
-Obj x140663455366535 = makeCons(symlength, x140663455366503);
-Obj x140663455366567 = makeCons(symelem_63, x140663455366535);
-Obj x140663455366599 = makeCons(symmacroexpand, x140663455366567);
-Obj x140663455366631 = makeCons(symmap, x140663455366599);
-Obj x140663455366663 = makeCons(symreverse, x140663455366631);
-Obj x140663455366695 = makeCons(symthrow, x140663455366663);
-Obj x140663455366727 = makeCons(symtry, x140663455366695);
-Obj x140663455366759 = makeCons(symload, x140663455366727);
-Obj x140663455366791 = makeCons(symimport, x140663455366759);
-Obj x140663455366823 = makeCons(symload_45so, x140663455366791);
-Obj x140663455366855 = makeCons(symapply, x140663455366823);
-Obj x140663455366887 = makeCons(symvalue_45or, x140663455366855);
-Obj x140663455366919 = makeCons(symvalue, x140663455366887);
-Obj x140663455366951 = makeCons(symread_45file_45as_45sexp, x140663455366919);
-Obj x140663455366983 = makeCons(symbytes_45length, x140663455366951);
-Obj x140663455367015 = makeCons(symbytes, x140663455366983);
-Obj x140663455367047 = makeCons(symvector_45length, x140663455367015);
-Obj x140663455367079 = makeCons(symvector_45ref, x140663455367047);
-Obj x140663455367111 = makeCons(symvector_45set_33, x140663455367079);
-Obj x140663455367143 = makeCons(symvector, x140663455367111);
-Obj x140663455371271 = makeCons(symsymbol_45_62string, x140663455367143);
-Obj x140663455371303 = makeCons(symintern, x140663455371271);
-Obj x140663455371335 = makeCons(symstring_45append, x140663455371303);
-Obj x140663455371367 = makeCons(symnull_63, x140663455371335);
-Obj x140663455371399 = makeCons(symnumber_63, x140663455371367);
-Obj x140663455371431 = makeCons(symboolean_63, x140663455371399);
-Obj x140663455371463 = makeCons(symatom_63, x140663455371431);
-Obj x140663455371495 = makeCons(sympair_63, x140663455371463);
-Obj x140663455371527 = makeCons(symcdddr, x140663455371495);
-Obj x140663455371559 = makeCons(symcadddr, x140663455371527);
-Obj x140663455371591 = makeCons(symcaddr, x140663455371559);
-Obj x140663455371623 = makeCons(symcddr, x140663455371591);
-Obj x140663455371655 = makeCons(symcdar, x140663455371623);
-Obj x140663455371687 = makeCons(symcaar, x140663455371655);
-Obj x140663455371719 = makeCons(symcadr, x140663455371687);
-Obj x140663455371751 = primSet(co, symcora_47init_35_42ns_45export_42, x140663455371719);
-Obj x140663455372039 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj x140663455372327 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj x140663455372615 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj x140663455372903 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj x140663455373191 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj x140663455373479 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj x140663455373767 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj x140663455374055 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj x140663455374343 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj x140663455374631 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj x140663455374919 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj x140663455375207 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj x140663455379591 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj x140663455379879 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj x140663455380167 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj x140663455380455 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj x140663455380743 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj x140663455381031 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj x140663455381319 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj x140663455381607 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj x140663455381895 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj x140663455382183 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj x140663455382471 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj x140663455382759 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj x140663455383047 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj x140663455383335 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj x140663455387719 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj x140663455388007 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj x140663455388295 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj x140663455388583 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj x140663455388871 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj x140663455389159 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj x140663455389447 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj x140663455389735 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj x140663455390023 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj x140663455390311 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj x140663455390599 = primSet(co, symcora_47init_35append, globalRef(symappend));
-Obj x140663455390823 = primSet(co, symcora_47init_35assq, globalRef(symassq));
+Obj x139886475595847 = __arg1;
+Obj x139886475597479 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(5, clofun1, 2, 0));
+Obj x139886475567847 = primSet(co, symcora_47init_35lookup_45var, makeNative(47, clofun0, 3, 0));
+Obj x139886475568487 = makeCons(makeCString("primSet"), Nil);
+Obj x139886475568519 = makeCons(MAKE_NUMBER(2), x139886475568487);
+Obj x139886475568551 = makeCons(symset, x139886475568519);
+Obj x139886475568903 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x139886475568935 = makeCons(MAKE_NUMBER(1), x139886475568903);
+Obj x139886475568967 = makeCons(symcar, x139886475568935);
+Obj x139886475569351 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x139886475569383 = makeCons(MAKE_NUMBER(1), x139886475569351);
+Obj x139886475569447 = makeCons(symcdr, x139886475569383);
+Obj x139886475569799 = makeCons(makeCString("makeCons"), Nil);
+Obj x139886475569863 = makeCons(MAKE_NUMBER(2), x139886475569799);
+Obj x139886475569895 = makeCons(symcons, x139886475569863);
+Obj x139886475570407 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x139886475570439 = makeCons(MAKE_NUMBER(1), x139886475570407);
+Obj x139886475570535 = makeCons(symcons_63, x139886475570439);
+Obj x139886475570919 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x139886475570951 = makeCons(MAKE_NUMBER(2), x139886475570919);
+Obj x139886475571015 = makeCons(sym_43, x139886475570951);
+Obj x139886475506343 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x139886475506503 = makeCons(MAKE_NUMBER(2), x139886475506343);
+Obj x139886475506535 = makeCons(sym_45, x139886475506503);
+Obj x139886475507079 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x139886475507111 = makeCons(MAKE_NUMBER(2), x139886475507079);
+Obj x139886475507143 = makeCons(sym_42, x139886475507111);
+Obj x139886475507527 = makeCons(makeCString("primDiv"), Nil);
+Obj x139886475507559 = makeCons(MAKE_NUMBER(2), x139886475507527);
+Obj x139886475507687 = makeCons(sym_47, x139886475507559);
+Obj x139886475508135 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x139886475508167 = makeCons(MAKE_NUMBER(2), x139886475508135);
+Obj x139886475508199 = makeCons(sym_61, x139886475508167);
+Obj x139886475508743 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x139886475508775 = makeCons(MAKE_NUMBER(2), x139886475508743);
+Obj x139886475508807 = makeCons(sym_62, x139886475508775);
+Obj x139886475509479 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x139886475509511 = makeCons(MAKE_NUMBER(2), x139886475509479);
+Obj x139886475509543 = makeCons(sym_60, x139886475509511);
+Obj x139886475469095 = makeCons(makeCString("primGenSym"), Nil);
+Obj x139886475469127 = makeCons(MAKE_NUMBER(0), x139886475469095);
+Obj x139886475469159 = makeCons(symgensym, x139886475469127);
+Obj x139886475469607 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x139886475469639 = makeCons(MAKE_NUMBER(1), x139886475469607);
+Obj x139886475469671 = makeCons(symsymbol_63, x139886475469639);
+Obj x139886475470375 = makeCons(makeCString("primNot"), Nil);
+Obj x139886475470407 = makeCons(MAKE_NUMBER(1), x139886475470375);
+Obj x139886475470535 = makeCons(symnot, x139886475470407);
+Obj x139886475470951 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x139886475471079 = makeCons(MAKE_NUMBER(1), x139886475470951);
+Obj x139886475471111 = makeCons(syminteger_63, x139886475471079);
+Obj x139886475471559 = makeCons(makeCString("primIsString"), Nil);
+Obj x139886475471591 = makeCons(MAKE_NUMBER(1), x139886475471559);
+Obj x139886475471623 = makeCons(symstring_63, x139886475471591);
+Obj x139886475471655 = makeCons(x139886475471623, Nil);
+Obj x139886475471783 = makeCons(x139886475471111, x139886475471655);
+Obj x139886475471815 = makeCons(x139886475470535, x139886475471783);
+Obj x139886475471879 = makeCons(x139886475469671, x139886475471815);
+Obj x139886475471911 = makeCons(x139886475469159, x139886475471879);
+Obj x139886475471943 = makeCons(x139886475509543, x139886475471911);
+Obj x139886475471975 = makeCons(x139886475508807, x139886475471943);
+Obj x139886475472007 = makeCons(x139886475508199, x139886475471975);
+Obj x139886475472039 = makeCons(x139886475507687, x139886475472007);
+Obj x139886475472135 = makeCons(x139886475507143, x139886475472039);
+Obj x139886475472167 = makeCons(x139886475506535, x139886475472135);
+Obj x139886475472199 = makeCons(x139886475571015, x139886475472167);
+Obj x139886475472263 = makeCons(x139886475570535, x139886475472199);
+Obj x139886475472295 = makeCons(x139886475569895, x139886475472263);
+Obj x139886475472327 = makeCons(x139886475569447, x139886475472295);
+Obj x139886475472359 = makeCons(x139886475568967, x139886475472327);
+Obj x139886475472391 = makeCons(x139886475568551, x139886475472359);
+Obj x139886475472423 = primSet(co, symcora_47init_35_42builtin_45prims_42, x139886475472391);
+Obj x139886475464199 = primSet(co, symassq, makeNative(45, clofun0, 2, 0));
+Obj x139886475382983 = primSet(co, symcora_47init_35builtin_63, makeNative(42, clofun0, 1, 0));
+Obj x139886476083175 = primSet(co, symcora_47init_35parse, makeNative(16, clofun0, 4, 0));
+Obj x139886475596647 = makeCons(symappend, Nil);
+Obj x139886475596679 = makeCons(symfilter, x139886475596647);
+Obj x139886475596711 = makeCons(symlength, x139886475596679);
+Obj x139886475596903 = makeCons(symelem_63, x139886475596711);
+Obj x139886475596967 = makeCons(symmacroexpand, x139886475596903);
+Obj x139886475596999 = makeCons(symmap, x139886475596967);
+Obj x139886475597031 = makeCons(symreverse, x139886475596999);
+Obj x139886475597063 = makeCons(symthrow, x139886475597031);
+Obj x139886475597223 = makeCons(symtry, x139886475597063);
+Obj x139886475597255 = makeCons(symload, x139886475597223);
+Obj x139886475597287 = makeCons(symimport, x139886475597255);
+Obj x139886475597319 = makeCons(symload_45so, x139886475597287);
+Obj x139886475597511 = makeCons(symapply, x139886475597319);
+Obj x139886475597543 = makeCons(symvalue_45or, x139886475597511);
+Obj x139886475597575 = makeCons(symvalue, x139886475597543);
+Obj x139886475597607 = makeCons(symread_45file_45as_45sexp, x139886475597575);
+Obj x139886475597895 = makeCons(symbytes_45length, x139886475597607);
+Obj x139886475597927 = makeCons(symbytes, x139886475597895);
+Obj x139886475597959 = makeCons(symvector_45length, x139886475597927);
+Obj x139886475597991 = makeCons(symvector_45ref, x139886475597959);
+Obj x139886475598055 = makeCons(symvector_45set_33, x139886475597991);
+Obj x139886475598151 = makeCons(symvector, x139886475598055);
+Obj x139886475598215 = makeCons(symsymbol_45_62string, x139886475598151);
+Obj x139886475598247 = makeCons(symintern, x139886475598215);
+Obj x139886475598279 = makeCons(symstring_45append, x139886475598247);
+Obj x139886475598311 = makeCons(symnull_63, x139886475598279);
+Obj x139886475598343 = makeCons(symnumber_63, x139886475598311);
+Obj x139886475598375 = makeCons(symboolean_63, x139886475598343);
+Obj x139886475598503 = makeCons(symatom_63, x139886475598375);
+Obj x139886475598535 = makeCons(sympair_63, x139886475598503);
+Obj x139886475598567 = makeCons(symcdddr, x139886475598535);
+Obj x139886475598599 = makeCons(symcadddr, x139886475598567);
+Obj x139886475598663 = makeCons(symcaddr, x139886475598599);
+Obj x139886475598759 = makeCons(symcddr, x139886475598663);
+Obj x139886475598791 = makeCons(symcdar, x139886475598759);
+Obj x139886475598887 = makeCons(symcaar, x139886475598791);
+Obj x139886475598951 = makeCons(symcadr, x139886475598887);
+Obj x139886475598983 = primSet(co, symcora_47init_35_42ns_45export_42, x139886475598951);
+Obj x139886475599367 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
+Obj x139886475599687 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
+Obj x139886475567399 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
+Obj x139886475567751 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
+Obj x139886475568007 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
+Obj x139886475568199 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
+Obj x139886475568583 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
+Obj x139886475568743 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
+Obj x139886475569095 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
+Obj x139886475569287 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
+Obj x139886475569639 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
+Obj x139886475569959 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
+Obj x139886475570279 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
+Obj x139886475570695 = primSet(co, symcora_47init_35intern, globalRef(symintern));
+Obj x139886475571047 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
+Obj x139886475506247 = primSet(co, symcora_47init_35vector, globalRef(symvector));
+Obj x139886475506631 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
+Obj x139886475506887 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
+Obj x139886475507399 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
+Obj x139886475507751 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
+Obj x139886475508071 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
+Obj x139886475508391 = primSet(co, symcora_47init_35value, globalRef(symvalue));
+Obj x139886475508839 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
+Obj x139886475509255 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
+Obj x139886475509671 = primSet(co, symcora_47init_35apply, globalRef(symapply));
+Obj x139886475469063 = primSet(co, symcora_47init_35load, globalRef(symload));
+Obj x139886475469319 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
+Obj x139886475469767 = primSet(co, symcora_47init_35import, globalRef(symimport));
+Obj x139886475470311 = primSet(co, symcora_47init_35try, globalRef(symtry));
+Obj x139886475470727 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
+Obj x139886475471207 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
+Obj x139886475471463 = primSet(co, symcora_47init_35map, globalRef(symmap));
+Obj x139886475472775 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
+Obj x139886475460647 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
+Obj x139886475461031 = primSet(co, symcora_47init_35length, globalRef(symlength));
+Obj x139886475461255 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
+Obj x139886475461575 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj x139886475461831 = primSet(co, symcora_47init_35assq, globalRef(symassq));
 __nargs = 2;
-__arg1 = x140663455390823;
+__arg1 = x139886475461831;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -784,19 +780,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj x140663453912167 = __arg1;
-Obj x140663453912199 = __arg2;
-Obj x140663453912263 = __arg3;
-Obj x140663453912295 = co->args[4];
-Obj x140663453907239 = makeNative(20, clofun0, 0, 4, x140663453912167, x140663453912199, x140663453912263, x140663453912295);
-Obj __ = x140663453912167;
-__ = x140663453912199;
-__ = x140663453912263;
-Obj x = x140663453912295;
-pushCont(co, 17, clofun0, 2, x, x140663453907239);
+Obj x139886476187367 = __arg1;
+Obj x139886476187399 = __arg2;
+Obj x139886476187463 = __arg3;
+Obj x139886476187495 = co->args[4];
+Obj x139886476185767 = makeNative(20, clofun0, 1, 4, x139886476187367, x139886476187399, x139886476187463, x139886476187495);
+pushCont(co, 17, clofun0, 2, x139886476187495, x139886476185767);
 __nargs = 2;
 __arg0 = globalRef(symnumber_63);
-__arg1 = x;
+__arg1 = x139886476187495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -806,48 +798,34 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x140663453285063 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453907239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453285063) {
-if (True == True) {
+Obj x139886476082279 = __arg1;
+Obj x139886476187495= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476185767= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886476082279) {
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907239;
+__arg0 = x139886476185767;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-Obj x140663453285543 = primIsString(x);
-if (True == x140663453285543) {
-if (True == True) {
+Obj x139886476082439 = primIsString(x139886476187495);
+if (True == x139886476082439) {
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907239;
+__arg0 = x139886476185767;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-pushCont(co, 18, clofun0, 2, x, x140663453907239);
+pushCont(co, 18, clofun0, 2, x139886476187495, x139886476185767);
 __nargs = 2;
 __arg0 = globalRef(symboolean_63);
-__arg1 = x;
+__arg1 = x139886476187495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -859,30 +837,23 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x140663453285959 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453907239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453285959) {
-if (True == True) {
+Obj x139886476082855 = __arg1;
+Obj x139886476187495= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476185767= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886476082855) {
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907239;
+__arg0 = x139886476185767;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-pushCont(co, 19, clofun0, 2, x, x140663453907239);
+pushCont(co, 19, clofun0, 1, x139886476185767);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x;
+__arg1 = x139886476187495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -893,75 +864,65 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x140663453286375 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453907239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453286375) {
-if (True == True) {
+Obj x139886476083143 = __arg1;
+Obj x139886476185767= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886476083143) {
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907239;
+__arg0 = x139886476185767;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-if (True == False) {
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907239;
+__arg0 = x139886476185767;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 }
 
 label20:
 {
-Obj x140663453882119 = makeNative(21, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj __ = closureRef(co, 0);
-__ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj x140663453332839 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663453332839) {
-Obj x140663453333383 = PRIM_CAR(closureRef(co, 3));
-Obj x140663453333415 = PRIM_EQ(symquote, x140663453333383);
-if (True == x140663453333415) {
-Obj x140663453333831 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453333863 = PRIM_ISCONS(x140663453333831);
-if (True == x140663453333863) {
-Obj x140663453334439 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453334471 = PRIM_CAR(x140663453334439);
-Obj x = x140663453334471;
-Obj x140663453335175 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453335207 = PRIM_CDR(x140663453335175);
-Obj x140663453335239 = PRIM_EQ(Nil, x140663453335207);
-if (True == x140663453335239) {
-Obj x140663453283751 = makeCons(x, Nil);
-Obj x140663453283783 = makeCons(symquote, x140663453283751);
+Obj x139886476185831 = __arg1;
+if (True == x139886476185831) {
 __nargs = 2;
-__arg1 = x140663453283783;
+__arg1 = closureRef(co, 3);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476104391 = makeNative(21, clofun0, 0, 4, closureRef(co, 3), closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886476107559 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x139886476107559) {
+Obj x139886476079335 = PRIM_CAR(closureRef(co, 3));
+Obj x139886476079367 = PRIM_EQ(symquote, x139886476079335);
+if (True == x139886476079367) {
+Obj x139886476079687 = PRIM_CDR(closureRef(co, 3));
+Obj x139886476079719 = PRIM_ISCONS(x139886476079687);
+if (True == x139886476079719) {
+Obj x139886476080263 = PRIM_CDR(closureRef(co, 3));
+Obj x139886476080295 = PRIM_CAR(x139886476080263);
+Obj x = x139886476080295;
+Obj x139886476080839 = PRIM_CDR(closureRef(co, 3));
+Obj x139886476080871 = PRIM_CDR(x139886476080839);
+Obj x139886476080935 = PRIM_EQ(Nil, x139886476080871);
+if (True == x139886476080935) {
+Obj x139886476081255 = makeCons(x, Nil);
+Obj x139886476081287 = makeCons(symquote, x139886476081255);
+__nargs = 2;
+__arg1 = x139886476081287;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453882119;
+__arg0 = x139886476104391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -970,7 +931,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453882119;
+__arg0 = x139886476104391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -979,7 +940,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453882119;
+__arg0 = x139886476104391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -988,29 +949,61 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453882119;
+__arg0 = x139886476104391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 }
 
 label21:
 {
-Obj x140663453791815 = makeNative(24, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x = closureRef(co, 3);
-Obj x140663453384231 = primIsSymbol(x);
-if (True == x140663453384231) {
-pushCont(co, 22, clofun0, 3, x, ns, import);
+Obj x139886475383847 = primIsSymbol(closureRef(co, 0));
+if (True == x139886475383847) {
+PUSH_CONT_0(co, 40, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
-__arg1 = x;
-__arg2 = env;
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476083047 = makeNative(24, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886476146439 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476146439) {
+Obj x139886476146823 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476146855 = PRIM_EQ(symlambda, x139886476146823);
+if (True == x139886476146855) {
+Obj x139886476147399 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476147431 = PRIM_ISCONS(x139886476147399);
+if (True == x139886476147431) {
+Obj x139886476147815 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476147847 = PRIM_CAR(x139886476147815);
+Obj args = x139886476147847;
+Obj x139886476148519 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476148551 = PRIM_CDR(x139886476148519);
+Obj x139886476148615 = PRIM_ISCONS(x139886476148551);
+if (True == x139886476148615) {
+Obj x139886476104935 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476104967 = PRIM_CDR(x139886476104935);
+Obj x139886476104999 = PRIM_CAR(x139886476104967);
+Obj body = x139886476104999;
+Obj x139886476105543 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476105575 = PRIM_CDR(x139886476105543);
+Obj x139886476105607 = PRIM_CDR(x139886476105575);
+Obj x139886476105703 = PRIM_EQ(Nil, x139886476105607);
+if (True == x139886476105703) {
+pushCont(co, 22, clofun0, 2, body, args);
+__nargs = 3;
+__arg0 = globalRef(symappend);
+__arg1 = args;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1018,101 +1011,145 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453791815;
+__arg0 = x139886476083047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476083047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476083047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476083047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476083047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label22:
 {
-Obj x140663453331527 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140663453331527) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 23, clofun0, 3, x, ns, import);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35builtin_63);
-__arg1 = x;
+Obj x139886476106311 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 23, clofun0, 1, args);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = x139886476106311;
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label23:
 {
-Obj x140663453331815 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140663453331815) {
+Obj x139886476106567 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106599 = makeCons(x139886476106567, Nil);
+Obj x139886476106631 = makeCons(args, x139886476106599);
+Obj x139886476106695 = makeCons(symlambda, x139886476106631);
 __nargs = 2;
-__arg1 = x;
+__arg1 = x139886476106695;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35lookup_45var);
-__arg1 = x;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label24:
 {
-Obj x140663453743079 = makeNative(27, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x140663453454375 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663453454375) {
-Obj x140663453454919 = PRIM_CAR(closureRef(co, 3));
-Obj x140663453454951 = PRIM_EQ(symlambda, x140663453454919);
-if (True == x140663453454951) {
-Obj x140663453455591 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453455719 = PRIM_ISCONS(x140663453455591);
-if (True == x140663453455719) {
-Obj x140663453456199 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453456231 = PRIM_CAR(x140663453456199);
-Obj args = x140663453456231;
-Obj x140663453456999 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453457031 = PRIM_CDR(x140663453456999);
-Obj x140663453457063 = PRIM_ISCONS(x140663453457031);
-if (True == x140663453457063) {
-Obj x140663453457863 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453457895 = PRIM_CDR(x140663453457863);
-Obj x140663453457927 = PRIM_CAR(x140663453457895);
-Obj body = x140663453457927;
-Obj x140663453380999 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453381031 = PRIM_CDR(x140663453380999);
-Obj x140663453381063 = PRIM_CDR(x140663453381031);
-Obj x140663453381095 = PRIM_EQ(Nil, x140663453381063);
-if (True == x140663453381095) {
-pushCont(co, 25, clofun0, 4, ns, import, body, args);
-__nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = args;
-__arg2 = env;
+Obj x139886475595943 = makeNative(27, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886475194183 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475194183) {
+Obj x139886475182151 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475182183 = PRIM_EQ(symdo, x139886475182151);
+if (True == x139886475182183) {
+Obj x139886475182439 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475182471 = PRIM_ISCONS(x139886475182439);
+if (True == x139886475182471) {
+Obj x139886475182791 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475182823 = PRIM_CAR(x139886475182791);
+Obj x139886475182855 = PRIM_ISCONS(x139886475182823);
+if (True == x139886475182855) {
+Obj x139886475183239 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475183271 = PRIM_CAR(x139886475183239);
+Obj x139886475183303 = PRIM_CAR(x139886475183271);
+Obj x139886475183335 = PRIM_EQ(symimport, x139886475183303);
+if (True == x139886475183335) {
+Obj x139886475183719 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475183751 = PRIM_CAR(x139886475183719);
+Obj x139886475183783 = PRIM_CDR(x139886475183751);
+Obj x139886475183815 = PRIM_ISCONS(x139886475183783);
+if (True == x139886475183815) {
+Obj x139886475184199 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475184231 = PRIM_CAR(x139886475184199);
+Obj x139886475184263 = PRIM_CDR(x139886475184231);
+Obj x139886475184295 = PRIM_CAR(x139886475184263);
+Obj pkg = x139886475184295;
+Obj x139886475184743 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475184775 = PRIM_CAR(x139886475184743);
+Obj x139886475184807 = PRIM_CDR(x139886475184775);
+Obj x139886475184839 = PRIM_CDR(x139886475184807);
+Obj x139886475184871 = PRIM_EQ(Nil, x139886475184839);
+if (True == x139886475184871) {
+Obj x139886476186503 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476186535 = PRIM_CDR(x139886476186503);
+Obj x139886476186567 = PRIM_ISCONS(x139886476186535);
+if (True == x139886476186567) {
+Obj x139886476187143 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476187239 = PRIM_CDR(x139886476187143);
+Obj x139886476187271 = PRIM_CAR(x139886476187239);
+Obj y = x139886476187271;
+Obj x139886476187975 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188231 = PRIM_CDR(x139886476187975);
+Obj x139886476188263 = PRIM_CDR(x139886476188231);
+Obj x139886476188295 = PRIM_EQ(Nil, x139886476188263);
+if (True == x139886476188295) {
+Obj x139886476188487 = primIsString(pkg);
+if (True == x139886476188487) {
+Obj x139886476189191 = makeCons(pkg, Nil);
+Obj x139886476189223 = makeCons(symimport, x139886476189191);
+pushCont(co, 25, clofun0, 2, pkg, y);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = x139886476189223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1120,7 +1157,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453743079;
+__arg0 = x139886475595943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1129,7 +1166,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453743079;
+__arg0 = x139886475595943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1138,7 +1175,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453743079;
+__arg0 = x139886475595943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1147,7 +1184,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453743079;
+__arg0 = x139886475595943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1156,7 +1193,52 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453743079;
+__arg0 = x139886475595943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475595943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475595943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475595943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475595943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475595943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1167,18 +1249,17 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x140663453382407 = __arg1;
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 26, clofun0, 1, args);
+Obj x139886476189319 = __arg1;
+Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476144807 = makeCons(pkg, closureRef(co, 3));
+pushCont(co, 26, clofun0, 1, x139886476189319);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140663453382407;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = body;
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x139886476144807;
+co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1188,13 +1269,13 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x140663453382535 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453382599 = makeCons(x140663453382535, Nil);
-Obj x140663453382631 = makeCons(args, x140663453382599);
-Obj x140663453382663 = makeCons(symlambda, x140663453382631);
+Obj x139886476144839 = __arg1;
+Obj x139886476189319= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476144903 = makeCons(x139886476144839, Nil);
+Obj x139886476144999 = makeCons(x139886476189319, x139886476144903);
+Obj x139886476145191 = makeCons(symdo, x139886476144999);
 __nargs = 2;
-__arg1 = x140663453382663;
+__arg1 = x139886476145191;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1202,156 +1283,49 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x140663453947367 = makeNative(30, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x140663453882631 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663453882631) {
-Obj x140663453883463 = PRIM_CAR(closureRef(co, 3));
-Obj x140663453883495 = PRIM_EQ(symdo, x140663453883463);
-if (True == x140663453883495) {
-Obj x140663453884263 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453884295 = PRIM_ISCONS(x140663453884263);
-if (True == x140663453884295) {
-Obj x140663453791047 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453791079 = PRIM_CAR(x140663453791047);
-Obj x140663453791143 = PRIM_ISCONS(x140663453791079);
-if (True == x140663453791143) {
-Obj x140663453792583 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453792615 = PRIM_CAR(x140663453792583);
-Obj x140663453792647 = PRIM_CAR(x140663453792615);
-Obj x140663453792711 = PRIM_EQ(symimport, x140663453792647);
-if (True == x140663453792711) {
-Obj x140663453793927 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453793959 = PRIM_CAR(x140663453793927);
-Obj x140663453793991 = PRIM_CDR(x140663453793959);
-Obj x140663453794023 = PRIM_ISCONS(x140663453793991);
-if (True == x140663453794023) {
-Obj x140663453742055 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453742183 = PRIM_CAR(x140663453742055);
-Obj x140663453742215 = PRIM_CDR(x140663453742183);
-Obj x140663453742247 = PRIM_CAR(x140663453742215);
-Obj pkg = x140663453742247;
-Obj x140663453744711 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453744967 = PRIM_CAR(x140663453744711);
-Obj x140663453744999 = PRIM_CDR(x140663453744967);
-Obj x140663453745031 = PRIM_CDR(x140663453744999);
-Obj x140663453745063 = PRIM_EQ(Nil, x140663453745031);
-if (True == x140663453745063) {
-Obj x140663453668007 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453668039 = PRIM_CDR(x140663453668007);
-Obj x140663453668071 = PRIM_ISCONS(x140663453668039);
-if (True == x140663453668071) {
-Obj x140663453668871 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453668903 = PRIM_CDR(x140663453668871);
-Obj x140663453668935 = PRIM_CAR(x140663453668903);
-Obj y = x140663453668935;
-Obj x140663453669895 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453669927 = PRIM_CDR(x140663453669895);
-Obj x140663453669959 = PRIM_CDR(x140663453669927);
-Obj x140663453669991 = PRIM_EQ(Nil, x140663453669959);
-if (True == x140663453669991) {
-Obj x140663453670311 = primIsString(pkg);
-if (True == x140663453670311) {
-Obj x140663453639015 = makeCons(pkg, Nil);
-Obj x140663453639047 = makeCons(symimport, x140663453639015);
-pushCont(co, 28, clofun0, 5, pkg, import, env, ns, y);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = x140663453639047;
+Obj x139886476186119 = makeNative(31, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886475192423 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475192423) {
+Obj x139886475192615 = PRIM_CAR(closureRef(co, 0));
+Obj op = x139886475192615;
+Obj x139886475192807 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886475192807;
+Obj x139886476186183 = makeNative(28, clofun0, 1, 6, op, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), args, x139886476186119);
+Obj x139886475193767 = PRIM_EQ(op, symif);
+if (True == x139886475193767) {
+__nargs = 2;
+__arg0 = x139886476186183;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x140663453947367;
+Obj x139886475193927 = PRIM_EQ(op, symdo);
+if (True == x139886475193927) {
+__nargs = 2;
+__arg0 = x139886476186183;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476186183;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947367;
+__arg0 = x139886476186119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1362,269 +1336,100 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x140663453639079 = __arg1;
-Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140663453639911 = makeCons(pkg, import);
-pushCont(co, 29, clofun0, 1, x140663453639079);
-__nargs = 5;
+Obj x139886476186279 = __arg1;
+if (True == x139886476186279) {
+PUSH_CONT_0(co, 29, clofun0);
+__nargs = 4;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = x140663453639911;
-co->args[4] = y;
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = closureRef(co, 5);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label29:
 {
-Obj x140663453640295 = __arg1;
-Obj x140663453639079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453640359 = makeCons(x140663453640295, Nil);
-Obj x140663453640391 = makeCons(x140663453639079, x140663453640359);
-Obj x140663453640423 = makeCons(symdo, x140663453640391);
-__nargs = 2;
-__arg1 = x140663453640423;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475193351 = __arg1;
+PUSH_CONT_0(co, 30, clofun0);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x139886475193351;
+__arg2 = closureRef(co, 4);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label30:
 {
-Obj x140663453911879 = makeNative(37, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x140663453911367 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663453911367) {
-Obj x140663453911751 = PRIM_CAR(closureRef(co, 3));
-Obj op = x140663453911751;
-Obj x140663453912647 = PRIM_CDR(closureRef(co, 3));
-Obj args = x140663453912647;
-Obj x140663453905255 = PRIM_EQ(op, symif);
-if (True == x140663453905255) {
-if (True == True) {
-pushCont(co, 35, clofun0, 2, args, op);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453911879;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-Obj x140663453907463 = PRIM_EQ(op, symdo);
-if (True == x140663453907463) {
-if (True == True) {
-pushCont(co, 33, clofun0, 2, args, op);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453911879;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 31, clofun0, 2, args, op);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453911879;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911879;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x139886475193415 = __arg1;
+Obj x139886475193447 = makeCons(closureRef(co, 0), x139886475193415);
+__nargs = 2;
+__arg1 = x139886475193447;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label31:
 {
-Obj x140663453881191 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 32, clofun0, 1, op);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x140663453881191;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x140663453881351 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453881479 = makeCons(op, x140663453881351);
-__nargs = 2;
-__arg1 = x140663453881479;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label33:
-{
-Obj x140663453908519 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 34, clofun0, 1, op);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x140663453908519;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label34:
-{
-Obj x140663453908583 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453908615 = makeCons(op, x140663453908583);
-__nargs = 2;
-__arg1 = x140663453908615;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label35:
-{
-Obj x140663453906215 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 36, clofun0, 1, op);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x140663453906215;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label36:
-{
-Obj x140663453906599 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453906791 = makeCons(op, x140663453906599);
-__nargs = 2;
-__arg1 = x140663453906791;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label37:
-{
-Obj x140663453908167 = makeNative(40, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x140663454541703 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663454541703) {
-Obj x140663454542503 = PRIM_CAR(closureRef(co, 3));
-Obj x140663454542535 = PRIM_EQ(symlet, x140663454542503);
-if (True == x140663454542535) {
-Obj x140663454543335 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454543367 = PRIM_ISCONS(x140663454543335);
-if (True == x140663454543367) {
-Obj x140663454498983 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454499175 = PRIM_CAR(x140663454498983);
-Obj a = x140663454499175;
-Obj x140663454500135 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454500167 = PRIM_CDR(x140663454500135);
-Obj x140663454500199 = PRIM_ISCONS(x140663454500167);
-if (True == x140663454500199) {
-Obj x140663454501447 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454501543 = PRIM_CDR(x140663454501447);
-Obj x140663454501639 = PRIM_CAR(x140663454501543);
-Obj b = x140663454501639;
-Obj x140663454502823 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454502855 = PRIM_CDR(x140663454502823);
-Obj x140663454502887 = PRIM_CDR(x140663454502855);
-Obj x140663453986983 = PRIM_ISCONS(x140663454502887);
-if (True == x140663453986983) {
-Obj x140663453988967 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453988999 = PRIM_CDR(x140663453988967);
-Obj x140663453989031 = PRIM_CDR(x140663453988999);
-Obj x140663453989095 = PRIM_CAR(x140663453989031);
-Obj c = x140663453989095;
-Obj x140663453990887 = PRIM_CDR(closureRef(co, 3));
-Obj x140663453946087 = PRIM_CDR(x140663453990887);
-Obj x140663453946183 = PRIM_CDR(x140663453946087);
-Obj x140663453946247 = PRIM_CDR(x140663453946183);
-Obj x140663453946279 = PRIM_EQ(Nil, x140663453946247);
-if (True == x140663453946279) {
-pushCont(co, 38, clofun0, 5, env, ns, import, c, a);
+Obj x139886476145703 = makeNative(34, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
+Obj x139886475245159 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475245159) {
+Obj x139886475245415 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475245447 = PRIM_EQ(symlet, x139886475245415);
+if (True == x139886475245447) {
+Obj x139886475245703 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475245735 = PRIM_ISCONS(x139886475245703);
+if (True == x139886475245735) {
+Obj x139886475245991 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475246023 = PRIM_CAR(x139886475245991);
+Obj a = x139886475246023;
+Obj x139886475246343 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475246375 = PRIM_CDR(x139886475246343);
+Obj x139886475246407 = PRIM_ISCONS(x139886475246375);
+if (True == x139886475246407) {
+Obj x139886475246727 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475246759 = PRIM_CDR(x139886475246727);
+Obj x139886475246791 = PRIM_CAR(x139886475246759);
+Obj b = x139886475246791;
+Obj x139886475247175 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475247207 = PRIM_CDR(x139886475247175);
+Obj x139886475247239 = PRIM_CDR(x139886475247207);
+Obj x139886475247271 = PRIM_ISCONS(x139886475247239);
+if (True == x139886475247271) {
+Obj x139886475190311 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475190343 = PRIM_CDR(x139886475190311);
+Obj x139886475190375 = PRIM_CDR(x139886475190343);
+Obj x139886475190407 = PRIM_CAR(x139886475190375);
+Obj c = x139886475190407;
+Obj x139886475190855 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475190887 = PRIM_CDR(x139886475190855);
+Obj x139886475190919 = PRIM_CDR(x139886475190887);
+Obj x139886475190951 = PRIM_CDR(x139886475190919);
+Obj x139886475190983 = PRIM_EQ(Nil, x139886475190951);
+if (True == x139886475190983) {
+pushCont(co, 32, clofun0, 2, c, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1633,7 +1438,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1642,7 +1447,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1651,7 +1456,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1660,7 +1465,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1669,7 +1474,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1678,7 +1483,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453908167;
+__arg0 = x139886476145703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1687,21 +1492,18 @@ goto *jumpTable[ps.label];
 }
 }
 
-label38:
+label32:
 {
-Obj x140663453948007 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x140663453949255 = makeCons(a, env);
-pushCont(co, 39, clofun0, 2, x140663453948007, a);
+Obj x139886475191367 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475191623 = makeCons(a, closureRef(co, 1));
+pushCont(co, 33, clofun0, 2, x139886475191367, a);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x140663453949255;
-__arg2 = ns;
-__arg3 = import;
+__arg1 = x139886475191623;
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1710,66 +1512,63 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label33:
 {
-Obj x140663453949543 = __arg1;
-Obj x140663453948007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475191719 = __arg1;
+Obj x139886475191367= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453949639 = makeCons(x140663453949543, Nil);
-Obj x140663453949671 = makeCons(x140663453948007, x140663453949639);
-Obj x140663453949703 = makeCons(a, x140663453949671);
-Obj x140663453949735 = makeCons(symlet, x140663453949703);
+Obj x139886475191751 = makeCons(x139886475191719, Nil);
+Obj x139886475191783 = makeCons(x139886475191367, x139886475191751);
+Obj x139886475191815 = makeCons(a, x139886475191783);
+Obj x139886475191847 = makeCons(symlet, x139886475191815);
 __nargs = 2;
-__arg1 = x140663453949735;
+__arg1 = x139886475191847;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label40:
+label34:
 {
-Obj x140663453790951 = makeNative(41, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj x140663454885063 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663454885063) {
-Obj x140663454885927 = PRIM_CAR(closureRef(co, 3));
-Obj x140663454885959 = PRIM_EQ(symns, x140663454885927);
-if (True == x140663454885959) {
-Obj x140663454886887 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454886951 = PRIM_ISCONS(x140663454886887);
-if (True == x140663454886951) {
-Obj x140663454887719 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454887783 = PRIM_CAR(x140663454887719);
-Obj path = x140663454887783;
-Obj x140663454602023 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454602183 = PRIM_CDR(x140663454602023);
-Obj x140663454602343 = PRIM_ISCONS(x140663454602183);
-if (True == x140663454602343) {
-Obj x140663454603303 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454603527 = PRIM_CDR(x140663454603303);
-Obj x140663454603559 = PRIM_CAR(x140663454603527);
-Obj import = x140663454603559;
-Obj x140663454604711 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454604743 = PRIM_CDR(x140663454604711);
-Obj x140663454604775 = PRIM_CDR(x140663454604743);
-Obj x140663454604807 = PRIM_ISCONS(x140663454604775);
-if (True == x140663454604807) {
-Obj x140663454581895 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454581927 = PRIM_CDR(x140663454581895);
-Obj x140663454582055 = PRIM_CDR(x140663454581927);
-Obj x140663454582087 = PRIM_CAR(x140663454582055);
-Obj body = x140663454582087;
-Obj x140663454583591 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454583623 = PRIM_CDR(x140663454583591);
-Obj x140663454583655 = PRIM_CDR(x140663454583623);
-Obj x140663454583687 = PRIM_CDR(x140663454583655);
-Obj x140663454583719 = PRIM_EQ(Nil, x140663454583687);
-if (True == x140663454583719) {
+Obj x139886476106951 = makeNative(35, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
+Obj x139886475269991 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139886475269991) {
+Obj x139886475270247 = PRIM_CAR(closureRef(co, 2));
+Obj x139886475270279 = PRIM_EQ(symns, x139886475270247);
+if (True == x139886475270279) {
+Obj x139886475270535 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475270567 = PRIM_ISCONS(x139886475270535);
+if (True == x139886475270567) {
+Obj x139886475270823 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475270855 = PRIM_CAR(x139886475270823);
+Obj path = x139886475270855;
+Obj x139886475271175 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475271207 = PRIM_CDR(x139886475271175);
+Obj x139886475271239 = PRIM_ISCONS(x139886475271207);
+if (True == x139886475271239) {
+Obj x139886475271559 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475271591 = PRIM_CDR(x139886475271559);
+Obj x139886475271623 = PRIM_CAR(x139886475271591);
+Obj import = x139886475271623;
+Obj x139886475272007 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475272039 = PRIM_CDR(x139886475272007);
+Obj x139886475272071 = PRIM_CDR(x139886475272039);
+Obj x139886475272103 = PRIM_ISCONS(x139886475272071);
+if (True == x139886475272103) {
+Obj x139886475243815 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475243847 = PRIM_CDR(x139886475243815);
+Obj x139886475243879 = PRIM_CDR(x139886475243847);
+Obj x139886475243911 = PRIM_CAR(x139886475243879);
+Obj body = x139886475243911;
+Obj x139886475244359 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475244391 = PRIM_CDR(x139886475244359);
+Obj x139886475244423 = PRIM_CDR(x139886475244391);
+Obj x139886475244455 = PRIM_CDR(x139886475244423);
+Obj x139886475244487 = PRIM_EQ(Nil, x139886475244455);
+if (True == x139886475244487) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
+__arg1 = closureRef(co, 3);
 __arg2 = path;
 __arg3 = import;
 co->args[4] = body;
@@ -1780,7 +1579,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1789,7 +1588,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1798,7 +1597,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1807,7 +1606,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1816,7 +1615,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1825,7 +1624,177 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453790951;
+__arg0 = x139886476106951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label35:
+{
+Obj x139886475981191 = makeNative(38, clofun0, 0, 4, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 0));
+Obj x139886475386279 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475386279) {
+Obj x139886475386567 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475386599 = PRIM_EQ(symdef, x139886475386567);
+if (True == x139886475386599) {
+Obj x139886475329767 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475329799 = PRIM_ISCONS(x139886475329767);
+if (True == x139886475329799) {
+Obj x139886475330087 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475330151 = PRIM_CAR(x139886475330087);
+Obj var = x139886475330151;
+Obj x139886475330471 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475330503 = PRIM_CDR(x139886475330471);
+Obj x139886475330631 = PRIM_ISCONS(x139886475330503);
+if (True == x139886475330631) {
+Obj x139886475330951 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475330983 = PRIM_CDR(x139886475330951);
+Obj x139886475331015 = PRIM_CAR(x139886475330983);
+Obj val = x139886475331015;
+Obj x139886475331463 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475331495 = PRIM_CDR(x139886475331463);
+Obj x139886475331527 = PRIM_CDR(x139886475331495);
+Obj x139886475331559 = PRIM_EQ(Nil, x139886475331527);
+if (True == x139886475331559) {
+pushCont(co, 36, clofun0, 1, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35var_45with_45ns);
+__arg1 = var;
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475981191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label36:
+{
+Obj x139886475331783 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj var1 = x139886475331783;
+Obj x139886475269095 = makeCons(var1, Nil);
+Obj x139886475269127 = makeCons(symquote, x139886475269095);
+pushCont(co, 37, clofun0, 1, x139886475269127);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x139886475269383 = __arg1;
+Obj x139886475269127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475269415 = makeCons(x139886475269383, Nil);
+Obj x139886475269447 = makeCons(x139886475269127, x139886475269415);
+Obj x139886475269479 = makeCons(symset, x139886475269447);
+__nargs = 2;
+__arg1 = x139886475269479;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label38:
+{
+PUSH_CONT_0(co, 39, clofun0);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+Obj x139886475386023 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = x139886475386023;
+__arg2 = closureRef(co, 3);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x139886475384071 = __arg1;
+if (True == x139886475384071) {
+__nargs = 2;
+__arg1 = closureRef(co, 0);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+PUSH_CONT_0(co, 41, clofun0);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35builtin_63);
+__arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1836,83 +1805,19 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140663453743591 = makeNative(44, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x140663454948231 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x140663454948231) {
-Obj x140663454949319 = PRIM_CAR(closureRef(co, 3));
-Obj x140663454949351 = PRIM_EQ(symdef, x140663454949319);
-if (True == x140663454949351) {
-Obj x140663454917383 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454917415 = PRIM_ISCONS(x140663454917383);
-if (True == x140663454917415) {
-Obj x140663454917991 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454918023 = PRIM_CAR(x140663454917991);
-Obj var = x140663454918023;
-Obj x140663454919175 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454919207 = PRIM_CDR(x140663454919175);
-Obj x140663454919239 = PRIM_ISCONS(x140663454919207);
-if (True == x140663454919239) {
-Obj x140663454920167 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454920199 = PRIM_CDR(x140663454920167);
-Obj x140663454920231 = PRIM_CAR(x140663454920199);
-Obj val = x140663454920231;
-Obj x140663454896967 = PRIM_CDR(closureRef(co, 3));
-Obj x140663454896999 = PRIM_CDR(x140663454896967);
-Obj x140663454897031 = PRIM_CDR(x140663454896999);
-Obj x140663454897063 = PRIM_EQ(Nil, x140663454897031);
-if (True == x140663454897063) {
-pushCont(co, 42, clofun0, 4, env, ns, import, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35var_45with_45ns);
-__arg1 = var;
-__arg2 = ns;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475384359 = __arg1;
+if (True == x139886475384359) {
+__nargs = 2;
+__arg1 = closureRef(co, 0);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x140663453743591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453743591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453743591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453743591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453743591;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35lookup_45var);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1923,93 +1828,8 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140663454897543 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj var1 = x140663454897543;
-Obj x140663454898823 = makeCons(var1, Nil);
-Obj x140663454898951 = makeCons(symquote, x140663454898823);
-pushCont(co, 43, clofun0, 1, x140663454898951);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label43:
-{
-Obj x140663454899559 = __arg1;
-Obj x140663454898951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454899623 = makeCons(x140663454899559, Nil);
-Obj x140663454899751 = makeCons(x140663454898951, x140663454899623);
-Obj x140663454899815 = makeCons(symset, x140663454899751);
-__nargs = 2;
-__arg1 = x140663454899815;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label44:
-{
-Obj x140663453671047 = makeNative(46, clofun0, 0, 0);
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj ls = closureRef(co, 3);
-pushCont(co, 45, clofun0, 1, ls);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj x140663454947751 = __arg1;
-Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x140663454947751;
-__arg2 = ls;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
 Obj x = __arg1;
-PUSH_CONT_0(co, 48, clofun0);
+PUSH_CONT_0(co, 43, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symassq);
 __arg1 = x;
@@ -2021,13 +1841,179 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label48:
+label43:
 {
-Obj x140663454976039 = __arg1;
-PUSH_CONT_0(co, 49, clofun0);
+Obj x139886475464679 = __arg1;
+PUSH_CONT_0(co, 44, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = x140663454976039;
+__arg1 = x139886475464679;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139886475382919 = __arg1;
+Obj x139886475382951 = primNot(x139886475382919);
+__nargs = 2;
+__arg1 = x139886475382951;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label45:
+{
+Obj x139886476186215 = __arg1;
+Obj x139886476186247 = __arg2;
+Obj x139886475460871 = PRIM_EQ(Nil, x139886476186247);
+if (True == x139886475460871) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476189095 = makeNative(46, clofun0, 0, 2, x139886476186247, x139886476186215);
+Obj x139886475462471 = PRIM_ISCONS(x139886476186247);
+if (True == x139886475462471) {
+Obj x139886475462727 = PRIM_CAR(x139886476186247);
+Obj x139886475462759 = PRIM_ISCONS(x139886475462727);
+if (True == x139886475462759) {
+Obj x139886475463015 = PRIM_CAR(x139886476186247);
+Obj x139886475463047 = PRIM_CAR(x139886475463015);
+Obj x = x139886475463047;
+Obj x139886475463335 = PRIM_CAR(x139886476186247);
+Obj x139886475463431 = PRIM_CDR(x139886475463335);
+Obj y = x139886475463431;
+Obj x139886475463623 = PRIM_CDR(x139886476186247);
+Obj x139886475463847 = PRIM_EQ(x139886476186215, x);
+if (True == x139886475463847) {
+Obj x139886475463943 = makeCons(x, y);
+__nargs = 2;
+__arg1 = x139886475463943;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476189095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476189095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476189095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label46:
+{
+Obj x139886475461319 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475461319) {
+Obj x139886475461671 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475461991 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475461991;
+__nargs = 3;
+__arg0 = globalRef(symassq);
+__arg1 = closureRef(co, 1);
+__arg2 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label47:
+{
+Obj x139886476103847 = __arg1;
+Obj x139886476103879 = __arg2;
+Obj x139886476103943 = __arg3;
+Obj x139886475598183 = PRIM_EQ(Nil, x139886476103943);
+if (True == x139886475598183) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35var_45with_45ns);
+__arg1 = x139886476103847;
+__arg2 = x139886476103879;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475598407 = PRIM_ISCONS(x139886476103943);
+if (True == x139886475598407) {
+Obj x139886475598631 = PRIM_CAR(x139886476103943);
+Obj import = x139886475598631;
+Obj x139886475598919 = PRIM_CDR(x139886476103943);
+Obj more = x139886475598919;
+pushCont(co, 48, clofun0, 4, import, x139886476103847, x139886476103879, more);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = import;
+__arg2 = makeCString("#*ns-export*");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label48:
+{
+Obj x139886475599431 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476103879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 49, clofun0, 4, import, x139886476103847, x139886476103879, more);
+__nargs = 2;
+__arg0 = globalRef(symintern);
+__arg1 = x139886475599431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2037,13 +2023,21 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140663454976071 = __arg1;
-Obj x140663454976103 = primNot(x140663454976071);
-__nargs = 2;
-__arg1 = x140663454976103;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475599495 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476103879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 0, clofun1, 4, import, x139886476103847, x139886476103879, more);
+__nargs = 3;
+__arg0 = globalRef(symvalue_45or);
+__arg1 = x139886475599495;
+__arg2 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -2068,74 +2062,47 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140663453987303 = __arg1;
-Obj x140663453987335 = __arg2;
-Obj x140663453989223 = makeNative(1, clofun1, 0, 2, x140663453987303, x140663453987335);
-Obj var = x140663453987303;
-Obj x140663454974439 = PRIM_EQ(Nil, x140663453987335);
-if (True == x140663454974439) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453989223;
+Obj x139886475599527 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476103879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj export = x139886475599527;
+pushCont(co, 1, clofun1, 4, import, x139886476103847, x139886476103879, more);
+__nargs = 3;
+__arg0 = globalRef(symelem_63);
+__arg1 = x139886476103847;
+__arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj x140663453990503 = makeNative(2, clofun1, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj var = closureRef(co, 0);
-Obj x140663455149927 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140663455149927) {
-Obj x140663455138151 = PRIM_CAR(closureRef(co, 1));
-Obj x140663455138183 = PRIM_ISCONS(x140663455138151);
-if (True == x140663455138183) {
-Obj x140663455138599 = PRIM_CAR(closureRef(co, 1));
-Obj x140663455138631 = PRIM_CAR(x140663455138599);
-Obj x = x140663455138631;
-Obj x140663455139143 = PRIM_CAR(closureRef(co, 1));
-Obj x140663455139175 = PRIM_CDR(x140663455139143);
-Obj y = x140663455139175;
-Obj x140663455139431 = PRIM_CDR(closureRef(co, 1));
-Obj __ = x140663455139431;
-Obj x140663455139719 = PRIM_EQ(var, x);
-if (True == x140663455139719) {
-Obj x140663455140039 = makeCons(x, y);
+Obj x139886475599719 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476103879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x139886475599719) {
+pushCont(co, 2, clofun1, 1, import);
 __nargs = 2;
-__arg1 = x140663455140039;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453990503;
+__arg0 = globalRef(symsymbol_45_62string);
+__arg1 = x139886476103847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-__nargs = 1;
-__arg0 = x140663453990503;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453990503;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35lookup_45var);
+__arg1 = x139886476103847;
+__arg2 = x139886476103879;
+__arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2146,39 +2113,29 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x140663453949063 = makeNative(3, clofun1, 0, 0);
-Obj var = closureRef(co, 0);
-Obj x140663455148679 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x140663455148679) {
-Obj x140663455148935 = PRIM_CAR(closureRef(co, 1));
-Obj __ = x140663455148935;
-Obj x140663455149191 = PRIM_CDR(closureRef(co, 1));
-Obj y = x140663455149191;
+Obj x139886475567559 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun1, 1, import);
 __nargs = 3;
-__arg0 = globalRef(symassq);
-__arg1 = var;
-__arg2 = y;
+__arg0 = globalRef(symstring_45append);
+__arg1 = makeCString("#");
+__arg2 = x139886475567559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453949063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label3:
 {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+Obj x139886475567591 = __arg1;
+Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 4, clofun1);
+__nargs = 3;
+__arg0 = globalRef(symstring_45append);
+__arg1 = import;
+__arg2 = x139886475567591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2188,224 +2145,30 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x140663453881255 = __arg1;
-Obj x140663453881287 = __arg2;
-Obj x140663453881319 = __arg3;
-Obj x140663453883655 = makeNative(5, clofun1, 0, 3, x140663453881255, x140663453881287, x140663453881319);
-Obj s = x140663453881255;
-Obj ns = x140663453881287;
-Obj x140663455146343 = PRIM_EQ(Nil, x140663453881319);
-if (True == x140663455146343) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35var_45with_45ns);
-__arg1 = s;
-__arg2 = ns;
+Obj x139886475567623 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(symintern);
+__arg1 = x139886475567623;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453883655;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj x140663453791399 = makeNative(13, clofun1, 0, 0);
-Obj s = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj x140663455163751 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x140663455163751) {
-Obj x140663455164007 = PRIM_CAR(closureRef(co, 2));
-Obj import = x140663455164007;
-Obj x140663455164263 = PRIM_CDR(closureRef(co, 2));
-Obj more = x140663455164263;
-pushCont(co, 6, clofun1, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symstring_45append);
-__arg1 = import;
-__arg2 = makeCString("#*ns-export*");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453791399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj x140663455164871 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 7, clofun1, 4, import, s, ns, more);
-__nargs = 2;
-__arg0 = globalRef(symintern);
-__arg1 = x140663455164871;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x140663455164903 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 8, clofun1, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symvalue_45or);
-__arg1 = x140663455164903;
-__arg2 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x140663455164967 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = x140663455164967;
-pushCont(co, 9, clofun1, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(symelem_63);
-__arg1 = s;
-__arg2 = export;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj x140663455165255 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140663455165255) {
-pushCont(co, 10, clofun1, 1, import);
-__nargs = 2;
-__arg0 = globalRef(symsymbol_45_62string);
-__arg1 = s;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35lookup_45var);
-__arg1 = s;
-__arg2 = ns;
-__arg3 = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj x140663455165991 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 11, clofun1, 1, import);
-__nargs = 3;
-__arg0 = globalRef(symstring_45append);
-__arg1 = makeCString("#");
-__arg2 = x140663455165991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x140663455166023 = __arg1;
-Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 12, clofun1);
-__nargs = 3;
-__arg0 = globalRef(symstring_45append);
-__arg1 = import;
-__arg2 = x140663455166023;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj x140663455166055 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symintern);
-__arg1 = x140663455166055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj x140663455198407 = PRIM_EQ(ns, makeCString(""));
-if (True == x140663455198407) {
+Obj x139886475596615 = PRIM_EQ(ns, makeCString(""));
+if (True == x139886475596615) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 15, clofun1, 2, var, ns);
+pushCont(co, 6, clofun1, 2, var, ns);
 __nargs = 2;
 __arg0 = globalRef(symsymbol_45cooked_63);
 __arg1 = var;
@@ -2417,19 +2180,19 @@ goto *jumpTable[ps.label];
 }
 }
 
-label15:
+label6:
 {
-Obj x140663455198663 = __arg1;
+Obj x139886475596935 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663455198663) {
+if (True == x139886475596935) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 16, clofun1, 1, ns);
+pushCont(co, 7, clofun1, 1, ns);
 __nargs = 2;
 __arg0 = globalRef(symsymbol_45_62string);
 __arg1 = var;
@@ -2441,15 +2204,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label7:
 {
-Obj x140663455162535 = __arg1;
+Obj x139886475597351 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 17, clofun1, 1, ns);
+pushCont(co, 8, clofun1, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = makeCString("#");
-__arg2 = x140663455162535;
+__arg2 = x139886475597351;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2457,15 +2220,15 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label8:
 {
-Obj x140663455162567 = __arg1;
+Obj x139886475597383 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 18, clofun1);
+PUSH_CONT_0(co, 9, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symstring_45append);
 __arg1 = ns;
-__arg2 = x140663455162567;
+__arg2 = x139886475597383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2473,12 +2236,12 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label9:
 {
-Obj x140663455162599 = __arg1;
+Obj x139886475597447 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symintern);
-__arg1 = x140663455162599;
+__arg1 = x139886475597447;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2486,10 +2249,10 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label10:
 {
 Obj sexp = __arg1;
-pushCont(co, 20, clofun1, 1, sexp);
+pushCont(co, 11, clofun1, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = sexp;
@@ -2500,12 +2263,12 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label11:
 {
-Obj x140663453334631 = __arg1;
+Obj x139886475981959 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = x140663453334631;
-pushCont(co, 21, clofun1, 1, path);
+Obj path = x139886475981959;
+pushCont(co, 12, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = sexp;
@@ -2516,14 +2279,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label12:
 {
-Obj x140663453335111 = __arg1;
+Obj x139886475982279 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 22, clofun1, 1, path);
+pushCont(co, 13, clofun1, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35parse_45package);
-__arg1 = x140663453335111;
+__arg1 = x139886475982279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2531,13 +2294,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label13:
 {
-Obj x140663453335143 = __arg1;
+Obj x139886475982311 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = x140663453335143;
-__arg1 = makeNative(23, clofun1, 3, 1, path);
+__arg0 = x139886475982311;
+__arg1 = makeNative(14, clofun1, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2545,16 +2308,16 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
+label14:
 {
 Obj import = __arg1;
 Obj export = __arg2;
 Obj body = __arg3;
-Obj x140663453286311 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 24, clofun1, 3, export, body, x140663453286311);
+Obj x139886475982855 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 15, clofun1, 3, export, body, x139886475982855);
 __nargs = 3;
 __arg0 = globalRef(symmap);
-__arg1 = makeNative(26, clofun1, 1, 0);
+__arg1 = makeNative(17, clofun1, 1, 0);
 __arg2 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2563,23 +2326,23 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label24:
+label15:
 {
-Obj x140663455196167 = __arg1;
+Obj x139886475983655 = __arg1;
 Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453286311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663455197319 = makeCons(export, Nil);
-Obj x140663455197351 = makeCons(symbackquote, x140663455197319);
-Obj x140663455197415 = makeCons(x140663455197351, Nil);
-Obj x140663455197447 = makeCons(sym_42ns_45export_42, x140663455197415);
-Obj x140663455197479 = makeCons(symdef, x140663455197447);
-Obj x140663455197543 = makeCons(x140663455197479, body);
-pushCont(co, 25, clofun1, 1, x140663453286311);
+Obj x139886475982855= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886475984359 = makeCons(export, Nil);
+Obj x139886475984391 = makeCons(symbackquote, x139886475984359);
+Obj x139886475984423 = makeCons(x139886475984391, Nil);
+Obj x139886475984455 = makeCons(sym_42ns_45export_42, x139886475984423);
+Obj x139886475984487 = makeCons(symdef, x139886475984455);
+Obj x139886475984615 = makeCons(x139886475984487, body);
+pushCont(co, 16, clofun1, 1, x139886475982855);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = x140663455196167;
-__arg2 = x140663455197543;
+__arg1 = x139886475983655;
+__arg2 = x139886475984615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2587,35 +2350,35 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label16:
 {
-Obj x140663455197575 = __arg1;
-Obj x140663453286311= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663455197607 = makeCons(symbegin, x140663455197575);
-Obj x140663455197671 = makeCons(x140663455197607, Nil);
-Obj x140663455197703 = makeCons(x140663453286311, x140663455197671);
-Obj x140663455197735 = makeCons(closureRef(co, 0), x140663455197703);
-Obj x140663455197767 = makeCons(symns, x140663455197735);
+Obj x139886475984647 = __arg1;
+Obj x139886475982855= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475984679 = makeCons(symbegin, x139886475984647);
+Obj x139886475984839 = makeCons(x139886475984679, Nil);
+Obj x139886475984871 = makeCons(x139886475982855, x139886475984839);
+Obj x139886475595783 = makeCons(closureRef(co, 0), x139886475984871);
+Obj x139886475595815 = makeCons(symns, x139886475595783);
 __nargs = 2;
-__arg1 = x140663455197767;
+__arg1 = x139886475595815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label26:
+label17:
 {
 Obj imp = __arg1;
-Obj x140663455196071 = makeCons(imp, Nil);
-Obj x140663455196103 = makeCons(symimport, x140663455196071);
+Obj x139886475983591 = makeCons(imp, Nil);
+Obj x139886475983623 = makeCons(symimport, x139886475983591);
 __nargs = 2;
-__arg1 = x140663455196103;
+__arg1 = x139886475983623;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label27:
+label18:
 {
 Obj data = __arg1;
 Obj k = __arg2;
@@ -2632,47 +2395,44 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label19:
 {
-Obj x140663453987559 = __arg1;
-Obj x140663453987591 = __arg2;
-Obj x140663453987655 = __arg3;
-Obj x140663453987687 = co->args[4];
-Obj x140663453945895 = makeNative(29, clofun1, 0, 4, x140663453987559, x140663453987591, x140663453987655, x140663453987687);
-Obj x140663453380871 = PRIM_ISCONS(x140663453987559);
-if (True == x140663453380871) {
-Obj x140663453381351 = PRIM_CAR(x140663453987559);
-Obj x140663453381383 = PRIM_ISCONS(x140663453381351);
-if (True == x140663453381383) {
-Obj x140663453382055 = PRIM_CAR(x140663453987559);
-Obj x140663453382087 = PRIM_CAR(x140663453382055);
-Obj x140663453382119 = PRIM_EQ(symimport, x140663453382087);
-if (True == x140663453382119) {
-Obj x140663453382791 = PRIM_CAR(x140663453987559);
-Obj x140663453382823 = PRIM_CDR(x140663453382791);
-Obj x140663453382855 = PRIM_ISCONS(x140663453382823);
-if (True == x140663453382855) {
-Obj x140663453383527 = PRIM_CAR(x140663453987559);
-Obj x140663453383559 = PRIM_CDR(x140663453383527);
-Obj x140663453383591 = PRIM_CAR(x140663453383559);
-Obj lib = x140663453383591;
-Obj x140663453384487 = PRIM_CAR(x140663453987559);
-Obj x140663453384519 = PRIM_CDR(x140663453384487);
-Obj x140663453384679 = PRIM_CDR(x140663453384519);
-Obj x140663453331463 = PRIM_EQ(Nil, x140663453384679);
-if (True == x140663453331463) {
-Obj x140663453331719 = PRIM_CDR(x140663453987559);
-Obj rest = x140663453331719;
-Obj imports = x140663453987591;
-Obj exports = x140663453987655;
-Obj k = x140663453987687;
-Obj x140663453332487 = makeCons(lib, imports);
+Obj x139886476148263 = __arg1;
+Obj x139886476148295 = __arg2;
+Obj x139886476148327 = __arg3;
+Obj x139886476148359 = co->args[4];
+Obj x139886476106887 = makeNative(20, clofun1, 0, 4, x139886476148327, x139886476148263, x139886476148295, x139886476148359);
+Obj x139886476080231 = PRIM_ISCONS(x139886476148263);
+if (True == x139886476080231) {
+Obj x139886476080487 = PRIM_CAR(x139886476148263);
+Obj x139886476080519 = PRIM_ISCONS(x139886476080487);
+if (True == x139886476080519) {
+Obj x139886476080967 = PRIM_CAR(x139886476148263);
+Obj x139886476080999 = PRIM_CAR(x139886476080967);
+Obj x139886476081031 = PRIM_EQ(symimport, x139886476080999);
+if (True == x139886476081031) {
+Obj x139886476081383 = PRIM_CAR(x139886476148263);
+Obj x139886476081415 = PRIM_CDR(x139886476081383);
+Obj x139886476081447 = PRIM_ISCONS(x139886476081415);
+if (True == x139886476081447) {
+Obj x139886476081991 = PRIM_CAR(x139886476148263);
+Obj x139886476082023 = PRIM_CDR(x139886476081991);
+Obj x139886476082055 = PRIM_CAR(x139886476082023);
+Obj lib = x139886476082055;
+Obj x139886476082535 = PRIM_CAR(x139886476148263);
+Obj x139886476082567 = PRIM_CDR(x139886476082535);
+Obj x139886476082599 = PRIM_CDR(x139886476082567);
+Obj x139886476082663 = PRIM_EQ(Nil, x139886476082599);
+if (True == x139886476082663) {
+Obj x139886476082823 = PRIM_CDR(x139886476148263);
+Obj rest = x139886476082823;
+Obj x139886476083079 = makeCons(lib, x139886476148295);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse_45package_45h);
 __arg1 = rest;
-__arg2 = x140663453332487;
-__arg3 = exports;
-co->args[4] = k;
+__arg2 = x139886476083079;
+__arg3 = x139886476148327;
+co->args[4] = x139886476148359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2680,16 +2440,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x140663453945895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945895;
+__arg0 = x139886476106887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2698,7 +2449,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453945895;
+__arg0 = x139886476106887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2707,7 +2458,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453945895;
+__arg0 = x139886476106887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2716,7 +2467,208 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x140663453945895;
+__arg0 = x139886476106887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476106887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj x139886476082631 = makeNative(21, clofun1, 0, 4, closureRef(co, 3), closureRef(co, 2), closureRef(co, 0), closureRef(co, 1));
+Obj x139886476106663 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139886476106663) {
+Obj x139886476107015 = PRIM_CAR(closureRef(co, 1));
+Obj x139886476107143 = PRIM_ISCONS(x139886476107015);
+if (True == x139886476107143) {
+Obj x139886476107463 = PRIM_CAR(closureRef(co, 1));
+Obj x139886476107495 = PRIM_CAR(x139886476107463);
+Obj x139886476107527 = PRIM_EQ(symexport, x139886476107495);
+if (True == x139886476107527) {
+Obj x139886476079143 = PRIM_CAR(closureRef(co, 1));
+Obj x139886476079175 = PRIM_CDR(x139886476079143);
+Obj more = x139886476079175;
+Obj x139886476079495 = PRIM_CDR(closureRef(co, 1));
+Obj rest = x139886476079495;
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse_45package_45h);
+__arg1 = rest;
+__arg2 = closureRef(co, 2);
+__arg3 = more;
+co->args[4] = closureRef(co, 3);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476082631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476082631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476082631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label21:
+{
+PUSH_CONT_0(co, 22, clofun1);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label22:
+{
+Obj x139886476106247 = __arg1;
+__nargs = 4;
+__arg0 = closureRef(co, 0);
+__arg1 = x139886476106247;
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label23:
+{
+Obj exp = __arg1;
+pushCont(co, 24, clofun1, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label24:
+{
+Obj x139886476105127 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 25, clofun1, 1, x139886476105127);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label25:
+{
+Obj x139886476105223 = __arg1;
+Obj x139886476105127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
+__arg1 = x139886476105127;
+__arg2 = x139886476105223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label26:
+{
+Obj fn = __arg1;
+Obj arglist = __arg2;
+pushCont(co, 27, clofun1, 2, arglist, fn);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = arglist;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label27:
+{
+Obj x139886476147591 = __arg1;
+Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 28, clofun1, 2, arglist, fn);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x139886476147591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label28:
+{
+Obj x139886476147623 = __arg1;
+Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886476147623) {
+Obj x139886476147911 = PRIM_CAR(arglist);
+pushCont(co, 30, clofun1, 2, x139886476147911, fn);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = arglist;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476148583 = PRIM_CAR(arglist);
+Obj x139886476103783 = PRIM_CDR(arglist);
+pushCont(co, 29, clofun1, 2, x139886476148583, fn);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
+__arg1 = fn;
+__arg2 = x139886476103783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2727,93 +2679,41 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x140663453909863 = makeNative(30, clofun1, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x140663453455367 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453455367) {
-Obj x140663453455879 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453455911 = PRIM_ISCONS(x140663453455879);
-if (True == x140663453455911) {
-Obj x140663453456615 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453456647 = PRIM_CAR(x140663453456615);
-Obj x140663453456679 = PRIM_EQ(symexport, x140663453456647);
-if (True == x140663453456679) {
-Obj x140663453457095 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453457159 = PRIM_CDR(x140663453457095);
-Obj more = x140663453457159;
-Obj x140663453457511 = PRIM_CDR(closureRef(co, 0));
-Obj rest = x140663453457511;
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45package_45h);
-__arg1 = rest;
-__arg2 = imports;
-__arg3 = more;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453909863;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453909863;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453909863;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x139886476103815 = __arg1;
+Obj x139886476148583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476104007 = makeCons(x139886476103815, Nil);
+Obj x139886476104071 = makeCons(x139886476148583, x139886476104007);
+Obj x139886476104423 = makeCons(fn, x139886476104071);
+__nargs = 2;
+__arg1 = x139886476104423;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label30:
 {
-Obj x140663453906247 = makeNative(32, clofun1, 0, 0);
-Obj body = closureRef(co, 0);
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-pushCont(co, 31, clofun1, 3, k, exports, body);
+Obj x139886476148103 = __arg1;
+Obj x139886476147911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476148135 = makeCons(x139886476148103, Nil);
+Obj x139886476148167 = makeCons(x139886476147911, x139886476148135);
+Obj x139886476148231 = makeCons(fn, x139886476148167);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = imports;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x139886476148231;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label31:
 {
-Obj x140663453454855 = __arg1;
-Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 4;
-__arg0 = k;
-__arg1 = x140663453454855;
-__arg2 = exports;
-__arg3 = body;
+Obj exp = __arg1;
+PUSH_CONT_0(co, 32, clofun1);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2823,9 +2723,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
+Obj x139886476146951 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(symcora_47init_35rewrite_45backquote);
+__arg1 = x139886476146951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2835,56 +2736,123 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj exp = __arg1;
-pushCont(co, 34, clofun1, 1, exp);
+Obj x139886476186631 = __arg1;
+Obj x139886476187783 = primIsSymbol(x139886476186631);
+if (True == x139886476187783) {
+Obj x139886476188007 = makeCons(x139886476186631, Nil);
+Obj x139886476188039 = makeCons(symquote, x139886476188007);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
+__arg1 = x139886476188039;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476188327 = makeNative(34, clofun1, 0, 1, x139886476186631);
+Obj x139886476144679 = PRIM_ISCONS(x139886476186631);
+if (True == x139886476144679) {
+Obj x139886476144935 = PRIM_CAR(x139886476186631);
+Obj x139886476144967 = PRIM_EQ(symunquote, x139886476144935);
+if (True == x139886476144967) {
+Obj x139886476145351 = PRIM_CDR(x139886476186631);
+Obj x139886476145383 = PRIM_ISCONS(x139886476145351);
+if (True == x139886476145383) {
+Obj x139886476145671 = PRIM_CDR(x139886476186631);
+Obj x139886476145735 = PRIM_CAR(x139886476145671);
+Obj x = x139886476145735;
+Obj x139886476146055 = PRIM_CDR(x139886476186631);
+Obj x139886476146087 = PRIM_CDR(x139886476146055);
+Obj x139886476146183 = PRIM_EQ(Nil, x139886476146087);
+if (True == x139886476146183) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476188327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label34:
 {
-Obj x140663453641095 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 35, clofun1, 1, x140663453641095);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
+Obj x139886476188551 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476188551) {
+Obj x139886476188807 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886476188807;
+Obj x139886476189031 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886476189031;
+Obj x139886476189383 = makeCons(x, more);
+PUSH_CONT_0(co, 35, clofun1);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = globalRef(symcora_47init_35rewrite_45backquote);
+__arg2 = x139886476189383;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = closureRef(co, 0);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label35:
 {
-Obj x140663453641383 = __arg1;
-Obj x140663453641095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
-__arg1 = x140663453641095;
-__arg2 = x140663453641383;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476189415 = __arg1;
+Obj x139886476189447 = makeCons(symlist, x139886476189415);
+__nargs = 2;
+__arg1 = x139886476189447;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label36:
 {
-Obj fn = __arg1;
-Obj arglist = __arg2;
-pushCont(co, 37, clofun1, 2, arglist, fn);
+Obj exp = __arg1;
+Obj x139886476187175 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = arglist;
+__arg0 = globalRef(symcora_47init_35rewrite_45begin);
+__arg1 = x139886476187175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2894,44 +2862,86 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x140663453670055 = __arg1;
-Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 38, clofun1, 2, arglist, fn);
+Obj x139886476185959 = __arg1;
+Obj x139886476186791 = makeNative(38, clofun1, 0, 1, x139886476185959);
+Obj x139886475268519 = PRIM_ISCONS(x139886476185959);
+if (True == x139886475268519) {
+Obj x139886475268679 = PRIM_CAR(x139886476185959);
+Obj x = x139886475268679;
+Obj x139886476186375 = PRIM_CDR(x139886476185959);
+Obj x139886476186407 = PRIM_EQ(Nil, x139886476186375);
+if (True == x139886476186407) {
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x140663453670055;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476186791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label38:
-{
-Obj x140663453670087 = __arg1;
-Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453670087) {
-Obj x140663453670631 = PRIM_CAR(arglist);
-pushCont(co, 40, clofun1, 2, x140663453670631, fn);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = arglist;
+} else {
+__nargs = 1;
+__arg0 = x139886476186791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+}
+
+label38:
+{
+Obj x139886476187911 = makeNative(39, clofun1, 0, 1, closureRef(co, 0));
+Obj x139886475332263 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475332263) {
+Obj x139886475332455 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886475332455;
+Obj x139886475332711 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475332743 = PRIM_ISCONS(x139886475332711);
+if (True == x139886475332743) {
+Obj x139886475332999 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475333031 = PRIM_CAR(x139886475332999);
+Obj y = x139886475333031;
+Obj x139886475333351 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475333383 = PRIM_CDR(x139886475333351);
+Obj x139886475333415 = PRIM_EQ(Nil, x139886475333383);
+if (True == x139886475333415) {
+Obj x139886475268103 = makeCons(y, Nil);
+Obj x139886475268135 = makeCons(x, x139886475268103);
+Obj x139886475268167 = makeCons(symdo, x139886475268135);
+__nargs = 2;
+__arg1 = x139886475268167;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140663453639207 = PRIM_CAR(arglist);
-Obj x140663453639943 = PRIM_CDR(arglist);
-pushCont(co, 39, clofun1, 2, x140663453639207, fn);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
-__arg1 = fn;
-__arg2 = x140663453639943;
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2942,29 +2952,42 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140663453639975 = __arg1;
-Obj x140663453639207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453640039 = makeCons(x140663453639975, Nil);
-Obj x140663453640071 = makeCons(x140663453639207, x140663453640039);
-Obj x140663453640103 = makeCons(fn, x140663453640071);
+Obj x139886475331239 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475331239) {
+Obj x139886475331431 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886475331431;
+Obj x139886475331623 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475331623;
+pushCont(co, 40, clofun1, 1, x);
 __nargs = 2;
-__arg1 = x140663453640103;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47init_35rewrite_45begin);
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label40:
 {
-Obj x140663453671239 = __arg1;
-Obj x140663453670631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453671303 = makeCons(x140663453671239, Nil);
-Obj x140663453671367 = makeCons(x140663453670631, x140663453671303);
-Obj x140663453671399 = makeCons(fn, x140663453671367);
+Obj x139886475331911 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475331943 = makeCons(x139886475331911, Nil);
+Obj x139886475331975 = makeCons(x, x139886475331943);
+Obj x139886475332007 = makeCons(symdo, x139886475331975);
 __nargs = 2;
-__arg1 = x140663453671399;
+__arg1 = x139886475332007;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2975,7 +2998,7 @@ label41:
 Obj exp = __arg1;
 PUSH_CONT_0(co, 42, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2986,10 +3009,11 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x140663453669159 = __arg1;
+Obj x139886475330535 = __arg1;
+PUSH_CONT_0(co, 43, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = x140663453669159;
+__arg0 = globalRef(symcora_47init_35rewrite_45namespace);
+__arg1 = x139886475330535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2999,148 +3023,81 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x140663453948327 = __arg1;
-Obj x140663453949191 = makeNative(44, clofun1, 0, 1, x140663453948327);
-Obj x = x140663453948327;
-Obj x140663453667687 = primIsSymbol(x);
-if (True == x140663453667687) {
-Obj x140663453668167 = makeCons(x, Nil);
-Obj x140663453668199 = makeCons(symquote, x140663453668167);
+Obj x139886475330567 = __arg1;
 __nargs = 2;
-__arg1 = x140663453668199;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453949191;
+__arg0 = globalRef(symcora_47init_35peval);
+__arg1 = x139886475330567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label44:
 {
-Obj x140663453909127 = makeNative(45, clofun1, 0, 1, closureRef(co, 0));
-Obj x140663453793607 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453793607) {
-Obj x140663453794279 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453741063 = PRIM_EQ(symunquote, x140663453794279);
-if (True == x140663453741063) {
-Obj x140663453741735 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453741767 = PRIM_ISCONS(x140663453741735);
-if (True == x140663453741767) {
-Obj x140663453742279 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453742535 = PRIM_CAR(x140663453742279);
-Obj x = x140663453742535;
-Obj x140663453743559 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453743623 = PRIM_CDR(x140663453743559);
-Obj x140663453743655 = PRIM_EQ(Nil, x140663453743623);
-if (True == x140663453743655) {
+Obj x = __arg1;
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453909127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453909127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453909127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453909127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label45:
 {
-Obj x140663453910567 = makeNative(47, clofun1, 0, 1, closureRef(co, 0));
-Obj x140663453791111 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453791111) {
-Obj x140663453791367 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140663453791367;
-Obj x140663453792071 = PRIM_CDR(closureRef(co, 0));
-Obj more = x140663453792071;
-Obj x140663453792871 = makeCons(x, more);
-PUSH_CONT_0(co, 46, clofun1);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = x140663453792871;
+Obj exp = __arg1;
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35parse);
+__arg1 = Nil;
+__arg2 = makeCString("");
+__arg3 = Nil;
+co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453910567;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label46:
 {
-Obj x140663453792903 = __arg1;
-Obj x140663453792935 = makeCons(symlist, x140663453792903);
+Obj exp = __arg1;
+pushCont(co, 47, clofun1, 1, exp);
 __nargs = 2;
-__arg1 = x140663453792935;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label47:
 {
-Obj x140663453912359 = makeNative(48, clofun1, 0, 0);
-Obj x = closureRef(co, 0);
+Obj x139886475385799 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 48, clofun1, 1, exp);
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun1) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47init_35extract_45rules);
+__arg1 = x139886475385799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label48:
 {
+Obj x139886475385831 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body = x139886475385831;
+pushCont(co, 49, clofun1, 2, exp, body);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(symcora_47init_35rules_45arg_45count);
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3150,11 +3107,14 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj exp = __arg1;
-Obj x140663453883207 = PRIM_CDR(exp);
+Obj x139886475385991 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj nargs = x139886475385991;
+pushCont(co, 0, clofun2, 2, exp, body);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = x140663453883207;
+__arg0 = globalRef(symcora_47init_35gen_45paramenters);
+__arg1 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3184,2286 +3144,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140663453987175 = __arg1;
-Obj x140663453988103 = makeNative(1, clofun2, 0, 1, x140663453987175);
-Obj x140663453880327 = PRIM_ISCONS(x140663453987175);
-if (True == x140663453880327) {
-Obj x140663453880807 = PRIM_CAR(x140663453987175);
-Obj x = x140663453880807;
-Obj x140663453881575 = PRIM_CDR(x140663453987175);
-Obj x140663453881607 = PRIM_EQ(Nil, x140663453881575);
-if (True == x140663453881607) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453988103;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988103;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label1:
-{
-Obj x140663453989319 = makeNative(2, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453911687 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453911687) {
-Obj x140663453912007 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140663453912007;
-Obj x140663453905159 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453905191 = PRIM_ISCONS(x140663453905159);
-if (True == x140663453905191) {
-Obj x140663453905639 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453905671 = PRIM_CAR(x140663453905639);
-Obj y = x140663453905671;
-Obj x140663453907015 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453907047 = PRIM_CDR(x140663453907015);
-Obj x140663453907079 = PRIM_EQ(Nil, x140663453907047);
-if (True == x140663453907079) {
-Obj x140663453908007 = makeCons(y, Nil);
-Obj x140663453908039 = makeCons(x, x140663453908007);
-Obj x140663453908071 = makeCons(symdo, x140663453908039);
-__nargs = 2;
-__arg1 = x140663453908071;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453989319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj x140663453946375 = makeNative(4, clofun2, 0, 0);
-Obj x140663453949607 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453949607) {
-Obj x140663453949863 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140663453949863;
-Obj x140663453909447 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140663453909447;
-pushCont(co, 3, clofun2, 1, x);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453946375;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label3:
-{
-Obj x140663453910759 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453910887 = makeCons(x140663453910759, Nil);
-Obj x140663453911175 = makeCons(x, x140663453910887);
-Obj x140663453911207 = makeCons(symdo, x140663453911175);
-__nargs = 2;
-__arg1 = x140663453911207;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj exp = __arg1;
-PUSH_CONT_0(co, 6, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x140663453946983 = __arg1;
-PUSH_CONT_0(co, 7, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45namespace);
-__arg1 = x140663453946983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x140663453947079 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x140663453947079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj exp = __arg1;
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = Nil;
-__arg2 = makeCString("");
-__arg3 = Nil;
-co->args[4] = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj x140663453987463 = __arg1;
-Obj x140663453988359 = makeNative(10, clofun2, 0, 1, x140663453987463);
-Obj x140663454500007 = PRIM_ISCONS(x140663453987463);
-if (True == x140663454500007) {
-Obj x140663454500743 = PRIM_CAR(x140663453987463);
-Obj x140663454500775 = PRIM_EQ(symquote, x140663454500743);
-if (True == x140663454500775) {
-Obj x140663454501575 = PRIM_CDR(x140663453987463);
-Obj x140663454501607 = PRIM_ISCONS(x140663454501575);
-if (True == x140663454501607) {
-Obj x140663454502311 = PRIM_CDR(x140663453987463);
-Obj x140663454502375 = PRIM_CAR(x140663454502311);
-Obj x = x140663454502375;
-Obj x140663453987399 = PRIM_CDR(x140663453987463);
-Obj x140663453987495 = PRIM_CDR(x140663453987399);
-Obj x140663453987527 = PRIM_EQ(Nil, x140663453987495);
-if (True == x140663453987527) {
-Obj x140663453988391 = makeCons(x, Nil);
-Obj x140663453988423 = makeCons(symquote, x140663453988391);
-__nargs = 2;
-__arg1 = x140663453988423;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453988359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj x140663453989767 = makeNative(12, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454583847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454583847) {
-Obj x140663454584551 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454584583 = PRIM_EQ(symcons_63, x140663454584551);
-if (True == x140663454584583) {
-Obj x140663454540455 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454540487 = PRIM_ISCONS(x140663454540455);
-if (True == x140663454540487) {
-Obj x140663454541191 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454541255 = PRIM_CAR(x140663454541191);
-Obj x = x140663454541255;
-Obj x140663454542279 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454542311 = PRIM_CDR(x140663454542279);
-Obj x140663454542343 = PRIM_EQ(Nil, x140663454542311);
-if (True == x140663454542343) {
-PUSH_CONT_0(co, 11, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453989767;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989767;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989767;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989767;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj x140663454542663 = __arg1;
-Obj x1 = x140663454542663;
-Obj x140663454543559 = makeCons(x1, Nil);
-Obj x140663454543591 = makeCons(symcons_63, x140663454543559);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454543591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj x140663453946151 = makeNative(14, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454602503 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454602503) {
-Obj x140663454603175 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454603271 = PRIM_EQ(symcar, x140663454603175);
-if (True == x140663454603271) {
-Obj x140663454604007 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454604039 = PRIM_ISCONS(x140663454604007);
-if (True == x140663454604039) {
-Obj x140663454604519 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454604551 = PRIM_CAR(x140663454604519);
-Obj x = x140663454604551;
-Obj x140663454581223 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454581255 = PRIM_CDR(x140663454581223);
-Obj x140663454581287 = PRIM_EQ(Nil, x140663454581255);
-if (True == x140663454581287) {
-PUSH_CONT_0(co, 13, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453946151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453946151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453946151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453946151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj x140663454581767 = __arg1;
-Obj x1 = x140663454581767;
-Obj x140663454582599 = makeCons(x1, Nil);
-Obj x140663454582631 = makeCons(symcar, x140663454582599);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454582631;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x140663453947591 = makeNative(16, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454899783 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454899783) {
-Obj x140663454883975 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454884039 = PRIM_EQ(symcdr, x140663454883975);
-if (True == x140663454884039) {
-Obj x140663454884551 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454884679 = PRIM_ISCONS(x140663454884551);
-if (True == x140663454884679) {
-Obj x140663454885351 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454885383 = PRIM_CAR(x140663454885351);
-Obj x = x140663454885383;
-Obj x140663454886215 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454886247 = PRIM_CDR(x140663454886215);
-Obj x140663454886279 = PRIM_EQ(Nil, x140663454886247);
-if (True == x140663454886279) {
-PUSH_CONT_0(co, 15, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453947591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453947591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x140663454886855 = __arg1;
-Obj x1 = x140663454886855;
-Obj x140663454887879 = makeCons(x1, Nil);
-Obj x140663454887911 = makeCons(symcdr, x140663454887879);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454887911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj x140663453948999 = makeNative(19, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454948807 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454948807) {
-Obj x140663454916679 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454916711 = PRIM_EQ(symand, x140663454916679);
-if (True == x140663454916711) {
-Obj x140663454917447 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454917479 = PRIM_ISCONS(x140663454917447);
-if (True == x140663454917479) {
-Obj x140663454917927 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454917959 = PRIM_CAR(x140663454917927);
-Obj x = x140663454917959;
-Obj x140663454918983 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454919015 = PRIM_CDR(x140663454918983);
-Obj x140663454919079 = PRIM_ISCONS(x140663454919015);
-if (True == x140663454919079) {
-Obj x140663454919847 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454919879 = PRIM_CDR(x140663454919847);
-Obj x140663454919911 = PRIM_CAR(x140663454919879);
-Obj y = x140663454919911;
-Obj x140663454896295 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454896327 = PRIM_CDR(x140663454896295);
-Obj x140663454896487 = PRIM_CDR(x140663454896327);
-Obj x140663454896519 = PRIM_EQ(Nil, x140663454896487);
-if (True == x140663454896519) {
-pushCont(co, 17, clofun2, 1, y);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453948999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label17:
-{
-Obj x140663454896839 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1 = x140663454896839;
-pushCont(co, 18, clofun2, 1, x1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj x140663454897159 = __arg1;
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y1 = x140663454897159;
-Obj x140663454898375 = makeCons(y1, Nil);
-Obj x140663454898407 = makeCons(x1, x140663454898375);
-Obj x140663454898439 = makeCons(symand, x140663454898407);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454898439;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj x140663453910215 = makeNative(21, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454975847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454975847) {
-Obj x140663454976391 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454976423 = PRIM_EQ(symnull_63, x140663454976391);
-if (True == x140663454976423) {
-Obj x140663454977095 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454977191 = PRIM_ISCONS(x140663454977095);
-if (True == x140663454977191) {
-Obj x140663454977895 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454977927 = PRIM_CAR(x140663454977895);
-Obj x = x140663454977927;
-Obj x140663454946023 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454946247 = PRIM_CDR(x140663454946023);
-Obj x140663454946279 = PRIM_EQ(Nil, x140663454946247);
-if (True == x140663454946279) {
-PUSH_CONT_0(co, 20, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453910215;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910215;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910215;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910215;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj x140663454946599 = __arg1;
-Obj x1 = x140663454946599;
-Obj x140663454947527 = makeCons(x1, Nil);
-Obj x140663454947591 = makeCons(symnull_63, x140663454947527);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454947591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label21:
-{
-Obj x140663453911655 = makeNative(23, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453335303 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453335303) {
-Obj x140663453283815 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453283847 = PRIM_EQ(symnot, x140663453283815);
-if (True == x140663453283847) {
-Obj x140663453284263 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453284295 = PRIM_ISCONS(x140663453284263);
-if (True == x140663453284295) {
-Obj x140663453284711 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453284743 = PRIM_CAR(x140663453284711);
-Obj x = x140663453284743;
-Obj x140663453285351 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453285383 = PRIM_CDR(x140663453285351);
-Obj x140663453285415 = PRIM_EQ(Nil, x140663453285383);
-if (True == x140663453285415) {
-PUSH_CONT_0(co, 22, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453911655;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911655;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911655;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911655;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label22:
-{
-Obj x140663453285671 = __arg1;
-Obj x1 = x140663453285671;
-Obj x140663454974727 = makeCons(x1, Nil);
-Obj x140663454974791 = makeCons(symnot, x140663454974727);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663454974791;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label23:
-{
-Obj x140663453913063 = makeNative(27, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453458151 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453458151) {
-Obj x140663453380775 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453380807 = PRIM_EQ(symif, x140663453380775);
-if (True == x140663453380807) {
-Obj x140663453381223 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453381255 = PRIM_ISCONS(x140663453381223);
-if (True == x140663453381255) {
-Obj x140663453381671 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453381703 = PRIM_CAR(x140663453381671);
-Obj x = x140663453381703;
-Obj x140663453382279 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453382311 = PRIM_CDR(x140663453382279);
-Obj x140663453382343 = PRIM_ISCONS(x140663453382311);
-if (True == x140663453382343) {
-Obj x140663453382919 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453382951 = PRIM_CDR(x140663453382919);
-Obj x140663453382983 = PRIM_CAR(x140663453382951);
-Obj y = x140663453382983;
-Obj x140663453383719 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453383751 = PRIM_CDR(x140663453383719);
-Obj x140663453383783 = PRIM_CDR(x140663453383751);
-Obj x140663453383815 = PRIM_ISCONS(x140663453383783);
-if (True == x140663453383815) {
-Obj x140663453384551 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453384583 = PRIM_CDR(x140663453384551);
-Obj x140663453384615 = PRIM_CDR(x140663453384583);
-Obj x140663453384647 = PRIM_CAR(x140663453384615);
-Obj z = x140663453384647;
-Obj x140663453332327 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453332359 = PRIM_CDR(x140663453332327);
-Obj x140663453332391 = PRIM_CDR(x140663453332359);
-Obj x140663453332423 = PRIM_CDR(x140663453332391);
-Obj x140663453332455 = PRIM_EQ(Nil, x140663453332423);
-if (True == x140663453332455) {
-pushCont(co, 24, clofun2, 2, y, z);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453913063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label24:
-{
-Obj x140663453332711 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x1 = x140663453332711;
-pushCont(co, 25, clofun2, 2, z, x1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label25:
-{
-Obj x140663453332967 = __arg1;
-Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y1 = x140663453332967;
-pushCont(co, 26, clofun2, 2, y1, x1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = z;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label26:
-{
-Obj x140663453333223 = __arg1;
-Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj z1 = x140663453333223;
-Obj x140663453334183 = makeCons(z1, Nil);
-Obj x140663453334215 = makeCons(y1, x140663453334183);
-Obj x140663453334247 = makeCons(x1, x140663453334215);
-Obj x140663453334279 = makeCons(symif, x140663453334247);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = x140663453334279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label27:
-{
-Obj x140663453907911 = makeNative(29, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453639655 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453639655) {
-Obj x140663453640167 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453640199 = PRIM_EQ(symlambda, x140663453640167);
-if (True == x140663453640199) {
-Obj x140663453640679 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453640711 = PRIM_ISCONS(x140663453640679);
-if (True == x140663453640711) {
-Obj x140663453641223 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453641255 = PRIM_CAR(x140663453641223);
-Obj args = x140663453641255;
-Obj x140663453641927 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453641959 = PRIM_CDR(x140663453641927);
-Obj x140663453641991 = PRIM_ISCONS(x140663453641959);
-if (True == x140663453641991) {
-Obj x140663453642599 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453642631 = PRIM_CDR(x140663453642599);
-Obj x140663453642663 = PRIM_CAR(x140663453642631);
-Obj body = x140663453642663;
-Obj x140663453455143 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453455175 = PRIM_CDR(x140663453455143);
-Obj x140663453455207 = PRIM_CDR(x140663453455175);
-Obj x140663453455239 = PRIM_EQ(Nil, x140663453455207);
-if (True == x140663453455239) {
-pushCont(co, 28, clofun2, 1, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label28:
-{
-Obj x140663453457127 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453457191 = makeCons(x140663453457127, Nil);
-Obj x140663453457223 = makeCons(args, x140663453457191);
-Obj x140663453457255 = makeCons(symlambda, x140663453457223);
-__nargs = 2;
-__arg1 = x140663453457255;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label29:
-{
-Obj x140663453881447 = makeNative(30, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453671079 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453671079) {
-Obj x140663453671335 = PRIM_CAR(closureRef(co, 0));
-Obj f = x140663453671335;
-Obj x140663453638823 = PRIM_CDR(closureRef(co, 0));
-Obj args = x140663453638823;
-Obj x140663453639239 = makeCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35propagate_45boolean);
-__arg2 = x140663453639239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453881447;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label30:
-{
-Obj x140663453883143 = makeNative(31, clofun2, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label31:
-{
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x140663453987431 = __arg1;
-Obj x140663453988295 = makeNative(33, clofun2, 0, 1, x140663453987431);
-Obj x140663453880711 = PRIM_ISCONS(x140663453987431);
-if (True == x140663453880711) {
-Obj x140663453881383 = PRIM_CAR(x140663453987431);
-Obj x140663453881415 = PRIM_EQ(symcar, x140663453881383);
-if (True == x140663453881415) {
-Obj x140663453882023 = PRIM_CDR(x140663453987431);
-Obj x140663453882087 = PRIM_ISCONS(x140663453882023);
-if (True == x140663453882087) {
-Obj x140663453882887 = PRIM_CDR(x140663453987431);
-Obj x140663453882919 = PRIM_CAR(x140663453882887);
-Obj x140663453882951 = PRIM_ISCONS(x140663453882919);
-if (True == x140663453882951) {
-Obj x140663453884039 = PRIM_CDR(x140663453987431);
-Obj x140663453884071 = PRIM_CAR(x140663453884039);
-Obj x140663453884103 = PRIM_CAR(x140663453884071);
-Obj x140663453884135 = PRIM_EQ(symcons, x140663453884103);
-if (True == x140663453884135) {
-Obj x140663453790887 = PRIM_CDR(x140663453987431);
-Obj x140663453790919 = PRIM_CAR(x140663453790887);
-Obj x140663453790983 = PRIM_CDR(x140663453790919);
-Obj x140663453791015 = PRIM_ISCONS(x140663453790983);
-if (True == x140663453791015) {
-Obj x140663453792199 = PRIM_CDR(x140663453987431);
-Obj x140663453792231 = PRIM_CAR(x140663453792199);
-Obj x140663453792263 = PRIM_CDR(x140663453792231);
-Obj x140663453792295 = PRIM_CAR(x140663453792263);
-Obj x = x140663453792295;
-Obj x140663453793319 = PRIM_CDR(x140663453987431);
-Obj x140663453793351 = PRIM_CAR(x140663453793319);
-Obj x140663453793415 = PRIM_CDR(x140663453793351);
-Obj x140663453793447 = PRIM_CDR(x140663453793415);
-Obj x140663453793479 = PRIM_ISCONS(x140663453793447);
-if (True == x140663453793479) {
-Obj x140663453741383 = PRIM_CDR(x140663453987431);
-Obj x140663453741415 = PRIM_CAR(x140663453741383);
-Obj x140663453741447 = PRIM_CDR(x140663453741415);
-Obj x140663453741479 = PRIM_CDR(x140663453741447);
-Obj x140663453741511 = PRIM_CAR(x140663453741479);
-Obj __ = x140663453741511;
-Obj x140663453743047 = PRIM_CDR(x140663453987431);
-Obj x140663453743111 = PRIM_CAR(x140663453743047);
-Obj x140663453743271 = PRIM_CDR(x140663453743111);
-Obj x140663453743303 = PRIM_CDR(x140663453743271);
-Obj x140663453743335 = PRIM_CDR(x140663453743303);
-Obj x140663453743367 = PRIM_EQ(Nil, x140663453743335);
-if (True == x140663453743367) {
-Obj x140663453744839 = PRIM_CDR(x140663453987431);
-Obj x140663453744903 = PRIM_CDR(x140663453744839);
-Obj x140663453744935 = PRIM_EQ(Nil, x140663453744903);
-if (True == x140663453744935) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453988295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label33:
-{
-Obj x140663453945927 = makeNative(34, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453988455 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453988455) {
-Obj x140663453989255 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453989351 = PRIM_EQ(symcdr, x140663453989255);
-if (True == x140663453989351) {
-Obj x140663453989895 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453989927 = PRIM_ISCONS(x140663453989895);
-if (True == x140663453989927) {
-Obj x140663453945959 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453946023 = PRIM_CAR(x140663453945959);
-Obj x140663453946055 = PRIM_ISCONS(x140663453946023);
-if (True == x140663453946055) {
-Obj x140663453947271 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453947431 = PRIM_CAR(x140663453947271);
-Obj x140663453947463 = PRIM_CAR(x140663453947431);
-Obj x140663453947623 = PRIM_EQ(symcons, x140663453947463);
-if (True == x140663453947623) {
-Obj x140663453948711 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453948775 = PRIM_CAR(x140663453948711);
-Obj x140663453948807 = PRIM_CDR(x140663453948775);
-Obj x140663453948839 = PRIM_ISCONS(x140663453948807);
-if (True == x140663453948839) {
-Obj x140663453908999 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453909095 = PRIM_CAR(x140663453908999);
-Obj x140663453909159 = PRIM_CDR(x140663453909095);
-Obj x140663453909191 = PRIM_CAR(x140663453909159);
-Obj __ = x140663453909191;
-Obj x140663453910503 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453910535 = PRIM_CAR(x140663453910503);
-Obj x140663453910599 = PRIM_CDR(x140663453910535);
-Obj x140663453910631 = PRIM_CDR(x140663453910599);
-Obj x140663453910663 = PRIM_ISCONS(x140663453910631);
-if (True == x140663453910663) {
-Obj x140663453912071 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453912103 = PRIM_CAR(x140663453912071);
-Obj x140663453912135 = PRIM_CDR(x140663453912103);
-Obj x140663453912327 = PRIM_CDR(x140663453912135);
-Obj x140663453912487 = PRIM_CAR(x140663453912327);
-Obj x = x140663453912487;
-Obj x140663453905959 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453905991 = PRIM_CAR(x140663453905959);
-Obj x140663453906023 = PRIM_CDR(x140663453905991);
-Obj x140663453906055 = PRIM_CDR(x140663453906023);
-Obj x140663453906087 = PRIM_CDR(x140663453906055);
-Obj x140663453906119 = PRIM_EQ(Nil, x140663453906087);
-if (True == x140663453906119) {
-Obj x140663453907271 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453907303 = PRIM_CDR(x140663453907271);
-Obj x140663453907335 = PRIM_EQ(Nil, x140663453907303);
-if (True == x140663453907335) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453945927;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj x140663453948615 = makeNative(35, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454605287 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454605287) {
-Obj x140663454581447 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454581479 = PRIM_EQ(symcons_63, x140663454581447);
-if (True == x140663454581479) {
-Obj x140663454581959 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454582023 = PRIM_ISCONS(x140663454581959);
-if (True == x140663454582023) {
-Obj x140663454582727 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454582759 = PRIM_CAR(x140663454582727);
-Obj x140663454582791 = PRIM_ISCONS(x140663454582759);
-if (True == x140663454582791) {
-Obj x140663454583911 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454583943 = PRIM_CAR(x140663454583911);
-Obj x140663454584007 = PRIM_CAR(x140663454583943);
-Obj x140663454584039 = PRIM_EQ(symcons, x140663454584007);
-if (True == x140663454584039) {
-Obj x140663454539943 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454539975 = PRIM_CAR(x140663454539943);
-Obj x140663454540071 = PRIM_CDR(x140663454539975);
-Obj x140663454540295 = PRIM_ISCONS(x140663454540071);
-if (True == x140663454540295) {
-Obj x140663454541351 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454541383 = PRIM_CAR(x140663454541351);
-Obj x140663454541415 = PRIM_CDR(x140663454541383);
-Obj x140663454541479 = PRIM_CAR(x140663454541415);
-Obj __ = x140663454541479;
-Obj x140663454542695 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454542727 = PRIM_CAR(x140663454542695);
-Obj x140663454542759 = PRIM_CDR(x140663454542727);
-Obj x140663454542791 = PRIM_CDR(x140663454542759);
-Obj x140663454542823 = PRIM_ISCONS(x140663454542791);
-if (True == x140663454542823) {
-Obj x140663454499015 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454499047 = PRIM_CAR(x140663454499015);
-Obj x140663454499079 = PRIM_CDR(x140663454499047);
-Obj x140663454499111 = PRIM_CDR(x140663454499079);
-Obj x140663454499143 = PRIM_CAR(x140663454499111);
-__ = x140663454499143;
-Obj x140663454500903 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454500935 = PRIM_CAR(x140663454500903);
-Obj x140663454500967 = PRIM_CDR(x140663454500935);
-Obj x140663454500999 = PRIM_CDR(x140663454500967);
-Obj x140663454501031 = PRIM_CDR(x140663454500999);
-Obj x140663454501063 = PRIM_EQ(Nil, x140663454501031);
-if (True == x140663454501063) {
-Obj x140663454501927 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454501959 = PRIM_CDR(x140663454501927);
-Obj x140663454501991 = PRIM_EQ(Nil, x140663454501959);
-if (True == x140663454501991) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453948615;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label35:
-{
-Obj x140663453910311 = makeNative(36, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454884455 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454884455) {
-Obj x140663454884999 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454885031 = PRIM_EQ(symand, x140663454884999);
-if (True == x140663454885031) {
-Obj x140663454885735 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454885767 = PRIM_ISCONS(x140663454885735);
-if (True == x140663454885767) {
-Obj x140663454886567 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454886631 = PRIM_CAR(x140663454886567);
-Obj x140663454886663 = PRIM_EQ(True, x140663454886631);
-if (True == x140663454886663) {
-Obj x140663454887591 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454887623 = PRIM_CDR(x140663454887591);
-Obj x140663454887655 = PRIM_ISCONS(x140663454887623);
-if (True == x140663454887655) {
-Obj x140663454602055 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454602087 = PRIM_CDR(x140663454602055);
-Obj x140663454602119 = PRIM_CAR(x140663454602087);
-Obj x140663454602151 = PRIM_EQ(True, x140663454602119);
-if (True == x140663454602151) {
-Obj x140663454603335 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454603367 = PRIM_CDR(x140663454603335);
-Obj x140663454603463 = PRIM_CDR(x140663454603367);
-Obj x140663454603495 = PRIM_EQ(Nil, x140663454603463);
-if (True == x140663454603495) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453910311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label36:
-{
-Obj x140663453911399 = makeNative(37, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454896807 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454896807) {
-Obj x140663454897351 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454897447 = PRIM_EQ(symnull_63, x140663454897351);
-if (True == x140663454897447) {
-Obj x140663454898087 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454898119 = PRIM_ISCONS(x140663454898087);
-if (True == x140663454898119) {
-Obj x140663454898855 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454898887 = PRIM_CAR(x140663454898855);
-Obj x140663454898919 = PRIM_EQ(Nil, x140663454898887);
-if (True == x140663454898919) {
-Obj x140663454899655 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454899687 = PRIM_CDR(x140663454899655);
-Obj x140663454899719 = PRIM_EQ(Nil, x140663454899687);
-if (True == x140663454899719) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453911399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453911399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label37:
-{
-Obj x140663453912231 = makeNative(38, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663454974759 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454974759) {
-Obj x140663454975271 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454975303 = PRIM_EQ(symnull_63, x140663454975271);
-if (True == x140663454975303) {
-Obj x140663454975879 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454975911 = PRIM_ISCONS(x140663454975879);
-if (True == x140663454975911) {
-Obj x140663454976647 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454976679 = PRIM_CAR(x140663454976647);
-Obj x140663454976711 = PRIM_ISCONS(x140663454976679);
-if (True == x140663454976711) {
-Obj x140663454977735 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454977767 = PRIM_CAR(x140663454977735);
-Obj x140663454977799 = PRIM_CAR(x140663454977767);
-Obj x140663454977831 = PRIM_EQ(symcons, x140663454977799);
-if (True == x140663454977831) {
-Obj x140663454946119 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454946151 = PRIM_CAR(x140663454946119);
-Obj x140663454946183 = PRIM_CDR(x140663454946151);
-Obj x140663454946215 = PRIM_ISCONS(x140663454946183);
-if (True == x140663454946215) {
-Obj x140663454947207 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454947239 = PRIM_CAR(x140663454947207);
-Obj x140663454947271 = PRIM_CDR(x140663454947239);
-Obj x140663454947303 = PRIM_CAR(x140663454947271);
-Obj __ = x140663454947303;
-Obj x140663454948359 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454948551 = PRIM_CAR(x140663454948359);
-Obj x140663454948583 = PRIM_CDR(x140663454948551);
-Obj x140663454948615 = PRIM_CDR(x140663454948583);
-Obj x140663454948647 = PRIM_ISCONS(x140663454948615);
-if (True == x140663454948647) {
-Obj x140663454917095 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454917127 = PRIM_CAR(x140663454917095);
-Obj x140663454917159 = PRIM_CDR(x140663454917127);
-Obj x140663454917191 = PRIM_CDR(x140663454917159);
-Obj x140663454917223 = PRIM_CAR(x140663454917191);
-__ = x140663454917223;
-Obj x140663454918471 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454918503 = PRIM_CAR(x140663454918471);
-Obj x140663454918535 = PRIM_CDR(x140663454918503);
-Obj x140663454918567 = PRIM_CDR(x140663454918535);
-Obj x140663454918759 = PRIM_CDR(x140663454918567);
-Obj x140663454918823 = PRIM_EQ(Nil, x140663454918759);
-if (True == x140663454918823) {
-Obj x140663454919559 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454919591 = PRIM_CDR(x140663454919559);
-Obj x140663454919623 = PRIM_EQ(Nil, x140663454919591);
-if (True == x140663454919623) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453912231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label38:
-{
-Obj x140663453906695 = makeNative(39, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453642503 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453642503) {
-Obj x140663453454535 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453454567 = PRIM_EQ(symnot, x140663453454535);
-if (True == x140663453454567) {
-Obj x140663453454983 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453455015 = PRIM_ISCONS(x140663453454983);
-if (True == x140663453455015) {
-Obj x140663453455623 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453455655 = PRIM_CAR(x140663453455623);
-Obj x140663453455687 = PRIM_EQ(True, x140663453455655);
-if (True == x140663453455687) {
-Obj x140663453456295 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453456327 = PRIM_CDR(x140663453456295);
-Obj x140663453456359 = PRIM_EQ(Nil, x140663453456327);
-if (True == x140663453456359) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453906695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453906695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453906695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453906695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453906695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label39:
-{
-Obj x140663453907527 = makeNative(40, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453639335 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453639335) {
-Obj x140663453639783 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453639815 = PRIM_EQ(symnot, x140663453639783);
-if (True == x140663453639815) {
-Obj x140663453640231 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453640263 = PRIM_ISCONS(x140663453640231);
-if (True == x140663453640263) {
-Obj x140663453640871 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453640903 = PRIM_CAR(x140663453640871);
-Obj x140663453640935 = PRIM_EQ(False, x140663453640903);
-if (True == x140663453640935) {
-Obj x140663453641543 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453641575 = PRIM_CDR(x140663453641543);
-Obj x140663453641607 = PRIM_EQ(Nil, x140663453641575);
-if (True == x140663453641607) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453907527;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907527;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907527;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907527;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453907527;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label40:
-{
-Obj x140663453908359 = makeNative(41, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453793127 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453793127) {
-Obj x140663453793639 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453793671 = PRIM_EQ(symif, x140663453793639);
-if (True == x140663453793671) {
-Obj x140663453794087 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453794215 = PRIM_ISCONS(x140663453794087);
-if (True == x140663453794215) {
-Obj x140663453741575 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453741607 = PRIM_CAR(x140663453741575);
-Obj x140663453741639 = PRIM_EQ(True, x140663453741607);
-if (True == x140663453741639) {
-Obj x140663453742311 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453742343 = PRIM_CDR(x140663453742311);
-Obj x140663453742375 = PRIM_ISCONS(x140663453742343);
-if (True == x140663453742375) {
-Obj x140663453743143 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453743207 = PRIM_CDR(x140663453743143);
-Obj x140663453743239 = PRIM_CAR(x140663453743207);
-Obj y = x140663453743239;
-Obj x140663453744743 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453744775 = PRIM_CDR(x140663453744743);
-Obj x140663453744807 = PRIM_CDR(x140663453744775);
-Obj x140663453744871 = PRIM_ISCONS(x140663453744807);
-if (True == x140663453744871) {
-Obj x140663453669767 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453669799 = PRIM_CDR(x140663453669767);
-Obj x140663453669831 = PRIM_CDR(x140663453669799);
-Obj x140663453669863 = PRIM_CAR(x140663453669831);
-Obj z = x140663453669863;
-Obj x140663453670791 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453670823 = PRIM_CDR(x140663453670791);
-Obj x140663453670855 = PRIM_CDR(x140663453670823);
-Obj x140663453670887 = PRIM_CDR(x140663453670855);
-Obj x140663453670919 = PRIM_EQ(Nil, x140663453670887);
-if (True == x140663453670919) {
-__nargs = 2;
-__arg1 = y;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453908359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label41:
-{
-Obj x140663453989575 = makeNative(42, clofun2, 0, 1, closureRef(co, 0));
-Obj x140663453907783 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663453907783) {
-Obj x140663453908391 = PRIM_CAR(closureRef(co, 0));
-Obj x140663453908423 = PRIM_EQ(symif, x140663453908391);
-if (True == x140663453908423) {
-Obj x140663453908871 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453908903 = PRIM_ISCONS(x140663453908871);
-if (True == x140663453908903) {
-Obj x140663453881031 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453881063 = PRIM_CAR(x140663453881031);
-Obj x140663453881095 = PRIM_EQ(False, x140663453881063);
-if (True == x140663453881095) {
-Obj x140663453881895 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453881927 = PRIM_CDR(x140663453881895);
-Obj x140663453881959 = PRIM_ISCONS(x140663453881927);
-if (True == x140663453881959) {
-Obj x140663453882663 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453882695 = PRIM_CDR(x140663453882663);
-Obj x140663453882727 = PRIM_CAR(x140663453882695);
-Obj y = x140663453882727;
-Obj x140663453883591 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453883623 = PRIM_CDR(x140663453883591);
-Obj x140663453883687 = PRIM_CDR(x140663453883623);
-Obj x140663453883719 = PRIM_ISCONS(x140663453883687);
-if (True == x140663453883719) {
-Obj x140663453790407 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453790439 = PRIM_CDR(x140663453790407);
-Obj x140663453790471 = PRIM_CDR(x140663453790439);
-Obj x140663453790503 = PRIM_CAR(x140663453790471);
-Obj z = x140663453790503;
-Obj x140663453791495 = PRIM_CDR(closureRef(co, 0));
-Obj x140663453791527 = PRIM_CDR(x140663453791495);
-Obj x140663453791559 = PRIM_CDR(x140663453791527);
-Obj x140663453791687 = PRIM_CDR(x140663453791559);
-Obj x140663453791719 = PRIM_EQ(Nil, x140663453791687);
-if (True == x140663453791719) {
-__nargs = 2;
-__arg1 = z;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453989575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label42:
-{
-Obj x140663453947047 = makeNative(43, clofun2, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun2) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label43:
-{
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label44:
-{
-Obj exp = __arg1;
-pushCont(co, 45, clofun2, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj x140663453909383 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 46, clofun2, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = x140663453909383;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-Obj x140663453909415 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = x140663453909415;
-pushCont(co, 47, clofun2, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rules_45arg_45count);
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
-Obj x140663453909671 = __arg1;
+Obj x139886475386151 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = x140663453909671;
-pushCont(co, 48, clofun2, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = nargs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label48:
-{
-Obj x140663453910119 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = x140663453910119;
-pushCont(co, 49, clofun2, 2, body, args);
+Obj args = x139886475386151;
+pushCont(co, 1, clofun2, 2, body, args);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -5474,23 +3159,1185 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label49:
+label1:
 {
-Obj x140663453910823 = __arg1;
+Obj x139886475386375 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453912519 = makeCons(symlist, args);
-Obj x140663453912583 = makeCons(x140663453912519, body);
-Obj x140663453912615 = makeCons(symmatch, x140663453912583);
-Obj x140663453912679 = makeCons(x140663453912615, Nil);
-Obj x140663453912711 = makeCons(args, x140663453912679);
-Obj x140663453912743 = makeCons(x140663453910823, x140663453912711);
-Obj x140663453912775 = makeCons(symdefun, x140663453912743);
+Obj x139886475386727 = makeCons(symlist, args);
+Obj x139886475386759 = makeCons(x139886475386727, body);
+Obj x139886475386791 = makeCons(symmatch, x139886475386759);
+Obj x139886475386823 = makeCons(x139886475386791, Nil);
+Obj x139886475386855 = makeCons(args, x139886475386823);
+Obj x139886475329543 = makeCons(x139886475386375, x139886475386855);
+Obj x139886475329575 = makeCons(symdefun, x139886475329543);
 __nargs = 2;
-__arg1 = x140663453912775;
+__arg1 = x139886475329575;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj n = __arg1;
+Obj x139886475384967 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == x139886475384967) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475385127 = primGenSym();
+Obj x139886475385287 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 3, clofun2, 1, x139886475385127);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35gen_45paramenters);
+__arg1 = x139886475385287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj x139886475385319 = __arg1;
+Obj x139886475385127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475385351 = makeCons(x139886475385127, x139886475385319);
+__nargs = 2;
+__arg1 = x139886475385351;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj rules = __arg1;
+PUSH_CONT_0(co, 5, clofun2);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rules_45patterns);
+__arg1 = Nil;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj x139886475383239 = __arg1;
+Obj pats = x139886475383239;
+PUSH_CONT_0(co, 6, clofun2);
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = makeNative(10, clofun2, 1, 0);
+__arg2 = pats;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj x139886475383623 = __arg1;
+Obj counts = x139886475383623;
+Obj x139886475383783 = PRIM_CAR(counts);
+Obj n = x139886475383783;
+Obj x139886475384423 = PRIM_CDR(counts);
+pushCont(co, 7, clofun2, 1, n);
+__nargs = 3;
+__arg0 = globalRef(symfilter);
+__arg1 = makeNative(9, clofun2, 1, 1, n);
+__arg2 = x139886475384423;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj x139886475384455 = __arg1;
+Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 8, clofun2, 1, n);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x139886475384455;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj x139886475384487 = __arg1;
+Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475384519 = primNot(x139886475384487);
+if (True == x139886475384519) {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("inconsistent func rule args count");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = n;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label9:
+{
+Obj x = __arg1;
+Obj x139886475384295 = PRIM_EQ(closureRef(co, 0), x);
+Obj x139886475384327 = primNot(x139886475384295);
+__nargs = 2;
+__arg1 = x139886475384327;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label10:
+{
+Obj x = __arg1;
+Obj x139886475383591 = PRIM_CDR(x);
+__nargs = 2;
+__arg0 = globalRef(symlength);
+__arg1 = x139886475383591;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label11:
+{
+Obj l1 = __arg1;
+Obj l2 = __arg2;
+Obj x139886475464391 = PRIM_EQ(l1, Nil);
+if (True == x139886475464391) {
+__nargs = 2;
+__arg1 = l2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475464551 = PRIM_CAR(l1);
+Obj x139886475382791 = PRIM_CDR(l1);
+pushCont(co, 12, clofun2, 1, x139886475464551);
+__nargs = 3;
+__arg0 = globalRef(symappend);
+__arg1 = x139886475382791;
+__arg2 = l2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj x139886475382823 = __arg1;
+Obj x139886475464551= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475382855 = makeCons(x139886475464551, x139886475382823);
+__nargs = 2;
+__arg1 = x139886475382855;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label13:
+{
+Obj fn = __arg1;
+Obj l = __arg2;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = Nil;
+__arg2 = fn;
+__arg3 = l;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj res = __arg1;
+Obj fn = __arg2;
+Obj l = __arg3;
+Obj x139886475462887 = PRIM_ISCONS(l);
+if (True == x139886475462887) {
+Obj x139886475463111 = PRIM_CAR(l);
+pushCont(co, 15, clofun2, 3, l, res, fn);
+__nargs = 2;
+__arg0 = fn;
+__arg1 = x139886475463111;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label15:
+{
+Obj x139886475463143 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139886475463143) {
+Obj x139886475463367 = PRIM_CAR(l);
+Obj x139886475463399 = makeCons(x139886475463367, res);
+Obj x139886475463495 = PRIM_CDR(l);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = x139886475463399;
+__arg2 = fn;
+__arg3 = x139886475463495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475463655 = PRIM_CDR(l);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg1 = res;
+__arg2 = fn;
+__arg3 = x139886475463655;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label16:
+{
+Obj l = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35length_45h);
+__arg1 = MAKE_NUMBER(0);
+__arg2 = l;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj i = __arg1;
+Obj l = __arg2;
+Obj x139886475461415 = PRIM_EQ(l, Nil);
+if (True == x139886475461415) {
+__nargs = 2;
+__arg1 = i;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475461607 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139886475461703 = PRIM_CDR(l);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35length_45h);
+__arg1 = x139886475461607;
+__arg2 = x139886475461703;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label18:
+{
+Obj res = __arg1;
+Obj rules = __arg2;
+pushCont(co, 19, clofun2, 2, res, rules);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj x139886475472711 = __arg1;
+Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475472711) {
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475460775 = PRIM_CAR(rules);
+Obj x139886475460807 = makeCons(x139886475460775, res);
+pushCont(co, 20, clofun2, 1, x139886475460807);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj x139886475460903 = __arg1;
+Obj x139886475460807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35rules_45patterns);
+__arg1 = x139886475460807;
+__arg2 = x139886475460903;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label21:
+{
+Obj input = __arg1;
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = input;
+__arg2 = Nil;
+__arg3 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label22:
+{
+Obj input = __arg1;
+Obj current = __arg2;
+Obj result = __arg3;
+Obj x139886475568135 = PRIM_EQ(Nil, input);
+if (True == x139886475568135) {
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = result;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476186471 = makeNative(24, clofun2, 0, 3, input, current, result);
+Obj x139886475507367 = PRIM_ISCONS(input);
+if (True == x139886475507367) {
+Obj x139886475507591 = PRIM_CAR(input);
+Obj x139886475507655 = PRIM_EQ(sym_61_62, x139886475507591);
+if (True == x139886475507655) {
+Obj x139886475507943 = PRIM_CDR(input);
+Obj x139886475507975 = PRIM_ISCONS(x139886475507943);
+if (True == x139886475507975) {
+Obj x139886475508231 = PRIM_CDR(input);
+Obj x139886475508263 = PRIM_CAR(x139886475508231);
+Obj act = x139886475508263;
+Obj x139886475508551 = PRIM_CDR(input);
+Obj x139886475508679 = PRIM_CDR(x139886475508551);
+Obj x139886475508711 = PRIM_ISCONS(x139886475508679);
+if (True == x139886475508711) {
+Obj x139886475509319 = PRIM_CDR(input);
+Obj x139886475509351 = PRIM_CDR(x139886475509319);
+Obj x139886475509383 = PRIM_CAR(x139886475509351);
+Obj x139886475509415 = PRIM_EQ(symwhere, x139886475509383);
+if (True == x139886475509415) {
+Obj x139886475468839 = PRIM_CDR(input);
+Obj x139886475468871 = PRIM_CDR(x139886475468839);
+Obj x139886475468903 = PRIM_CDR(x139886475468871);
+Obj x139886475468935 = PRIM_ISCONS(x139886475468903);
+if (True == x139886475468935) {
+Obj x139886475469351 = PRIM_CDR(input);
+Obj x139886475469383 = PRIM_CDR(x139886475469351);
+Obj x139886475469447 = PRIM_CDR(x139886475469383);
+Obj x139886475469479 = PRIM_CAR(x139886475469447);
+Obj pred = x139886475469479;
+Obj x139886475470119 = PRIM_CDR(input);
+Obj x139886475470151 = PRIM_CDR(x139886475470119);
+Obj x139886475470183 = PRIM_CDR(x139886475470151);
+Obj x139886475470215 = PRIM_CDR(x139886475470183);
+Obj remain = x139886475470215;
+pushCont(co, 23, clofun2, 4, act, pred, result, remain);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = current;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label23:
+{
+Obj x139886475470471 = __arg1;
+Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj result= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475470503 = makeCons(symlist, x139886475470471);
+Obj pat = x139886475470503;
+Obj x139886475470983 = makeCons(act, Nil);
+Obj x139886475471015 = makeCons(pred, x139886475470983);
+Obj x139886475471047 = makeCons(symwhere, x139886475471015);
+Obj x139886475471143 = makeCons(pat, result);
+Obj x139886475471175 = makeCons(x139886475471047, x139886475471143);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = x139886475471175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label24:
+{
+Obj x139886476189063 = makeNative(26, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886475569735 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475569735) {
+Obj x139886475570023 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475570055 = PRIM_EQ(sym_61_62, x139886475570023);
+if (True == x139886475570055) {
+Obj x139886475570471 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475570503 = PRIM_ISCONS(x139886475570471);
+if (True == x139886475570503) {
+Obj x139886475570791 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475570823 = PRIM_CAR(x139886475570791);
+Obj act = x139886475570823;
+Obj x139886475505991 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475506023 = PRIM_CDR(x139886475505991);
+Obj remain = x139886475506023;
+pushCont(co, 25, clofun2, 2, act, remain);
+__nargs = 2;
+__arg0 = globalRef(symreverse);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476189063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476189063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476189063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label25:
+{
+Obj x139886475506375 = __arg1;
+Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475506407 = makeCons(symlist, x139886475506375);
+Obj pat = x139886475506407;
+Obj x139886475506759 = makeCons(pat, closureRef(co, 2));
+Obj x139886475506791 = makeCons(act, x139886475506759);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = x139886475506791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label26:
+{
+Obj x139886475568775 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475568775) {
+Obj x139886475568999 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886475568999;
+Obj x139886475569191 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475569191;
+Obj x139886475569415 = makeCons(x, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg1 = y;
+__arg2 = x139886475569415;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label27:
+{
+Obj exp = __arg1;
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45match);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label28:
+{
+Obj exp = __arg1;
+pushCont(co, 29, clofun2, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj x139886475597831 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 30, clofun2, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = x139886475597831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886475597863 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj value = x139886475597863;
+pushCont(co, 31, clofun2, 1, value);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
+Obj x139886475598023 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules = x139886475598023;
+Obj x139886476186087 = makeNative(32, clofun2, 1, 2, value, rules);
+Obj x139886475599591 = PRIM_ISCONS(value);
+if (True == x139886475599591) {
+Obj x139886475567271 = PRIM_CAR(value);
+Obj x139886475567303 = PRIM_EQ(symcons, x139886475567271);
+Obj x139886475567335 = primNot(x139886475567303);
+if (True == x139886475567335) {
+__nargs = 2;
+__arg0 = x139886476186087;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476186087;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = x139886476186087;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label32:
+{
+Obj x139886476186151 = __arg1;
+if (True == x139886476186151) {
+Obj x139886475598439 = primGenSym();
+Obj val = x139886475598439;
+pushCont(co, 33, clofun2, 1, val);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = val;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label33:
+{
+Obj x139886475599015 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475599047 = makeCons(x139886475599015, Nil);
+Obj x139886475599143 = makeCons(closureRef(co, 0), x139886475599047);
+Obj x139886475599175 = makeCons(val, x139886475599143);
+Obj x139886475599207 = makeCons(symlet, x139886475599175);
+__nargs = 2;
+__arg1 = x139886475599207;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label34:
+{
+Obj value = __arg1;
+Obj rules = __arg2;
+pushCont(co, 35, clofun2, 2, value, rules);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj x139886475982503 = __arg1;
+Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475982503) {
+Obj x139886475982727 = makeCons(makeCString("no match-help found!"), Nil);
+Obj x139886475982759 = makeCons(symerror, x139886475982727);
+__nargs = 2;
+__arg1 = x139886475982759;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476186023 = makeNative(38, clofun2, 1, 2, value, rules);
+pushCont(co, 36, clofun2, 2, rules, x139886476186023);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label36:
+{
+Obj x139886475596871 = __arg1;
+Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475596871) {
+Obj x139886475597095 = PRIM_CDR(rules);
+pushCont(co, 37, clofun2, 1, x139886476186023);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = x139886475597095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476186023;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label37:
+{
+Obj x139886475597127 = __arg1;
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886475597127) {
+__nargs = 2;
+__arg0 = x139886476186023;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476186023;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label38:
+{
+Obj x139886476186055 = __arg1;
+if (True == x139886476186055) {
+Obj x139886475983239 = PRIM_CAR(closureRef(co, 1));
+Obj pat = x139886475983239;
+Obj x139886475983495 = primGenSym();
+Obj cc = x139886475983495;
+pushCont(co, 39, clofun2, 2, pat, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
+__arg1 = closureRef(co, 1);
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label39:
+{
+Obj x139886475983687 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj action = x139886475983687;
+pushCont(co, 40, clofun2, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(symmacroexpand);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x139886475984007 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 41, clofun2, 1, cc);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = x139886475984007;
+__arg2 = closureRef(co, 0);
+__arg3 = action;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label41:
+{
+Obj x139886475984071 = __arg1;
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj curr = x139886475984071;
+Obj x139886475984519 = PRIM_CDR(closureRef(co, 1));
+Obj x139886475984551 = PRIM_CDR(x139886475984519);
+pushCont(co, 42, clofun2, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg1 = closureRef(co, 0);
+__arg2 = x139886475984551;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x139886475984583 = __arg1;
+Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj rest = x139886475984583;
+Obj x139886475596039 = makeCons(rest, Nil);
+Obj x139886475596071 = makeCons(Nil, x139886475596039);
+Obj x139886475596103 = makeCons(symlambda, x139886475596071);
+Obj x139886475596359 = makeCons(curr, Nil);
+Obj x139886475596391 = makeCons(x139886475596103, x139886475596359);
+Obj x139886475596423 = makeCons(cc, x139886475596391);
+Obj x139886475596455 = makeCons(symlet, x139886475596423);
+__nargs = 2;
+__arg1 = x139886475596455;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label43:
+{
+Obj rules = __arg1;
+Obj cc = __arg2;
+Obj x139886476082951 = PRIM_CDR(rules);
+Obj x139886476082983 = PRIM_CAR(x139886476082951);
+Obj action = x139886476082983;
+Obj x139886476185927 = makeNative(45, clofun2, 1, 2, cc, action);
+pushCont(co, 44, clofun2, 2, action, x139886476185927);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139886475981863 = __arg1;
+Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476185927= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475981863) {
+Obj x139886475982087 = PRIM_CAR(action);
+Obj x139886475982119 = PRIM_EQ(x139886475982087, symwhere);
+if (True == x139886475982119) {
+__nargs = 2;
+__arg0 = x139886476185927;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476185927;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = x139886476185927;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label45:
+{
+Obj x139886476185991 = __arg1;
+if (True == x139886476185991) {
+PUSH_CONT_0(co, 46, clofun2);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = closureRef(co, 1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label46:
+{
+Obj x139886475981063 = __arg1;
+pushCont(co, 47, clofun2, 1, x139886475981063);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x139886475981287 = __arg1;
+Obj x139886475981063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475981479 = makeCons(closureRef(co, 0), Nil);
+Obj x139886475981511 = makeCons(x139886475981479, Nil);
+Obj x139886475981543 = makeCons(x139886475981287, x139886475981511);
+Obj x139886475981575 = makeCons(x139886475981063, x139886475981543);
+Obj x139886475981607 = makeCons(symif, x139886475981575);
+__nargs = 2;
+__arg1 = x139886475981607;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label48:
+{
+Obj pat = __arg1;
+Obj expr = __arg2;
+Obj body = __arg3;
+Obj cc = co->args[4];
+pushCont(co, 49, clofun2, 4, expr, body, cc, pat);
+__nargs = 2;
+__arg0 = makeNative(2, clofun3, 1, 0);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label49:
+{
+Obj x139886476079271 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x139886476079271) {
+Obj x139886476079431 = PRIM_EQ(pat, expr);
+if (True == x139886476079431) {
+__nargs = 2;
+__arg1 = body;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476079783 = makeCons(expr, Nil);
+Obj x139886476079815 = makeCons(pat, x139886476079783);
+Obj x139886476079847 = makeCons(sym_61, x139886476079815);
+Obj x139886476080071 = makeCons(cc, Nil);
+Obj x139886476080103 = makeCons(x139886476080071, Nil);
+Obj x139886476080135 = makeCons(body, x139886476080103);
+Obj x139886476080167 = makeCons(x139886476079847, x139886476080135);
+Obj x139886476080199 = makeCons(symif, x139886476080167);
+__nargs = 2;
+__arg1 = x139886476080199;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+Obj x139886476080359 = primIsSymbol(pat);
+if (True == x139886476080359) {
+Obj x139886476080647 = makeCons(body, Nil);
+Obj x139886476080679 = makeCons(expr, x139886476080647);
+Obj x139886476080711 = makeCons(pat, x139886476080679);
+Obj x139886476080743 = makeCons(symlet, x139886476080711);
+__nargs = 2;
+__arg1 = x139886476080743;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 0, clofun3, 4, expr, body, cc, pat);
+__nargs = 2;
+__arg0 = globalRef(sympair_63);
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 fail:
@@ -5515,21 +4362,60 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj n = __arg1;
-Obj x140663453948167 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == x140663453948167) {
+Obj x139886476080903 = __arg1;
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+if (True == x139886476080903) {
+Obj x139886476081127 = PRIM_CAR(pat);
+Obj x139886476081159 = PRIM_EQ(x139886476081127, symquote);
+if (True == x139886476081159) {
+Obj x139886476081511 = makeCons(expr, Nil);
+Obj x139886476081543 = makeCons(pat, x139886476081511);
+Obj x139886476081575 = makeCons(sym_61, x139886476081543);
+Obj x139886476081799 = makeCons(cc, Nil);
+Obj x139886476081831 = makeCons(x139886476081799, Nil);
+Obj x139886476081863 = makeCons(body, x139886476081831);
+Obj x139886476081895 = makeCons(x139886476081575, x139886476081863);
+Obj x139886476081927 = makeCons(symif, x139886476081895);
 __nargs = 2;
-__arg1 = Nil;
+__arg1 = x139886476081927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140663453948743 = primGenSym();
-Obj x140663453949383 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 1, clofun3, 1, x140663453948743);
+Obj x139886476082151 = PRIM_CAR(pat);
+Obj x139886476082183 = PRIM_EQ(x139886476082151, symcons);
+if (True == x139886476082183) {
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match_45cons_45expander);
+__arg1 = pat;
+__arg2 = expr;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = x140663453949383;
+__arg0 = globalRef(symerror);
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+PUSH_CONT_0(co, 1, clofun3);
+__nargs = 3;
+__arg0 = globalRef(symstr);
+__arg1 = makeCString("match fail ");
+__arg2 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5540,24 +4426,24 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x140663453949415 = __arg1;
-Obj x140663453948743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453949479 = makeCons(x140663453948743, x140663453949415);
+Obj x139886476082471 = __arg1;
 __nargs = 2;
-__arg1 = x140663453949479;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symerror);
+__arg1 = x139886476082471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj rules = __arg1;
-PUSH_CONT_0(co, 3, clofun3);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = Nil;
-__arg2 = rules;
+Obj x = __arg1;
+pushCont(co, 3, clofun3, 1, x);
+__nargs = 2;
+__arg0 = globalRef(symatom_63);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5567,34 +4453,43 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x140663453988551 = __arg1;
-Obj pats = x140663453988551;
-Obj len = makeNative(8, clofun3, 1, 0);
-PUSH_CONT_0(co, 4, clofun3);
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = len;
-__arg2 = pats;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476107655 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886476107655) {
+Obj x139886476079207 = primIsSymbol(x);
+Obj x139886476079239 = primNot(x139886476079207);
+if (True == x139886476079239) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label4:
 {
-Obj x140663453989639 = __arg1;
-Obj counts = x140663453989639;
-Obj x140663453989959 = PRIM_CAR(counts);
-Obj n = x140663453989959;
-Obj dif = makeNative(7, clofun3, 1, 1, n);
-Obj x140663453946823 = PRIM_CDR(counts);
-pushCont(co, 5, clofun3, 1, n);
-__nargs = 3;
-__arg0 = globalRef(symfilter);
-__arg1 = dif;
-__arg2 = x140663453946823;
+Obj pat = __arg1;
+Obj expr = __arg2;
+Obj body = __arg3;
+Obj cc = co->args[4];
+pushCont(co, 5, clofun3, 4, pat, body, cc, expr);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5604,12 +4499,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x140663453946855 = __arg1;
-Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 6, clofun3, 1, n);
+Obj x139886476148039 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x = x139886476148039;
+pushCont(co, 6, clofun3, 4, x, body, cc, expr);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x140663453946855;
+__arg0 = globalRef(symcaddr);
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5619,13 +4518,21 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x140663453946887 = __arg1;
-Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453946919 = primNot(x140663453946887);
-if (True == x140663453946919) {
+Obj x139886476148199 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj y = x139886476148199;
+Obj x139886476185863 = makeNative(7, clofun3, 1, 5, x, y, expr, body, cc);
+Obj x139886476106759 = PRIM_ISCONS(expr);
+if (True == x139886476106759) {
+Obj x139886476107047 = PRIM_CAR(expr);
+Obj x139886476107079 = PRIM_EQ(x139886476107047, symcons);
+if (True == x139886476107079) {
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("inconsistent func rule args count");
+__arg0 = x139886476185863;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5633,32 +4540,73 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg1 = n;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = x139886476185863;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = x139886476185863;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj x = __arg1;
-Obj x140663453990791 = PRIM_EQ(closureRef(co, 0), x);
-Obj x140663453990823 = primNot(x140663453990791);
+Obj x139886476185895 = __arg1;
+if (True == x139886476185895) {
+PUSH_CONT_0(co, 10, clofun3);
 __nargs = 2;
-__arg1 = x140663453990823;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcadr);
+__arg1 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476105255 = makeCons(closureRef(co, 2), Nil);
+Obj x139886476105287 = makeCons(symcons_63, x139886476105255);
+Obj x139886476105639 = makeCons(closureRef(co, 2), Nil);
+Obj x139886476105671 = makeCons(symcar, x139886476105639);
+Obj x139886476105959 = makeCons(closureRef(co, 2), Nil);
+Obj x139886476105991 = makeCons(symcdr, x139886476105959);
+pushCont(co, 8, clofun3, 2, x139886476105671, x139886476105287);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = closureRef(co, 1);
+__arg2 = x139886476105991;
+__arg3 = closureRef(co, 3);
+co->args[4] = closureRef(co, 4);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label8:
 {
-Obj x = __arg1;
-Obj x140663453989287 = PRIM_CDR(x);
-__nargs = 2;
-__arg0 = globalRef(symlength);
-__arg1 = x140663453989287;
+Obj x139886476106087 = __arg1;
+Obj x139886476105671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476105287= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 9, clofun3, 1, x139886476105287);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = closureRef(co, 0);
+__arg2 = x139886476105671;
+__arg3 = x139886476106087;
+co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5668,52 +4616,47 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj l1 = __arg1;
-Obj l2 = __arg2;
-Obj x140663454502183 = PRIM_EQ(l1, Nil);
-if (True == x140663454502183) {
+Obj x139886476106215 = __arg1;
+Obj x139886476105287= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106407 = makeCons(closureRef(co, 4), Nil);
+Obj x139886476106439 = makeCons(x139886476106407, Nil);
+Obj x139886476106471 = makeCons(x139886476106215, x139886476106439);
+Obj x139886476106503 = makeCons(x139886476105287, x139886476106471);
+Obj x139886476106535 = makeCons(symif, x139886476106503);
 __nargs = 2;
-__arg1 = l2;
+__arg1 = x139886476106535;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454502631 = PRIM_CAR(l1);
-Obj x140663453987143 = PRIM_CDR(l1);
-pushCont(co, 10, clofun3, 1, x140663454502631);
-__nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = x140663453987143;
-__arg2 = l2;
+}
+
+label10:
+{
+Obj x139886476148711 = __arg1;
+Obj e1 = x139886476148711;
+pushCont(co, 11, clofun3, 1, e1);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label10:
-{
-Obj x140663453987239 = __arg1;
-Obj x140663454502631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453987271 = makeCons(x140663454502631, x140663453987239);
-__nargs = 2;
-__arg1 = x140663453987271;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
 
 label11:
 {
-Obj fn = __arg1;
-Obj l = __arg2;
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = Nil;
-__arg2 = fn;
-__arg3 = l;
+Obj x139886476103975 = __arg1;
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj e2 = x139886476103975;
+pushCont(co, 12, clofun3, 1, e1);
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = closureRef(co, 1);
+__arg2 = e2;
+__arg3 = closureRef(co, 3);
+co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5723,75 +4666,43 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj res = __arg1;
-Obj fn = __arg2;
-Obj l = __arg3;
-Obj x140663454543239 = PRIM_ISCONS(l);
-if (True == x140663454543239) {
-Obj x140663454543687 = PRIM_CAR(l);
-pushCont(co, 13, clofun3, 3, l, res, fn);
-__nargs = 2;
-__arg0 = fn;
-__arg1 = x140663454543687;
+Obj x139886476104903 = __arg1;
+Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(symcora_47init_35match1);
+__arg1 = closureRef(co, 0);
+__arg2 = e1;
+__arg3 = x139886476104903;
+co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = res;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label13:
 {
-Obj x140663454543783 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x140663454543783) {
-Obj x140663454499303 = PRIM_CAR(l);
-Obj x140663454499367 = makeCons(x140663454499303, res);
-Obj x140663454499879 = PRIM_CDR(l);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = x140663454499367;
-__arg2 = fn;
-__arg3 = x140663454499879;
+Obj exp = __arg1;
+Obj x139886476147655 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rcons1);
+__arg1 = x139886476147655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x140663454500519 = PRIM_CDR(l);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = res;
-__arg2 = fn;
-__arg3 = x140663454500519;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label14:
 {
-Obj l = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = MAKE_NUMBER(0);
-__arg2 = l;
+Obj pat = __arg1;
+Obj x139886476146567 = PRIM_CDR(pat);
+pushCont(co, 15, clofun3, 1, pat);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x139886476146567;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5801,22 +4712,22 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj i = __arg1;
-Obj l = __arg2;
-Obj x140663454541095 = PRIM_EQ(l, Nil);
-if (True == x140663454541095) {
+Obj x139886476146599 = __arg1;
+Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886476146599) {
+Obj x139886476146695 = PRIM_CAR(pat);
 __nargs = 2;
-__arg1 = i;
+__arg1 = x139886476146695;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140663454541575 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj x140663454541799 = PRIM_CDR(l);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = x140663454541575;
-__arg2 = x140663454541799;
+Obj x139886476146919 = PRIM_CAR(pat);
+Obj x139886476147143 = PRIM_CDR(pat);
+pushCont(co, 16, clofun3, 1, x139886476146919);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rcons1);
+__arg1 = x139886476147143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5827,56 +4738,53 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj res = __arg1;
-Obj rules = __arg2;
-pushCont(co, 17, clofun3, 2, res, rules);
+Obj x139886476147175 = __arg1;
+Obj x139886476146919= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476147207 = makeCons(x139886476147175, Nil);
+Obj x139886476147239 = makeCons(x139886476146919, x139886476147207);
+Obj x139886476147271 = makeCons(symcons, x139886476147239);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x139886476147271;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label17:
 {
-Obj x140663454583975 = __arg1;
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663454583975) {
+Obj x = __arg1;
+Obj x139886476145959 = PRIM_EQ(x, True);
+if (True == x139886476145959) {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = res;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140663454584743 = PRIM_CAR(rules);
-Obj x140663454584807 = makeCons(x140663454584743, res);
-pushCont(co, 18, clofun3, 1, x140663454584807);
+Obj x139886476146119 = PRIM_EQ(x, False);
+if (True == x139886476146119) {
 __nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 }
 
 label18:
 {
-Obj x140663454540103 = __arg1;
-Obj x140663454584807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = x140663454584807;
-__arg2 = x140663454540103;
+Obj exp = __arg1;
+Obj x139886476145511 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45and);
+__arg1 = x139886476145511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5886,286 +4794,190 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj input = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = input;
-__arg2 = Nil;
-__arg3 = Nil;
+Obj l = __arg1;
+Obj x139886476188967 = PRIM_EQ(Nil, l);
+if (True == x139886476188967) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476189255 = PRIM_CAR(l);
+Obj x139886476189287 = PRIM_EQ(x139886476189255, False);
+if (True == x139886476189287) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476189511 = PRIM_CDR(l);
+pushCont(co, 20, clofun3, 1, l);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45and);
+__arg1 = x139886476189511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
 label20:
 {
-Obj input = __arg1;
-Obj current = __arg2;
-Obj result = __arg3;
-Obj x140663453987623 = makeNative(21, clofun3, 0, 3, input, current, result);
-Obj x140663454582119 = PRIM_EQ(Nil, input);
-if (True == x140663454582119) {
+Obj x139886476189543 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj more = x139886476189543;
+Obj x139886476144647 = PRIM_EQ(more, False);
+if (True == x139886476144647) {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = result;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x140663453987623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476144871 = PRIM_CAR(l);
+Obj x139886476145031 = makeCons(False, Nil);
+Obj x139886476145063 = makeCons(more, x139886476145031);
+Obj x139886476145095 = makeCons(x139886476144871, x139886476145063);
+Obj x139886476145127 = makeCons(symif, x139886476145095);
+__nargs = 2;
+__arg1 = x139886476145127;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label21:
 {
-Obj x140663453987719 = makeNative(23, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140663454899527 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454899527) {
-Obj x140663454899975 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454900007 = PRIM_EQ(sym_61_62, x140663454899975);
-if (True == x140663454900007) {
-Obj x140663454884135 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454884167 = PRIM_ISCONS(x140663454884135);
-if (True == x140663454884167) {
-Obj x140663454884615 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454884647 = PRIM_CAR(x140663454884615);
-Obj act = x140663454884647;
-Obj x140663454885415 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454885447 = PRIM_CDR(x140663454885415);
-Obj x140663454885479 = PRIM_ISCONS(x140663454885447);
-if (True == x140663454885479) {
-Obj x140663454886311 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454886343 = PRIM_CDR(x140663454886311);
-Obj x140663454886375 = PRIM_CAR(x140663454886343);
-Obj x140663454886407 = PRIM_EQ(symwhere, x140663454886375);
-if (True == x140663454886407) {
-Obj x140663454887303 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454887335 = PRIM_CDR(x140663454887303);
-Obj x140663454887367 = PRIM_CDR(x140663454887335);
-Obj x140663454887399 = PRIM_ISCONS(x140663454887367);
-if (True == x140663454887399) {
-Obj x140663454601735 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454601767 = PRIM_CDR(x140663454601735);
-Obj x140663454601799 = PRIM_CDR(x140663454601767);
-Obj x140663454601831 = PRIM_CAR(x140663454601799);
-Obj pred = x140663454601831;
-Obj x140663454602695 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454602727 = PRIM_CDR(x140663454602695);
-Obj x140663454602759 = PRIM_CDR(x140663454602727);
-Obj x140663454602791 = PRIM_CDR(x140663454602759);
-Obj remain = x140663454602791;
-pushCont(co, 22, clofun3, 3, act, pred, remain);
+Obj exp = __arg1;
+Obj x139886476188583 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = closureRef(co, 1);
+__arg0 = globalRef(symcora_47init_35rewrite_45or);
+__arg1 = x139886476188583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453987719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label22:
 {
-Obj x140663454603399 = __arg1;
-Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663454603431 = makeCons(symlist, x140663454603399);
-Obj pat = x140663454603431;
-Obj x140663454604615 = makeCons(act, Nil);
-Obj x140663454604647 = makeCons(pred, x140663454604615);
-Obj x140663454604679 = makeCons(symwhere, x140663454604647);
-Obj x140663454605223 = makeCons(pat, closureRef(co, 2));
-Obj x140663454605255 = makeCons(x140663454604679, x140663454605223);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = x140663454605255;
+Obj l = __arg1;
+Obj x139886476186759 = PRIM_EQ(l, Nil);
+if (True == x139886476186759) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476187079 = PRIM_CAR(l);
+Obj x139886476187111 = PRIM_EQ(x139886476187079, True);
+if (True == x139886476187111) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476187335 = PRIM_CDR(l);
+pushCont(co, 23, clofun3, 1, l);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45or);
+__arg1 = x139886476187335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+}
 }
 
 label23:
 {
-Obj x140663453990407 = makeNative(25, clofun3, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x140663454919943 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454919943) {
-Obj x140663454920423 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454920487 = PRIM_EQ(sym_61_62, x140663454920423);
-if (True == x140663454920487) {
-Obj x140663454896423 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454896455 = PRIM_ISCONS(x140663454896423);
-if (True == x140663454896455) {
-Obj x140663454896903 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454896935 = PRIM_CAR(x140663454896903);
-Obj act = x140663454896935;
-Obj x140663454897383 = PRIM_CDR(closureRef(co, 0));
-Obj x140663454897415 = PRIM_CDR(x140663454897383);
-Obj remain = x140663454897415;
-pushCont(co, 24, clofun3, 2, act, remain);
+Obj x139886476187431 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj more = x139886476187431;
+Obj x139886476187655 = PRIM_EQ(more, True);
+if (True == x139886476187655) {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
-__arg1 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x140663453990407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453990407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x140663453990407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476187879 = PRIM_CAR(l);
+Obj x139886476188071 = makeCons(more, Nil);
+Obj x139886476188103 = makeCons(True, x139886476188071);
+Obj x139886476188135 = makeCons(x139886476187879, x139886476188103);
+Obj x139886476188167 = makeCons(symif, x139886476188135);
+__nargs = 2;
+__arg1 = x139886476188167;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label24:
 {
-Obj x140663454898023 = __arg1;
-Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454898055 = makeCons(symlist, x140663454898023);
-Obj pat = x140663454898055;
-Obj x140663454898759 = makeCons(pat, closureRef(co, 2));
-Obj x140663454898791 = makeCons(act, x140663454898759);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = x140663454898791;
+Obj exp = __arg1;
+Obj x139886475461159 = PRIM_CDR(exp);
+Obj x139886475461191 = PRIM_EQ(Nil, x139886475461159);
+if (True == x139886475461191) {
+Obj x139886475461351 = makeCons(makeCString("no cond match"), Nil);
+Obj x139886475461383 = makeCons(symerror, x139886475461351);
+__nargs = 2;
+__arg1 = x139886475461383;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 25, clofun3, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label25:
 {
-Obj x140663453947015 = makeNative(26, clofun3, 0, 0);
-Obj x140663454918375 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454918375) {
-Obj x140663454918791 = PRIM_CAR(closureRef(co, 0));
-Obj x = x140663454918791;
-Obj x140663454919047 = PRIM_CDR(closureRef(co, 0));
-Obj y = x140663454919047;
-Obj x140663454919527 = makeCons(x, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
-__arg1 = y;
-__arg2 = x140663454919527;
-__arg3 = closureRef(co, 2);
+Obj x139886475461543 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj curr = x139886475461543;
+Obj x139886475461767 = PRIM_CAR(curr);
+pushCont(co, 26, clofun3, 2, exp, x139886475461767);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = curr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x140663453947015;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label26:
 {
+Obj x139886475461927 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475461767= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 27, clofun3, 2, x139886475461927, x139886475461767);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(symcddr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6175,9 +4987,83 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj exp = __arg1;
+Obj x139886475462151 = __arg1;
+Obj x139886475461927= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475461767= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475462183 = makeCons(symcond, x139886475462151);
+Obj x139886475462215 = makeCons(x139886475462183, Nil);
+Obj x139886475462247 = makeCons(x139886475461927, x139886475462215);
+Obj x139886475462279 = makeCons(x139886475461767, x139886475462247);
+Obj x139886476186311 = makeCons(symif, x139886475462279);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45match);
+__arg1 = x139886476186311;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label28:
+{
+Obj exp = __arg1;
+Obj x139886475460711 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45let);
+__arg1 = x139886475460711;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj exp = __arg1;
+Obj x139886475471719 = PRIM_CDR(exp);
+pushCont(co, 30, clofun3, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symnull_63);
+__arg1 = x139886475471719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886475471751 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886475471751) {
+Obj x139886475471847 = PRIM_CAR(exp);
+__nargs = 2;
+__arg1 = x139886475471847;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475472071 = PRIM_CAR(exp);
+pushCont(co, 31, clofun3, 2, exp, x139886475472071);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label31:
+{
+Obj x139886475472231 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475472071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 32, clofun3, 2, x139886475472231, x139886475472071);
+__nargs = 2;
+__arg0 = globalRef(symcddr);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6186,10 +5072,89 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label32:
+{
+Obj x139886475472455 = __arg1;
+Obj x139886475472231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475472071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 33, clofun3, 2, x139886475472231, x139886475472071);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35rewrite_45let);
+__arg1 = x139886475472455;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label33:
+{
+Obj x139886475472487 = __arg1;
+Obj x139886475472231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475472071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475472519 = makeCons(x139886475472487, Nil);
+Obj x139886475472551 = makeCons(x139886475472231, x139886475472519);
+Obj x139886475472583 = makeCons(x139886475472071, x139886475472551);
+Obj x139886475472615 = makeCons(symlet, x139886475472583);
+__nargs = 2;
+__arg1 = x139886475472615;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label34:
+{
+Obj x = __arg1;
+Obj x139886475471239 = PRIM_ISCONS(x);
+Obj x139886475471271 = primNot(x139886475471239);
+__nargs = 2;
+__arg1 = x139886475471271;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label35:
+{
+Obj x = __arg1;
+Obj l = __arg2;
+Obj x139886475470439 = PRIM_ISCONS(l);
+if (True == x139886475470439) {
+Obj x139886475470663 = PRIM_CAR(l);
+Obj x139886475470695 = PRIM_EQ(x139886475470663, x);
+if (True == x139886475470695) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475470855 = PRIM_CDR(l);
+__nargs = 3;
+__arg0 = globalRef(symelem_63);
+__arg1 = x;
+__arg2 = x139886475470855;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label36:
 {
 Obj exp = __arg1;
-pushCont(co, 29, clofun3, 1, exp);
+pushCont(co, 37, clofun3, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -6200,29 +5165,13 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label29:
+label37:
 {
-Obj x140663454975111 = __arg1;
+Obj x139886475469415 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 30, clofun3, 1, exp);
+pushCont(co, 38, clofun3, 2, exp, x139886475469415);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = x140663454975111;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj x140663454975143 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = x140663454975143;
-pushCont(co, 31, clofun3, 1, value);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(symcaddr);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6231,241 +5180,15 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
-{
-Obj x140663454975399 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = x140663454975399;
-Obj x140663454975815 = PRIM_ISCONS(value);
-if (True == x140663454975815) {
-Obj x140663454976455 = PRIM_CAR(value);
-Obj x140663454976487 = PRIM_EQ(symcons, x140663454976455);
-Obj x140663454976519 = primNot(x140663454976487);
-if (True == x140663454976519) {
-if (True == True) {
-Obj x140663454976775 = primGenSym();
-Obj val = x140663454976775;
-pushCont(co, 34, clofun3, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj x140663454945831 = primGenSym();
-Obj val = x140663454945831;
-pushCont(co, 33, clofun3, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-Obj x140663454947559 = primGenSym();
-Obj val = x140663454947559;
-pushCont(co, 32, clofun3, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label32:
-{
-Obj x140663454948775 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454948839 = makeCons(x140663454948775, Nil);
-Obj x140663454948871 = makeCons(value, x140663454948839);
-Obj x140663454948903 = makeCons(val, x140663454948871);
-Obj x140663454948935 = makeCons(symlet, x140663454948903);
-__nargs = 2;
-__arg1 = x140663454948935;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label33:
-{
-Obj x140663454946951 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454947015 = makeCons(x140663454946951, Nil);
-Obj x140663454947047 = makeCons(value, x140663454947015);
-Obj x140663454947079 = makeCons(val, x140663454947047);
-Obj x140663454947111 = makeCons(symlet, x140663454947079);
-__nargs = 2;
-__arg1 = x140663454947111;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label34:
-{
-Obj x140663454977959 = __arg1;
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454945319 = makeCons(x140663454977959, Nil);
-Obj x140663454945351 = makeCons(value, x140663454945319);
-Obj x140663454945383 = makeCons(val, x140663454945351);
-Obj x140663454945415 = makeCons(symlet, x140663454945383);
-__nargs = 2;
-__arg1 = x140663454945415;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label35:
-{
-Obj value = __arg1;
-Obj rules = __arg2;
-pushCont(co, 36, clofun3, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label36:
-{
-Obj x140663453881159 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453881159) {
-Obj x140663453881703 = makeCons(makeCString("no match-help found!"), Nil);
-Obj x140663453881735 = makeCons(symerror, x140663453881703);
-__nargs = 2;
-__arg1 = x140663453881735;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 37, clofun3, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label37:
-{
-Obj x140663453882055 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453882055) {
-Obj x140663453882503 = PRIM_CDR(rules);
-pushCont(co, 42, clofun3, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = x140663453882503;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
-Obj x140663453742919 = PRIM_CAR(rules);
-Obj pat = x140663453742919;
-Obj x140663453743175 = primGenSym();
-Obj cc = x140663453743175;
-pushCont(co, 38, clofun3, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
 label38:
 {
-Obj x140663453743463 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140663453743463;
-pushCont(co, 39, clofun3, 4, action, rules, value, cc);
+Obj x139886475469703 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475469415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 39, clofun3, 2, x139886475469703, x139886475469415);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
+__arg0 = globalRef(symcadddr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6475,39 +5198,29 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x140663453744551 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 40, clofun3, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140663453744551;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475469863 = __arg1;
+Obj x139886475469703= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475469415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475469895 = makeCons(x139886475469863, Nil);
+Obj x139886475469927 = makeCons(x139886475469703, x139886475469895);
+Obj x139886475469959 = makeCons(symlambda, x139886475469927);
+Obj x139886475469991 = makeCons(x139886475469959, Nil);
+Obj x139886475470023 = makeCons(x139886475469415, x139886475469991);
+Obj x139886475470055 = makeCons(symdef, x139886475470023);
+__nargs = 2;
+__arg1 = x139886475470055;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label40:
 {
-Obj x140663453744679 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140663453744679;
-Obj x140663453667463 = PRIM_CDR(rules);
-Obj x140663453667495 = PRIM_CDR(x140663453667463);
-pushCont(co, 41, clofun3, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = x140663453667495;
+Obj exp = __arg1;
+Obj x139886475468967 = PRIM_CDR(exp);
+__nargs = 2;
+__arg0 = globalRef(symrcons);
+__arg1 = x139886475468967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6517,96 +5230,44 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x140663453667527 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140663453667527;
-Obj x140663453668743 = makeCons(rest, Nil);
-Obj x140663453668775 = makeCons(Nil, x140663453668743);
-Obj x140663453668807 = makeCons(symlambda, x140663453668775);
-Obj x140663454973991 = makeCons(curr, Nil);
-Obj x140663454974023 = makeCons(x140663453668807, x140663454973991);
-Obj x140663454974055 = makeCons(cc, x140663454974023);
-Obj x140663454974087 = makeCons(symlet, x140663454974055);
+Obj exp = __arg1;
+pushCont(co, 42, clofun3, 1, exp);
 __nargs = 2;
-__arg1 = x140663454974087;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label42:
 {
-Obj x140663453882535 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453882535) {
-if (True == True) {
-Obj x140663453882791 = PRIM_CAR(rules);
-Obj pat = x140663453882791;
-Obj x140663453883015 = primGenSym();
-Obj cc = x140663453883015;
-pushCont(co, 47, clofun3, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
+Obj x139886475508583 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475508615 = makeCons(x139886475508583, Nil);
+Obj x139886475508647 = makeCons(symquote, x139886475508615);
+pushCont(co, 43, clofun3, 2, exp, x139886475508647);
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
+__arg0 = globalRef(symcaddr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj x140663453792455 = PRIM_CAR(rules);
-Obj pat = x140663453792455;
-Obj x140663453792679 = primGenSym();
-Obj cc = x140663453792679;
-pushCont(co, 43, clofun3, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label43:
 {
-Obj x140663453792967 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140663453792967;
-pushCont(co, 44, clofun3, 4, action, rules, value, cc);
+Obj x139886475508935 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475508647= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 44, clofun3, 2, x139886475508935, x139886475508647);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
+__arg0 = globalRef(symcdddr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6616,78 +5277,86 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x140663453793383 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 45, clofun3, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140663453793383;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj x140663453793511 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140663453793511;
-Obj x140663453794119 = PRIM_CDR(rules);
-Obj x140663453794151 = PRIM_CDR(x140663453794119);
-pushCont(co, 46, clofun3, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = x140663453794151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-Obj x140663453794183 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140663453794183;
-Obj x140663453742087 = makeCons(rest, Nil);
-Obj x140663453742119 = makeCons(Nil, x140663453742087);
-Obj x140663453742151 = makeCons(symlambda, x140663453742119);
-Obj x140663453742407 = makeCons(curr, Nil);
-Obj x140663453742439 = makeCons(x140663453742151, x140663453742407);
-Obj x140663453742471 = makeCons(cc, x140663453742439);
-Obj x140663453742503 = makeCons(symlet, x140663453742471);
+Obj x139886475509031 = __arg1;
+Obj x139886475508935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475508647= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475509063 = makeCons(x139886475508935, x139886475509031);
+Obj x139886475509095 = makeCons(symlambda, x139886475509063);
+Obj x139886475509127 = makeCons(x139886475509095, Nil);
+Obj x139886475509159 = makeCons(x139886475508647, x139886475509127);
+Obj x139886475509191 = makeCons(symcora_47init_35add_45to_45_42macros_42, x139886475509159);
 __nargs = 2;
-__arg1 = x140663453742503;
+__arg1 = x139886475509191;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label47:
+label45:
 {
-Obj x140663453883335 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = x140663453883335;
-pushCont(co, 48, clofun3, 4, action, rules, value, cc);
+Obj exp = __arg1;
+Obj x139886475570983 = PRIM_ISCONS(exp);
+if (True == x139886475570983) {
+Obj x139886475506087 = PRIM_CAR(exp);
+Obj x139886475506119 = PRIM_EQ(x139886475506087, globalRef(sym_42protect_45symbol_42));
+if (True == x139886475506119) {
+Obj x139886475506215 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = pat;
+__arg1 = x139886475506215;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475506439 = PRIM_CAR(exp);
+Obj x139886475506471 = PRIM_EQ(x139886475506439, symlambda);
+if (True == x139886475506471) {
+pushCont(co, 48, clofun3, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcadr);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475507271 = PRIM_CAR(exp);
+Obj x139886475507303 = PRIM_EQ(x139886475507271, symquote);
+if (True == x139886475507303) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 46, clofun3, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand1);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label46:
+{
+Obj x139886475507847 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = makeNative(47, clofun3, 1, 1, exp);
+__arg1 = x139886475507847;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6695,20 +5364,40 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label47:
+{
+Obj exp1 = __arg1;
+Obj x139886475507623 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == x139886475507623) {
+__nargs = 3;
+__arg0 = globalRef(symmap);
+__arg1 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg2 = exp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg1 = exp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label48:
 {
-Obj x140663453883783 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 49, clofun3, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x140663453883783;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
+Obj x139886475506695 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 49, clofun3, 1, x139886475506695);
+__nargs = 2;
+__arg0 = globalRef(symcaddr);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6718,18 +5407,12 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x140663453883911 = __arg1;
-Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = x140663453883911;
-Obj x140663453790311 = PRIM_CDR(rules);
-Obj x140663453790343 = PRIM_CDR(x140663453790311);
-pushCont(co, 0, clofun4, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
-__arg1 = value;
-__arg2 = x140663453790343;
+Obj x139886475506919 = __arg1;
+Obj x139886475506695= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun4, 1, x139886475506695);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg1 = x139886475506919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6753,1626 +5436,25 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43, &&label44, &&label45, &&label46, &&label47, &&label48, &&label49};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x140663453790375 = __arg1;
-Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x140663453790375;
-Obj x140663453791591 = makeCons(rest, Nil);
-Obj x140663453791623 = makeCons(Nil, x140663453791591);
-Obj x140663453791655 = makeCons(symlambda, x140663453791623);
-Obj x140663453791943 = makeCons(curr, Nil);
-Obj x140663453791975 = makeCons(x140663453791655, x140663453791943);
-Obj x140663453792007 = makeCons(cc, x140663453791975);
-Obj x140663453792039 = makeCons(symlet, x140663453792007);
+Obj x139886475506951 = __arg1;
+Obj x139886475506695= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475506983 = makeCons(x139886475506951, Nil);
+Obj x139886475507015 = makeCons(x139886475506695, x139886475506983);
+Obj x139886475507047 = makeCons(symlambda, x139886475507015);
 __nargs = 2;
-__arg1 = x140663453792039;
+__arg1 = x139886475507047;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
-{
-Obj rules = __arg1;
-Obj cc = __arg2;
-Obj x140663453909959 = PRIM_CDR(rules);
-Obj x140663453909991 = PRIM_CAR(x140663453909959);
-Obj action = x140663453909991;
-pushCont(co, 2, clofun4, 2, cc, action);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x140663453910375 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x140663453910375) {
-Obj x140663453910855 = PRIM_CAR(action);
-Obj x140663453911015 = PRIM_EQ(x140663453910855, symwhere);
-if (True == x140663453911015) {
-if (True == True) {
-pushCont(co, 7, clofun4, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 5, clofun4, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-} else {
-if (True == False) {
-pushCont(co, 3, clofun4, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-}
-
-label3:
-{
-Obj x140663453908231 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 4, clofun4, 2, cc, x140663453908231);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x140663453908647 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453908231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453880391 = makeCons(cc, Nil);
-Obj x140663453880455 = makeCons(x140663453880391, Nil);
-Obj x140663453880487 = makeCons(x140663453908647, x140663453880455);
-Obj x140663453880519 = makeCons(x140663453908231, x140663453880487);
-Obj x140663453880551 = makeCons(symif, x140663453880519);
-__nargs = 2;
-__arg1 = x140663453880551;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label5:
-{
-Obj x140663453905447 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 6, clofun4, 2, cc, x140663453905447);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x140663453905831 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453905447= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453906439 = makeCons(cc, Nil);
-Obj x140663453906631 = makeCons(x140663453906439, Nil);
-Obj x140663453906663 = makeCons(x140663453905831, x140663453906631);
-Obj x140663453906727 = makeCons(x140663453905447, x140663453906663);
-Obj x140663453906759 = makeCons(symif, x140663453906727);
-__nargs = 2;
-__arg1 = x140663453906759;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label7:
-{
-Obj x140663453911783 = __arg1;
-Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 8, clofun4, 2, cc, x140663453911783);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x140663453912455 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453911783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453912871 = makeCons(cc, Nil);
-Obj x140663453912935 = makeCons(x140663453912871, Nil);
-Obj x140663453912967 = makeCons(x140663453912455, x140663453912935);
-Obj x140663453912999 = makeCons(x140663453911783, x140663453912967);
-Obj x140663453913031 = makeCons(symif, x140663453912999);
-__nargs = 2;
-__arg1 = x140663453913031;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label9:
-{
-Obj pat = __arg1;
-Obj expr = __arg2;
-Obj body = __arg3;
-Obj cc = co->args[4];
-Obj literal_63 = makeNative(13, clofun4, 1, 0);
-pushCont(co, 10, clofun4, 4, expr, body, cc, pat);
-__nargs = 2;
-__arg0 = literal_63;
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x140663454502023 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140663454502023) {
-Obj x140663454502343 = PRIM_EQ(pat, expr);
-if (True == x140663454502343) {
-__nargs = 2;
-__arg1 = body;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663453987847 = makeCons(expr, Nil);
-Obj x140663453987879 = makeCons(pat, x140663453987847);
-Obj x140663453987911 = makeCons(sym_61, x140663453987879);
-Obj x140663453988711 = makeCons(cc, Nil);
-Obj x140663453988775 = makeCons(x140663453988711, Nil);
-Obj x140663453988807 = makeCons(body, x140663453988775);
-Obj x140663453988839 = makeCons(x140663453987911, x140663453988807);
-Obj x140663453988871 = makeCons(symif, x140663453988839);
-__nargs = 2;
-__arg1 = x140663453988871;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-Obj x140663453989159 = primIsSymbol(pat);
-if (True == x140663453989159) {
-Obj x140663453990119 = makeCons(body, Nil);
-Obj x140663453990151 = makeCons(expr, x140663453990119);
-Obj x140663453990215 = makeCons(pat, x140663453990151);
-Obj x140663453990279 = makeCons(symlet, x140663453990215);
-__nargs = 2;
-__arg1 = x140663453990279;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 11, clofun4, 4, expr, body, cc, pat);
-__nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label11:
-{
-Obj x140663453990631 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x140663453990631) {
-Obj x140663453946119 = PRIM_CAR(pat);
-Obj x140663453946215 = PRIM_EQ(x140663453946119, symquote);
-if (True == x140663453946215) {
-Obj x140663453947495 = makeCons(expr, Nil);
-Obj x140663453947527 = makeCons(pat, x140663453947495);
-Obj x140663453947559 = makeCons(sym_61, x140663453947527);
-Obj x140663453948263 = makeCons(cc, Nil);
-Obj x140663453948359 = makeCons(x140663453948263, Nil);
-Obj x140663453948391 = makeCons(body, x140663453948359);
-Obj x140663453948455 = makeCons(x140663453947559, x140663453948391);
-Obj x140663453948487 = makeCons(symif, x140663453948455);
-__nargs = 2;
-__arg1 = x140663453948487;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663453948935 = PRIM_CAR(pat);
-Obj x140663453949031 = PRIM_EQ(x140663453948935, symcons);
-if (True == x140663453949031) {
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match_45cons_45expander);
-__arg1 = pat;
-__arg2 = expr;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-PUSH_CONT_0(co, 12, clofun4);
-__nargs = 3;
-__arg0 = globalRef(symstr);
-__arg1 = makeCString("match fail ");
-__arg2 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj x140663453909031 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = x140663453909031;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x = __arg1;
-pushCont(co, 14, clofun4, 1, x);
-__nargs = 2;
-__arg0 = globalRef(symatom_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x140663454501191 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140663454501191) {
-Obj x140663454501703 = primIsSymbol(x);
-Obj x140663454501735 = primNot(x140663454501703);
-if (True == x140663454501735) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label15:
-{
-Obj pat = __arg1;
-Obj expr = __arg2;
-Obj body = __arg3;
-Obj cc = co->args[4];
-pushCont(co, 16, clofun4, 4, pat, expr, body, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj x140663454886599 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = x140663454886599;
-pushCont(co, 17, clofun4, 4, expr, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj x140663454886919 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = x140663454886919;
-Obj x140663454887239 = PRIM_ISCONS(expr);
-if (True == x140663454887239) {
-Obj x140663454887751 = PRIM_CAR(expr);
-Obj x140663454887815 = PRIM_EQ(x140663454887751, symcons);
-if (True == x140663454887815) {
-if (True == True) {
-pushCont(co, 30, clofun4, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x140663454603207 = makeCons(expr, Nil);
-Obj x140663454603239 = makeCons(symcons_63, x140663454603207);
-Obj x140663454604167 = makeCons(expr, Nil);
-Obj x140663454604199 = makeCons(symcar, x140663454604167);
-Obj x140663454604839 = makeCons(expr, Nil);
-Obj x140663454604871 = makeCons(symcdr, x140663454604839);
-pushCont(co, 28, clofun4, 4, x, x140663454604199, cc, x140663454603239);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = x140663454604871;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 25, clofun4, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x140663454583399 = makeCons(expr, Nil);
-Obj x140663454583431 = makeCons(symcons_63, x140663454583399);
-Obj x140663454584295 = makeCons(expr, Nil);
-Obj x140663454584327 = makeCons(symcar, x140663454584295);
-Obj x140663454540007 = makeCons(expr, Nil);
-Obj x140663454540039 = makeCons(symcdr, x140663454540007);
-pushCont(co, 23, clofun4, 4, x, x140663454584327, cc, x140663454583431);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = x140663454540039;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-pushCont(co, 20, clofun4, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x140663454542919 = makeCons(expr, Nil);
-Obj x140663454542951 = makeCons(symcons_63, x140663454542919);
-Obj x140663454498823 = makeCons(expr, Nil);
-Obj x140663454498855 = makeCons(symcar, x140663454498823);
-Obj x140663454499495 = makeCons(expr, Nil);
-Obj x140663454499527 = makeCons(symcdr, x140663454499495);
-pushCont(co, 18, clofun4, 4, x, x140663454498855, cc, x140663454542951);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = x140663454499527;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label18:
-{
-Obj x140663454499751 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454498855= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663454542951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 19, clofun4, 2, cc, x140663454542951);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = x140663454498855;
-__arg3 = x140663454499751;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj x140663454499815 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454542951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454500231 = makeCons(cc, Nil);
-Obj x140663454500295 = makeCons(x140663454500231, Nil);
-Obj x140663454500359 = makeCons(x140663454499815, x140663454500295);
-Obj x140663454500391 = makeCons(x140663454542951, x140663454500359);
-Obj x140663454500423 = makeCons(symif, x140663454500391);
-__nargs = 2;
-__arg1 = x140663454500423;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj x140663454541159 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140663454541159;
-pushCont(co, 21, clofun4, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label21:
-{
-Obj x140663454541447 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140663454541447;
-pushCont(co, 22, clofun4, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label22:
-{
-Obj x140663454542055 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = x140663454542055;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label23:
-{
-Obj x140663454540199 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454584327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663454583431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 24, clofun4, 2, cc, x140663454583431);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = x140663454584327;
-__arg3 = x140663454540199;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label24:
-{
-Obj x140663454540263 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454583431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454540743 = makeCons(cc, Nil);
-Obj x140663454540807 = makeCons(x140663454540743, Nil);
-Obj x140663454540839 = makeCons(x140663454540263, x140663454540807);
-Obj x140663454540871 = makeCons(x140663454583431, x140663454540839);
-Obj x140663454540903 = makeCons(symif, x140663454540871);
-__nargs = 2;
-__arg1 = x140663454540903;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label25:
-{
-Obj x140663454581575 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140663454581575;
-pushCont(co, 26, clofun4, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label26:
-{
-Obj x140663454581831 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140663454581831;
-pushCont(co, 27, clofun4, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label27:
-{
-Obj x140663454582375 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = x140663454582375;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label28:
-{
-Obj x140663454605127 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454604199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663454603239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 29, clofun4, 2, cc, x140663454603239);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = x140663454604199;
-__arg3 = x140663454605127;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label29:
-{
-Obj x140663454605191 = __arg1;
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454603239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454581031 = makeCons(cc, Nil);
-Obj x140663454581095 = makeCons(x140663454581031, Nil);
-Obj x140663454581127 = makeCons(x140663454605191, x140663454581095);
-Obj x140663454581159 = makeCons(x140663454603239, x140663454581127);
-Obj x140663454581191 = makeCons(symif, x140663454581159);
-__nargs = 2;
-__arg1 = x140663454581191;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label30:
-{
-Obj x140663454601351 = __arg1;
-Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = x140663454601351;
-pushCont(co, 31, clofun4, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label31:
-{
-Obj x140663454601703 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = x140663454601703;
-pushCont(co, 32, clofun4, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x140663454602311 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x;
-__arg2 = e1;
-__arg3 = x140663454602311;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label33:
-{
-Obj exp = __arg1;
-Obj x140663454885991 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140663454885991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label34:
-{
-Obj pat = __arg1;
-Obj x140663454900167 = PRIM_CDR(pat);
-pushCont(co, 35, clofun4, 1, pat);
-__nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x140663454900167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label35:
-{
-Obj x140663454900199 = __arg1;
-Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140663454900199) {
-Obj x140663454884007 = PRIM_CAR(pat);
-__nargs = 2;
-__arg1 = x140663454884007;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454884583 = PRIM_CAR(pat);
-Obj x140663454885127 = PRIM_CDR(pat);
-pushCont(co, 36, clofun4, 1, x140663454884583);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x140663454885127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label36:
-{
-Obj x140663454885159 = __arg1;
-Obj x140663454884583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454885223 = makeCons(x140663454885159, Nil);
-Obj x140663454885255 = makeCons(x140663454884583, x140663454885223);
-Obj x140663454885287 = makeCons(symcons, x140663454885255);
-__nargs = 2;
-__arg1 = x140663454885287;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label37:
-{
-Obj x = __arg1;
-Obj x140663454899111 = PRIM_EQ(x, True);
-if (True == x140663454899111) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454899399 = PRIM_EQ(x, False);
-if (True == x140663454899399) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-}
-
-label38:
-{
-Obj exp = __arg1;
-Obj x140663454898471 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140663454898471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label39:
-{
-Obj l = __arg1;
-Obj x140663454920039 = PRIM_EQ(Nil, l);
-if (True == x140663454920039) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454920455 = PRIM_CAR(l);
-Obj x140663454920519 = PRIM_EQ(x140663454920455, False);
-if (True == x140663454920519) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454896359 = PRIM_CDR(l);
-pushCont(co, 40, clofun4, 1, l);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x140663454896359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label40:
-{
-Obj x140663454896391 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140663454896391;
-Obj x140663454896679 = PRIM_EQ(more, False);
-if (True == x140663454896679) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454897223 = PRIM_CAR(l);
-Obj x140663454897671 = makeCons(False, Nil);
-Obj x140663454897703 = makeCons(more, x140663454897671);
-Obj x140663454897735 = makeCons(x140663454897223, x140663454897703);
-Obj x140663454897767 = makeCons(symif, x140663454897735);
-__nargs = 2;
-__arg1 = x140663454897767;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label41:
-{
-Obj exp = __arg1;
-Obj x140663454919399 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140663454919399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label42:
-{
-Obj l = __arg1;
-Obj x140663454949127 = PRIM_EQ(l, Nil);
-if (True == x140663454949127) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454916775 = PRIM_CAR(l);
-Obj x140663454916839 = PRIM_EQ(x140663454916775, True);
-if (True == x140663454916839) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454917287 = PRIM_CDR(l);
-pushCont(co, 43, clofun4, 1, l);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x140663454917287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label43:
-{
-Obj x140663454917319 = __arg1;
-Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x140663454917319;
-Obj x140663454917607 = PRIM_EQ(more, True);
-if (True == x140663454917607) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454918151 = PRIM_CAR(l);
-Obj x140663454918599 = makeCons(more, Nil);
-Obj x140663454918631 = makeCons(True, x140663454918599);
-Obj x140663454918663 = makeCons(x140663454918151, x140663454918631);
-Obj x140663454918695 = makeCons(symif, x140663454918663);
-__nargs = 2;
-__arg1 = x140663454918695;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label44:
-{
-Obj exp = __arg1;
-Obj x140663454946055 = PRIM_CDR(exp);
-Obj x140663454946087 = PRIM_EQ(Nil, x140663454946055);
-if (True == x140663454946087) {
-Obj x140663454946503 = makeCons(makeCString("no cond match"), Nil);
-Obj x140663454946535 = makeCons(symerror, x140663454946503);
-__nargs = 2;
-__arg1 = x140663454946535;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 45, clofun4, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label45:
-{
-Obj x140663454946791 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = x140663454946791;
-Obj x140663454947335 = PRIM_CAR(curr);
-pushCont(co, 46, clofun4, 2, exp, x140663454947335);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = curr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-Obj x140663454947719 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454947335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 47, clofun4, 2, x140663454947719, x140663454947335);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
-Obj x140663454948295 = __arg1;
-Obj x140663454947719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454947335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454948327 = makeCons(symcond, x140663454948295);
-Obj x140663454948391 = makeCons(x140663454948327, Nil);
-Obj x140663454948423 = makeCons(x140663454947719, x140663454948391);
-Obj x140663454948455 = makeCons(x140663454947335, x140663454948423);
-Obj x140663454948487 = makeCons(symif, x140663454948455);
-__nargs = 2;
-__arg1 = x140663454948487;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun4) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label48:
-{
-Obj exp = __arg1;
-Obj x140663454978023 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140663454978023;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label49:
-{
-Obj exp = __arg1;
-Obj x140663454975431 = PRIM_CDR(exp);
-pushCont(co, 0, clofun5, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x140663454975431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-static void clofun5(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj x140663454975463 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x140663454975463) {
-Obj x140663454975655 = PRIM_CAR(exp);
-__nargs = 2;
-__arg1 = x140663454975655;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663454976199 = PRIM_CAR(exp);
-pushCont(co, 1, clofun5, 2, exp, x140663454976199);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label1:
-{
-Obj x140663454976583 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454976199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 2, clofun5, 2, x140663454976583, x140663454976199);
-__nargs = 2;
-__arg0 = globalRef(symcddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x140663454977127 = __arg1;
-Obj x140663454976583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454976199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 3, clofun5, 2, x140663454976583, x140663454976199);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x140663454977127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x140663454977159 = __arg1;
-Obj x140663454976583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454976199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663454977223 = makeCons(x140663454977159, Nil);
-Obj x140663454977255 = makeCons(x140663454976583, x140663454977223);
-Obj x140663454977287 = makeCons(x140663454976199, x140663454977255);
-Obj x140663454977319 = makeCons(symlet, x140663454977287);
-__nargs = 2;
-__arg1 = x140663454977319;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-Obj x = __arg1;
-Obj x140663454974631 = PRIM_ISCONS(x);
-Obj x140663454974663 = primNot(x140663454974631);
-__nargs = 2;
-__arg1 = x140663454974663;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label5:
-{
-Obj x = __arg1;
-Obj l = __arg2;
-Obj x140663453907175 = PRIM_ISCONS(l);
-if (True == x140663453907175) {
-Obj x140663453907655 = PRIM_CAR(l);
-Obj x140663453907719 = PRIM_EQ(x140663453907655, x);
-if (True == x140663453907719) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663453908135 = PRIM_CDR(l);
-__nargs = 3;
-__arg0 = globalRef(symelem_63);
-__arg1 = x;
-__arg2 = x140663453908135;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label6:
-{
-Obj exp = __arg1;
-pushCont(co, 7, clofun5, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x140663453905127 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 8, clofun5, 2, exp, x140663453905127);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x140663453905863 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453905127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 9, clofun5, 2, x140663453905863, x140663453905127);
-__nargs = 2;
-__arg0 = globalRef(symcadddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj x140663453906279 = __arg1;
-Obj x140663453905863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453905127= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453906343 = makeCons(x140663453906279, Nil);
-Obj x140663453906375 = makeCons(x140663453905863, x140663453906343);
-Obj x140663453906407 = makeCons(symlambda, x140663453906375);
-Obj x140663453906471 = makeCons(x140663453906407, Nil);
-Obj x140663453906503 = makeCons(x140663453905127, x140663453906471);
-Obj x140663453906535 = makeCons(symdef, x140663453906503);
-__nargs = 2;
-__arg1 = x140663453906535;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label10:
-{
-Obj exp = __arg1;
-Obj x140663453912391 = PRIM_CDR(exp);
-__nargs = 2;
-__arg0 = globalRef(symrcons);
-__arg1 = x140663453912391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj exp = __arg1;
-pushCont(co, 12, clofun5, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj x140663453909735 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453909799 = makeCons(x140663453909735, Nil);
-Obj x140663453909831 = makeCons(symquote, x140663453909799);
-pushCont(co, 13, clofun5, 2, exp, x140663453909831);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x140663453910695 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453909831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 14, clofun5, 2, x140663453910695, x140663453909831);
-__nargs = 2;
-__arg0 = globalRef(symcdddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x140663453910919 = __arg1;
-Obj x140663453910695= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453909831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x140663453910951 = makeCons(x140663453910695, x140663453910919);
-Obj x140663453910983 = makeCons(symlambda, x140663453910951);
-Obj x140663453911047 = makeCons(x140663453910983, Nil);
-Obj x140663453911079 = makeCons(x140663453909831, x140663453911047);
-Obj x140663453911111 = makeCons(symcora_47init_35add_45to_45_42macros_42, x140663453911079);
-__nargs = 2;
-__arg1 = x140663453911111;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj exp = __arg1;
-Obj x140663453989735 = PRIM_ISCONS(exp);
-if (True == x140663453989735) {
-Obj x140663453990183 = PRIM_CAR(exp);
-Obj x140663453990247 = PRIM_EQ(x140663453990183, globalRef(sym_42protect_45symbol_42));
-if (True == x140663453990247) {
-Obj x140663453990471 = PRIM_CDR(exp);
-__nargs = 2;
-__arg1 = x140663453990471;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x140663453945863 = PRIM_CAR(exp);
-Obj x140663453945991 = PRIM_EQ(x140663453945863, symlambda);
-if (True == x140663453945991) {
-pushCont(co, 18, clofun5, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcadr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x140663453947847 = PRIM_CAR(exp);
-Obj x140663453947911 = PRIM_EQ(x140663453947847, symquote);
-if (True == x140663453947911) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 16, clofun5, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand1);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label16:
-{
-Obj x140663453949095 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = makeNative(17, clofun5, 1, 1, exp);
-__arg1 = x140663453949095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj exp1 = __arg1;
-Obj x140663453948423 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == x140663453948423) {
-__nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg2 = exp1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = exp1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label18:
-{
-Obj x140663453946599 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 19, clofun5, 1, x140663453946599);
-__nargs = 2;
-__arg0 = globalRef(symcaddr);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj x140663453947207 = __arg1;
-Obj x140663453946599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 20, clofun5, 1, x140663453946599);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = x140663453947207;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj x140663453947239 = __arg1;
-Obj x140663453946599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663453947303 = makeCons(x140663453947239, Nil);
-Obj x140663453947335 = makeCons(x140663453946599, x140663453947303);
-Obj x140663453947399 = makeCons(symlambda, x140663453947335);
-__nargs = 2;
-__arg1 = x140663453947399;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label21:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -8382,130 +5464,116 @@ __arg2 = globalRef(sym_42macros_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label2:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj x140663454500327 = PRIM_EQ(Nil, macros);
-if (True == x140663454500327) {
+Obj x139886475568807 = PRIM_EQ(Nil, macros);
+if (True == x139886475568807) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x140663453988487 = PRIM_CAR(macros);
+Obj x139886475570311 = PRIM_CAR(macros);
 __nargs = 2;
-__arg0 = makeNative(23, clofun5, 1, 2, exp, macros);
-__arg1 = x140663453988487;
+__arg0 = makeNative(3, clofun4, 1, 2, macros, exp);
+__arg1 = x139886475570311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label23:
+label3:
 {
 Obj item = __arg1;
-Obj x140663454500839 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x140663454500839) {
-Obj x140663454501255 = PRIM_CAR(closureRef(co, 0));
-Obj x140663454501479 = PRIM_CAR(item);
-Obj x140663454501511 = PRIM_EQ(x140663454501255, x140663454501479);
-if (True == x140663454501511) {
-if (True == True) {
-Obj x140663454501831 = PRIM_CDR(item);
+Obj x139886476187015 = makeNative(4, clofun4, 1, 3, item, closureRef(co, 1), closureRef(co, 0));
+Obj x139886475569831 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139886475569831) {
+Obj x139886475570087 = PRIM_CAR(closureRef(co, 1));
+Obj x139886475570183 = PRIM_CAR(item);
+Obj x139886475570215 = PRIM_EQ(x139886475570087, x139886475570183);
+if (True == x139886475570215) {
 __nargs = 2;
-__arg0 = x140663454501831;
-__arg1 = closureRef(co, 0);
+__arg0 = x139886476187015;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x140663454502247 = PRIM_CDR(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
-__arg1 = closureRef(co, 0);
-__arg2 = x140663454502247;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj x140663454502567 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140663454502567;
-__arg1 = closureRef(co, 0);
+__arg0 = x139886476187015;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x140663453987079 = PRIM_CDR(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
-__arg1 = closureRef(co, 0);
-__arg2 = x140663453987079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
 } else {
-if (True == False) {
-Obj x140663453987751 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = x140663453987751;
-__arg1 = closureRef(co, 0);
+__arg0 = x139886476187015;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x140663453988199 = PRIM_CDR(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
-__arg1 = closureRef(co, 0);
-__arg2 = x140663453988199;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 }
 
-label24:
+label4:
+{
+Obj x139886476187047 = __arg1;
+if (True == x139886476187047) {
+Obj x139886475569319 = PRIM_CDR(closureRef(co, 0));
+__nargs = 2;
+__arg0 = x139886475569319;
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475569575 = PRIM_CDR(closureRef(co, 2));
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
+__arg1 = closureRef(co, 1);
+__arg2 = x139886475569575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj x140663454499591 = makeCons(n, v);
-Obj x140663454499655 = makeCons(x140663454499591, globalRef(sym_42macros_42));
-Obj x140663454499687 = primSet(co, sym_42macros_42, x140663454499655);
+Obj x139886475568359 = makeCons(n, v);
+Obj x139886475568391 = makeCons(x139886475568359, globalRef(sym_42macros_42));
+Obj x139886475568423 = primSet(co, sym_42macros_42, x139886475568391);
 __nargs = 2;
-__arg1 = x140663454499687;
+__arg1 = x139886475568423;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label25:
+label6:
 {
 Obj f = __arg1;
 Obj l = __arg2;
@@ -8517,26 +5585,26 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label7:
 {
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj x140663454541223 = PRIM_ISCONS(l);
-if (True == x140663454541223) {
-Obj x140663454541895 = PRIM_CAR(l);
-pushCont(co, 27, clofun5, 3, res, l, f);
+Obj x139886475599463 = PRIM_ISCONS(l);
+if (True == x139886475599463) {
+Obj x139886475599751 = PRIM_CAR(l);
+pushCont(co, 8, clofun4, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = x140663454541895;
+__arg1 = x139886475599751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -8545,204 +5613,204 @@ __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label27:
+label8:
 {
-Obj x140663454541927 = __arg1;
+Obj x139886475599783 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x140663454541991 = makeCons(x140663454541927, res);
-Obj x140663454542247 = PRIM_CDR(l);
+Obj x139886475599815 = makeCons(x139886475599783, res);
+Obj x139886475567143 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symmap_45h);
-__arg1 = x140663454541991;
+__arg1 = x139886475599815;
 __arg2 = f;
-__arg3 = x140663454542247;
+__arg3 = x139886475567143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label9:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj x140663454584391 = PRIM_ISCONS(l);
-if (True == x140663454584391) {
-Obj x140663454539847 = PRIM_CAR(l);
-Obj x140663454539911 = makeCons(x140663454539847, res);
-Obj x140663454540135 = PRIM_CDR(l);
+Obj x139886475598471 = PRIM_ISCONS(l);
+if (True == x139886475598471) {
+Obj x139886475598695 = PRIM_CAR(l);
+Obj x139886475598727 = makeCons(x139886475598695, res);
+Obj x139886475598823 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = x140663454539911;
-__arg2 = x140663454540135;
+__arg1 = x139886475598727;
+__arg2 = x139886475598823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label29:
+label10:
 {
 Obj x = __arg1;
-Obj x140663454583783 = PRIM_ISCONS(x);
+Obj x139886475598087 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = x140663454583783;
+__arg1 = x139886475598087;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label30:
+label11:
 {
 Obj exp = __arg1;
-Obj x140663454581991 = PRIM_ISCONS(exp);
-if (True == x140663454581991) {
-Obj x140663454582535 = PRIM_CAR(exp);
-Obj x140663454583079 = PRIM_CDR(exp);
-pushCont(co, 31, clofun5, 1, x140663454582535);
+Obj x139886475597191 = PRIM_ISCONS(exp);
+if (True == x139886475597191) {
+Obj x139886475597415 = PRIM_CAR(exp);
+Obj x139886475597639 = PRIM_CDR(exp);
+pushCont(co, 12, clofun4, 1, x139886475597415);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = x140663454583079;
+__arg1 = x139886475597639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label31:
+label12:
 {
-Obj x140663454583111 = __arg1;
-Obj x140663454582535= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x140663454583175 = makeCons(x140663454583111, Nil);
-Obj x140663454583207 = makeCons(x140663454582535, x140663454583175);
-Obj x140663454583239 = makeCons(symcons, x140663454583207);
+Obj x139886475597671 = __arg1;
+Obj x139886475597415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475597703 = makeCons(x139886475597671, Nil);
+Obj x139886475597735 = makeCons(x139886475597415, x139886475597703);
+Obj x139886475597767 = makeCons(symcons, x139886475597735);
 __nargs = 2;
-__arg1 = x140663454583239;
+__arg1 = x139886475597767;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label32:
-{
-Obj x = __arg1;
-Obj x140663454581319 = PRIM_CDR(x);
-Obj x140663454581351 = PRIM_CDR(x140663454581319);
-Obj x140663454581383 = PRIM_CDR(x140663454581351);
-__nargs = 2;
-__arg1 = x140663454581383;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label33:
+label13:
 {
 Obj x = __arg1;
-Obj x140663454604935 = PRIM_CDR(x);
-Obj x140663454604967 = PRIM_CDR(x140663454604935);
-Obj x140663454604999 = PRIM_CDR(x140663454604967);
-Obj x140663454605031 = PRIM_CAR(x140663454604999);
+Obj x139886475596743 = PRIM_CDR(x);
+Obj x139886475596775 = PRIM_CDR(x139886475596743);
+Obj x139886475596807 = PRIM_CDR(x139886475596775);
 __nargs = 2;
-__arg1 = x140663454605031;
+__arg1 = x139886475596807;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label34:
+label14:
 {
 Obj x = __arg1;
-Obj x140663454603847 = PRIM_CDR(x);
-Obj x140663454603879 = PRIM_CDR(x140663454603847);
-Obj x140663454603911 = PRIM_CAR(x140663454603879);
+Obj x139886475596199 = PRIM_CDR(x);
+Obj x139886475596231 = PRIM_CDR(x139886475596199);
+Obj x139886475596263 = PRIM_CDR(x139886475596231);
+Obj x139886475596295 = PRIM_CAR(x139886475596263);
 __nargs = 2;
-__arg1 = x140663454603911;
+__arg1 = x139886475596295;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label35:
+label15:
 {
 Obj x = __arg1;
-Obj x140663454602951 = PRIM_CDR(x);
-Obj x140663454602983 = PRIM_CDR(x140663454602951);
+Obj x139886475984711 = PRIM_CDR(x);
+Obj x139886475984743 = PRIM_CDR(x139886475984711);
+Obj x139886475984775 = PRIM_CAR(x139886475984743);
 __nargs = 2;
-__arg1 = x140663454602983;
+__arg1 = x139886475984775;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label36:
+label16:
 {
 Obj x = __arg1;
-Obj x140663454602215 = PRIM_CAR(x);
-Obj x140663454602247 = PRIM_CDR(x140663454602215);
+Obj x139886475984231 = PRIM_CDR(x);
+Obj x139886475984263 = PRIM_CDR(x139886475984231);
 __nargs = 2;
-__arg1 = x140663454602247;
+__arg1 = x139886475984263;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label37:
+label17:
 {
 Obj x = __arg1;
-Obj x140663454601479 = PRIM_CAR(x);
-Obj x140663454601511 = PRIM_CAR(x140663454601479);
+Obj x139886475983815 = PRIM_CAR(x);
+Obj x139886475983847 = PRIM_CDR(x139886475983815);
 __nargs = 2;
-__arg1 = x140663454601511;
+__arg1 = x139886475983847;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label38:
+label18:
 {
 Obj x = __arg1;
-Obj x140663454887463 = PRIM_CDR(x);
-Obj x140663454887495 = PRIM_CAR(x140663454887463);
+Obj x139886475983399 = PRIM_CAR(x);
+Obj x139886475983431 = PRIM_CAR(x139886475983399);
 __nargs = 2;
-__arg1 = x140663454887495;
+__arg1 = x139886475983431;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label39:
+label19:
 {
 Obj x = __arg1;
-Obj x140663454886759 = PRIM_EQ(x, Nil);
+Obj x139886475982983 = PRIM_CDR(x);
+Obj x139886475983015 = PRIM_CAR(x139886475982983);
 __nargs = 2;
-__arg1 = x140663454886759;
+__arg1 = x139886475983015;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label20:
+{
+Obj x = __arg1;
+Obj x139886475982599 = PRIM_EQ(x, Nil);
+__nargs = 2;
+__arg1 = x139886475982599;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 

--- a/init.cora
+++ b/init.cora
@@ -300,47 +300,14 @@
               (cons 'match (cons (cons 'list args)
                                  body)))))))
 
-(func cora/init#propagate-boolean0
-      ['car ['cons x _]] => x
-      ['cdr ['cons _ x]] => x
-      ['cons? ['cons _ _]] => true
-      ['and true true] => true
-      ['null? ()] => true
-      ['null? ['cons _ _]] => false
-      ['not true] => false
-      ['not false] => true
-      ['if true y z] => y
-      ['if false y z] => z
-      x => x)
-
-(func cora/init#propagate-boolean
-      ['quote x] => ['quote x]
-      ['cons? x] => (let x1 (cora/init#propagate-boolean x)
-		       (cora/init#propagate-boolean0 ['cons? x1]))
-      ['car x] => (let x1 (cora/init#propagate-boolean x)
-		       (cora/init#propagate-boolean0 ['car x1]))
-      ['cdr x] => (let x1 (cora/init#propagate-boolean x)
-		       (cora/init#propagate-boolean0 ['cdr x1]))
-      ['and x y] => (let x1 (cora/init#propagate-boolean x)
-			 y1 (cora/init#propagate-boolean y)
-			 (cora/init#propagate-boolean0 ['and x1 y1]))
-      ['null? x] => (let x1 (cora/init#propagate-boolean x)
-			 (cora/init#propagate-boolean0 ['null? x1]))
-      ['not x] => (let x1 (cora/init#propagate-boolean x)
-		       (cora/init#propagate-boolean0 ['not x1]))
-      ['if x y z] => (let x1 (cora/init#propagate-boolean x)
-			  y1 (cora/init#propagate-boolean y)
-			  z1 (cora/init#propagate-boolean z)
-			  (cora/init#propagate-boolean0 ['if x1 y1 z1]))
-      ['lambda args body] => ['lambda args (cora/init#propagate-boolean body)]
-      [f . args] => (map cora/init#propagate-boolean [f . args])
-      x => x)
-
 (defun cora/init#rewrite-namespace (exp)
   (cora/init#parse () "" () exp))
 
+;; rewrite by a real partial evaluation later
+(set 'cora/init#peval (lambda (x) x))
+
 (defun macroexpand (exp)
-  (cora/init#propagate-boolean
+  (cora/init#peval
    (cora/init#rewrite-namespace
     (cora/init#macroexpand-boot exp))))
 

--- a/lib/eval.cora
+++ b/lib/eval.cora
@@ -1,5 +1,6 @@
 (package "cora/lib/eval"
   (export eval)
+  (import "cora/lib/peval")
 
   (set 'set (set))
   (set 'car (car))
@@ -13,7 +14,7 @@
   (set '= (=))
   (set '> (>))
   (set '< (<))
-  (set 'gensym (gensym))
+  (set 'gensym (lambda () (gensym)))
   (set 'symbol? (symbol?))
   (set 'not (not))
   (set 'string? (string?))

--- a/lib/peval.cora
+++ b/lib/peval.cora
@@ -1,0 +1,131 @@
+(package "cora/lib/peval"
+	 (export peval)
+	 (import "cora/lib/sys")
+
+	 (defun const-symbol? (x)
+	   (and (cons? x)
+		(= (car x) 'quote)))
+
+	 (defun const? (x)
+	   (or (null? x)
+	       (boolean? x)
+	       (number? x)
+	       (string? x)
+	       (const-symbol? x)))
+
+	 (func const-list?
+	       ['cons x more] => (and (const? x)
+				      (or (= more ())
+					  (const-list? more)))
+	       _ => false)
+
+	 (func const-list-length
+	       ['cons _ ()] => 1
+	       ['cons _ more] => (+ 1 (const-list-length more)))
+
+	 (defun shrink-env (params env)
+	   (filter (lambda (kv)
+		     (not (member (car kv) params)))
+		   env))
+
+	 (func peval
+	       env x => (let find (assq x env)
+			     (if (cons? find)
+				 (cdr find)
+				 x)) where (symbol? x)
+	       env ['quote v] => ['quote v]
+	       env ['if a b c] => (let v (peval env a)
+				       (cond
+					 ((= v true) (peval env b))
+					 ((= v false) (peval env c))
+					 (true ['if v (peval env b) (peval env c)])))
+	       env ['do a b] => (let a1 (peval env a)
+				     (if (and (cons? a1) (= (car a1) 'lambda))
+					 (peval env b)
+					 ['do a1 (peval env b)]))
+	       env ['lambda params body] => ['lambda params (peval (shrink-env params env) body)]
+	       env ['let a b c] => (peval-let a (peval env b) c env)
+	       env [f . args] => (peval-app (map (peval env) [f . args]) env)
+	       env x => x)
+
+	 (func ref-count
+	       x exp => 0 where (or (const? exp) (const-list? exp))
+	       x ['quote _] => 0
+	       x var => (if (= x var) 1 0) where (symbol? var)
+	       x ['if a b c] => (+ (ref-count x a)
+				   (+ (ref-count x b) (ref-count x c)))
+	       x ['do a b] => (+ (ref-count x a) (ref-count x b))
+	       x ['let var val body] => (+ (ref-count x val)
+					   (if (= var x) 0
+					       (ref-count x body)))
+	       x ['lambda params body] => (if (member x params) 0
+					      (ref-count x body))
+	       x [f . args] => (foldl (lambda (acc exp)
+					(+ acc (ref-count x exp)))
+				      0 [f . args]))
+
+	 (defun side-effect-free? (exp)
+	   (or (and (cons? exp) (= (car exp) 'lambda))
+	       (const? exp)
+	       (const-list? exp)))
+
+	 (defun peval-let (var val body env)
+	   (if (or (const? val)            ;; val is const
+		   (symbol? val)           ;; val is symbol
+		   (and (const-list? val) (< (const-list-length val) 3))) ;; val is short const list
+	       (peval [(cons var val) . env] body)
+	       (let refs (ref-count var body)
+		    safe (side-effect-free? val)
+		    (cond
+		      ((= refs 0) ;; var is not really used
+		       (if safe (peval env body) 
+			   ['do val (peval env body)]))
+		      ((and (= refs 1) safe) ;; var is used exactly once and val is side effect free
+		       (peval [(cons var val) . env] body))
+		      (true ['let var val (peval (shrink-env [var] env) body)])))))
+		      
+	 ;; collect the static const to env
+	 (defun extend-env (params args env k)
+	   (extend-env-h () () params args env k))
+
+	 (func extend-env-h
+	       retp reta [p . ps] [a . as] env k => (if (or (const? a) (const-list? a))
+							(extend-env-h retp reta ps as (cons (cons p a) env) k)
+							(extend-env-h (cons p retp) (cons a reta) ps as env k))
+	       retp reta [] args env k => (k (reverse retp) (append (reverse reta) args) env)
+	       retp reta params [] env k => (k (append (reverse retp) params) (reverse reta) env))
+
+	 (func peval-apply-lambda
+	       [] [] body => body
+	       params [] body => ['lambda params body]
+	       params args body => [['lambda params body] . args])
+
+	 (func peval-app
+	       ['cons? ['cons _ _]] env => true
+	       ['car ['cons x _]] env => x
+	       ['cdr ['cons _ x]] env => x
+	       ['and true true] env => true
+	       ['null? ()] env => true
+	       ['null? ['cons _ _]] env => false
+	       ['not true] env => false
+	       ['not false] env => true
+	       ['+ x y] env => (+ x y) where (and (number? x) (number? y))
+	       ['- x y] env => (- x y) where (and (number? x) (number? y))
+	       [['lambda params body] . args] env => (extend-env params args env
+								 (lambda (params1 args1 env1)
+								   (let body1 (peval (shrink-env params1 env1) body)
+									(peval-apply-lambda params1 args1 body1))))
+	       x env => x)
+
+	 ;; (peval () `(let example1 (lambda (a b c)
+	 ;; 			   (if (null? a) b (+ (car a) c)))
+	 ;; 		(example1 [10 11] not-const 1)))
+
+	 ;; (peval () `(let example2 (lambda (x y)
+	 ;; 		 (let (q (lambda (a b)
+	 ;; 			   (if (< a 0) b (- 10 b))))
+	 ;; 		   (if (< x 0) (q (- y) (- x)) (q y x))))))
+
+	 (set 'cora/init#peval (peval ()))
+
+	 )

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -10,7 +10,6 @@ static void clofun5(struct Cora* co);
 static void clofun6(struct Cora* co);
 static void clofun7(struct Cora* co);
 static void clofun8(struct Cora* co);
-static void clofun9(struct Cora* co);
 
 
 static Obj symcora_47lib_47io_35close_45output_45file;
@@ -81,9 +80,9 @@ static Obj symcora_47init_35vector_45ref;
 static Obj symcora_47lib_47toc_35collect_45lambda;
 static Obj sym_37continuation;
 static Obj symcora_47lib_47toc_35explicit_45stack;
-static Obj symcora_47lib_47toc_35wrap_45var;
 static Obj symcora_47init_35caar;
 static Obj symcora_47init_35pair_63;
+static Obj symcora_47lib_47toc_35wrap_45var;
 static Obj symcora_47init_35reverse;
 static Obj symcora_47lib_47toc_35tailify_45list;
 static Obj symcora_47lib_47toc_35tailify;
@@ -101,19 +100,19 @@ static Obj symcora_47lib_47toc_35diff;
 static Obj symcora_47lib_47toc_35union;
 static Obj symcora_47init_35boolean_63;
 static Obj symcora_47init_35number_63;
-static Obj sym_37const;
 static Obj symquote;
-static Obj sym_37global;
-static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
-static Obj symcora_47init_35elem_63;
-static Obj symif;
 static Obj symdo;
 static Obj symlet;
+static Obj symif;
 static Obj symcora_47init_35append;
 static Obj symlambda;
 static Obj sym_37builtin;
 static Obj symcora_47init_35length;
 static Obj symcora_47init_35map;
+static Obj sym_37global;
+static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
+static Obj symcora_47init_35elem_63;
+static Obj sym_37const;
 static Obj symcora_47lib_47toc_35parse;
 static Obj symcora_47lib_47toc_35temp_45list;
 static Obj symcora_47init_35cadr;
@@ -217,9 +216,9 @@ symcora_47init_35vector_45ref = intern("cora/init#vector-ref");
 symcora_47lib_47toc_35collect_45lambda = intern("cora/lib/toc#collect-lambda");
 sym_37continuation = intern("%continuation");
 symcora_47lib_47toc_35explicit_45stack = intern("cora/lib/toc#explicit-stack");
-symcora_47lib_47toc_35wrap_45var = intern("cora/lib/toc#wrap-var");
 symcora_47init_35caar = intern("cora/init#caar");
 symcora_47init_35pair_63 = intern("cora/init#pair?");
+symcora_47lib_47toc_35wrap_45var = intern("cora/lib/toc#wrap-var");
 symcora_47init_35reverse = intern("cora/init#reverse");
 symcora_47lib_47toc_35tailify_45list = intern("cora/lib/toc#tailify-list");
 symcora_47lib_47toc_35tailify = intern("cora/lib/toc#tailify");
@@ -237,19 +236,19 @@ symcora_47lib_47toc_35diff = intern("cora/lib/toc#diff");
 symcora_47lib_47toc_35union = intern("cora/lib/toc#union");
 symcora_47init_35boolean_63 = intern("cora/init#boolean?");
 symcora_47init_35number_63 = intern("cora/init#number?");
-sym_37const = intern("%const");
 symquote = intern("quote");
-sym_37global = intern("%global");
-symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
-symcora_47init_35elem_63 = intern("cora/init#elem?");
-symif = intern("if");
 symdo = intern("do");
 symlet = intern("let");
+symif = intern("if");
 symcora_47init_35append = intern("cora/init#append");
 symlambda = intern("lambda");
 sym_37builtin = intern("%builtin");
 symcora_47init_35length = intern("cora/init#length");
 symcora_47init_35map = intern("cora/init#map");
+sym_37global = intern("%global");
+symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
+symcora_47init_35elem_63 = intern("cora/init#elem?");
+sym_37const = intern("%const");
 symcora_47lib_47toc_35parse = intern("cora/lib/toc#parse");
 symcora_47lib_47toc_35temp_45list = intern("cora/lib/toc#temp-list");
 symcora_47init_35cadr = intern("cora/init#cadr");
@@ -312,7 +311,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139749080363143 = __arg1;
+Obj x139886475385895 = __arg1;
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -326,7 +325,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139749080363463 = __arg1;
+Obj x139886475386055 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -340,123 +339,123 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139749080363783 = __arg1;
-Obj x139749080364071 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
-Obj x139749080353191 = primSet(co, symcora_47lib_47toc_35assq, makeNative(43, clofun9, 2, 0));
-Obj x139749079971719 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(39, clofun9, 3, 0));
-Obj x139749079783687 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(35, clofun9, 3, 0));
-Obj x139749079784263 = primSet(co, symcora_47lib_47toc_35index, makeNative(34, clofun9, 2, 0));
-Obj x139749079758695 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(30, clofun9, 2, 0));
-Obj x139749079759815 = makeCons(makeCString("primSet"), Nil);
-Obj x139749079759847 = makeCons(MAKE_NUMBER(2), x139749079759815);
-Obj x139749079759879 = makeCons(symset, x139749079759847);
-Obj x139749079760711 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x139749079760743 = makeCons(MAKE_NUMBER(1), x139749079760711);
-Obj x139749079760775 = makeCons(symcar, x139749079760743);
-Obj x139749079245543 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x139749079245575 = makeCons(MAKE_NUMBER(1), x139749079245543);
-Obj x139749079245607 = makeCons(symcdr, x139749079245575);
-Obj x139749079246439 = makeCons(makeCString("makeCons"), Nil);
-Obj x139749079246471 = makeCons(MAKE_NUMBER(2), x139749079246439);
-Obj x139749079246503 = makeCons(symcons, x139749079246471);
-Obj x139749079247367 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x139749079247399 = makeCons(MAKE_NUMBER(1), x139749079247367);
-Obj x139749079247463 = makeCons(symcons_63, x139749079247399);
-Obj x139749079248295 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x139749079248327 = makeCons(MAKE_NUMBER(2), x139749079248295);
-Obj x139749079248359 = makeCons(sym_43, x139749079248327);
-Obj x139749079228743 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x139749079228775 = makeCons(MAKE_NUMBER(2), x139749079228743);
-Obj x139749079228807 = makeCons(sym_45, x139749079228775);
-Obj x139749079229671 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x139749079229703 = makeCons(MAKE_NUMBER(2), x139749079229671);
-Obj x139749079229735 = makeCons(sym_42, x139749079229703);
-Obj x139749079230535 = makeCons(makeCString("primDiv"), Nil);
-Obj x139749079230567 = makeCons(MAKE_NUMBER(2), x139749079230535);
-Obj x139749079230599 = makeCons(sym_47, x139749079230567);
-Obj x139749079231527 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x139749079231559 = makeCons(MAKE_NUMBER(2), x139749079231527);
-Obj x139749079231591 = makeCons(sym_61, x139749079231559);
-Obj x139749079232423 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x139749079232455 = makeCons(MAKE_NUMBER(2), x139749079232423);
-Obj x139749079232487 = makeCons(sym_62, x139749079232455);
-Obj x139749079208711 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x139749079208743 = makeCons(MAKE_NUMBER(2), x139749079208711);
-Obj x139749079208775 = makeCons(sym_60, x139749079208743);
-Obj x139749079209639 = makeCons(makeCString("primGenSym"), Nil);
-Obj x139749079209671 = makeCons(MAKE_NUMBER(0), x139749079209639);
-Obj x139749079209703 = makeCons(symgensym, x139749079209671);
-Obj x139749079210503 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x139749079210535 = makeCons(MAKE_NUMBER(1), x139749079210503);
-Obj x139749079210567 = makeCons(symsymbol_63, x139749079210535);
-Obj x139749079211399 = makeCons(makeCString("primNot"), Nil);
-Obj x139749079211431 = makeCons(MAKE_NUMBER(1), x139749079211399);
-Obj x139749079211463 = makeCons(symnot, x139749079211431);
-Obj x139749079171335 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x139749079171367 = makeCons(MAKE_NUMBER(1), x139749079171335);
-Obj x139749079171399 = makeCons(syminteger_63, x139749079171367);
-Obj x139749079172199 = makeCons(makeCString("primIsString"), Nil);
-Obj x139749079172231 = makeCons(MAKE_NUMBER(1), x139749079172199);
-Obj x139749079172263 = makeCons(symstring_63, x139749079172231);
-Obj x139749079172327 = makeCons(x139749079172263, Nil);
-Obj x139749079172359 = makeCons(x139749079171399, x139749079172327);
-Obj x139749079172423 = makeCons(x139749079211463, x139749079172359);
-Obj x139749079172455 = makeCons(x139749079210567, x139749079172423);
-Obj x139749079172487 = makeCons(x139749079209703, x139749079172455);
-Obj x139749079172519 = makeCons(x139749079208775, x139749079172487);
-Obj x139749079172551 = makeCons(x139749079232487, x139749079172519);
-Obj x139749079172583 = makeCons(x139749079231591, x139749079172551);
-Obj x139749079172615 = makeCons(x139749079230599, x139749079172583);
-Obj x139749079172647 = makeCons(x139749079229735, x139749079172615);
-Obj x139749079172679 = makeCons(x139749079228807, x139749079172647);
-Obj x139749079172711 = makeCons(x139749079248359, x139749079172679);
-Obj x139749079172743 = makeCons(x139749079247463, x139749079172711);
-Obj x139749079172775 = makeCons(x139749079246503, x139749079172743);
-Obj x139749079172807 = makeCons(x139749079245607, x139749079172775);
-Obj x139749079172839 = makeCons(x139749079760775, x139749079172807);
-Obj x139749079172871 = makeCons(x139749079759879, x139749079172839);
-Obj x139749079172903 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139749079172871);
-Obj x139749079173863 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(27, clofun9, 1, 0));
-Obj x139749079174951 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(24, clofun9, 1, 0));
-Obj x139749079155623 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(21, clofun9, 1, 0));
-Obj x139749079157863 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(18, clofun9, 2, 0));
-Obj x139749079970183 = primSet(co, symcora_47lib_47toc_35parse, makeNative(36, clofun8, 3, 0));
-Obj x139749079783143 = primSet(co, symcora_47lib_47toc_35union, makeNative(30, clofun8, 2, 0));
-Obj x139749079759367 = primSet(co, symcora_47lib_47toc_35diff, makeNative(24, clofun8, 2, 0));
-Obj x139749079155655 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(17, clofun8, 1, 0));
-Obj x139749079784103 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(44, clofun7, 1, 0));
-Obj x139749079142407 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(29, clofun7, 2, 0));
-Obj x139749079143271 = primSet(co, symcora_47lib_47toc_35id, makeNative(28, clofun7, 1, 0));
-Obj x139749080465159 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(10, clofun7, 2, 0));
-Obj x139749079973191 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(0, clofun7, 3, 0));
-Obj x139749079144711 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(32, clofun6, 2, 0));
-Obj x139749078648103 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(12, clofun6, 2, 0));
-Obj x139749078650535 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(8, clofun6, 2, 0));
-Obj x139749078422823 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(6, clofun6, 2, 0));
-Obj x139749080461735 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(42, clofun5, 4, 0));
-Obj x139749080463687 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(39, clofun5, 2, 0));
-Obj x139749080448647 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(5, clofun4, 4, 0));
-Obj x139749079758599 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(31, clofun3, 3, 0));
-Obj x139749079230215 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(25, clofun3, 5, 0));
-Obj x139749079231687 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(24, clofun3, 4, 0));
-Obj x139749079232231 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
-Obj x139749079210087 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(22, clofun3, 3, 0));
-Obj x139749079172167 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(18, clofun3, 3, 0));
-Obj x139749079157319 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(11, clofun3, 3, 0));
-Obj x139749079143751 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(6, clofun3, 3, 0));
-Obj x139749079071623 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(2, clofun3, 4, 0));
-Obj x139749078777383 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(40, clofun2, 3, 0));
-Obj x139749078769959 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(39, clofun2, 2, 0));
-Obj x139749078770695 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(38, clofun2, 1, 0));
-Obj x139749078771239 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(37, clofun2, 1, 0));
-Obj x139749078772071 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(36, clofun2, 1, 0));
-Obj x139749078648839 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(30, clofun2, 1, 0));
-Obj x139749078422919 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(27, clofun2, 2, 0));
+Obj x139886475386215 = __arg1;
+Obj x139886475386375 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
+Obj x139886475331943 = primSet(co, symcora_47lib_47toc_35assq, makeNative(37, clofun8, 2, 0));
+Obj x139886475333031 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(35, clofun8, 3, 0));
+Obj x139886475269671 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(33, clofun8, 3, 0));
+Obj x139886475269959 = primSet(co, symcora_47lib_47toc_35index, makeNative(32, clofun8, 2, 0));
+Obj x139886475271207 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(30, clofun8, 2, 0));
+Obj x139886475271623 = makeCons(makeCString("primSet"), Nil);
+Obj x139886475271655 = makeCons(MAKE_NUMBER(2), x139886475271623);
+Obj x139886475271687 = makeCons(symset, x139886475271655);
+Obj x139886475271975 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x139886475272007 = makeCons(MAKE_NUMBER(1), x139886475271975);
+Obj x139886475272039 = makeCons(symcar, x139886475272007);
+Obj x139886475243655 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x139886475243687 = makeCons(MAKE_NUMBER(1), x139886475243655);
+Obj x139886475243719 = makeCons(symcdr, x139886475243687);
+Obj x139886475244007 = makeCons(makeCString("makeCons"), Nil);
+Obj x139886475244039 = makeCons(MAKE_NUMBER(2), x139886475244007);
+Obj x139886475244071 = makeCons(symcons, x139886475244039);
+Obj x139886475244359 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x139886475244391 = makeCons(MAKE_NUMBER(1), x139886475244359);
+Obj x139886475244423 = makeCons(symcons_63, x139886475244391);
+Obj x139886475244775 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x139886475244807 = makeCons(MAKE_NUMBER(2), x139886475244775);
+Obj x139886475244839 = makeCons(sym_43, x139886475244807);
+Obj x139886475245127 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x139886475245159 = makeCons(MAKE_NUMBER(2), x139886475245127);
+Obj x139886475245191 = makeCons(sym_45, x139886475245159);
+Obj x139886475245479 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x139886475245511 = makeCons(MAKE_NUMBER(2), x139886475245479);
+Obj x139886475245543 = makeCons(sym_42, x139886475245511);
+Obj x139886475245831 = makeCons(makeCString("primDiv"), Nil);
+Obj x139886475245863 = makeCons(MAKE_NUMBER(2), x139886475245831);
+Obj x139886475245895 = makeCons(sym_47, x139886475245863);
+Obj x139886475246183 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x139886475246215 = makeCons(MAKE_NUMBER(2), x139886475246183);
+Obj x139886475246247 = makeCons(sym_61, x139886475246215);
+Obj x139886475246535 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x139886475246567 = makeCons(MAKE_NUMBER(2), x139886475246535);
+Obj x139886475246599 = makeCons(sym_62, x139886475246567);
+Obj x139886475246887 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x139886475246919 = makeCons(MAKE_NUMBER(2), x139886475246887);
+Obj x139886475246951 = makeCons(sym_60, x139886475246919);
+Obj x139886475247239 = makeCons(makeCString("primGenSym"), Nil);
+Obj x139886475247271 = makeCons(MAKE_NUMBER(0), x139886475247239);
+Obj x139886475247303 = makeCons(symgensym, x139886475247271);
+Obj x139886475247591 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x139886475190279 = makeCons(MAKE_NUMBER(1), x139886475247591);
+Obj x139886475190311 = makeCons(symsymbol_63, x139886475190279);
+Obj x139886475190599 = makeCons(makeCString("primNot"), Nil);
+Obj x139886475190631 = makeCons(MAKE_NUMBER(1), x139886475190599);
+Obj x139886475190663 = makeCons(symnot, x139886475190631);
+Obj x139886475190951 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x139886475190983 = makeCons(MAKE_NUMBER(1), x139886475190951);
+Obj x139886475191015 = makeCons(syminteger_63, x139886475190983);
+Obj x139886475191303 = makeCons(makeCString("primIsString"), Nil);
+Obj x139886475191335 = makeCons(MAKE_NUMBER(1), x139886475191303);
+Obj x139886475191367 = makeCons(symstring_63, x139886475191335);
+Obj x139886475191399 = makeCons(x139886475191367, Nil);
+Obj x139886475191431 = makeCons(x139886475191015, x139886475191399);
+Obj x139886475191463 = makeCons(x139886475190663, x139886475191431);
+Obj x139886475191495 = makeCons(x139886475190311, x139886475191463);
+Obj x139886475191527 = makeCons(x139886475247303, x139886475191495);
+Obj x139886475191559 = makeCons(x139886475246951, x139886475191527);
+Obj x139886475191591 = makeCons(x139886475246599, x139886475191559);
+Obj x139886475191623 = makeCons(x139886475246247, x139886475191591);
+Obj x139886475191655 = makeCons(x139886475245895, x139886475191623);
+Obj x139886475191687 = makeCons(x139886475245543, x139886475191655);
+Obj x139886475191719 = makeCons(x139886475245191, x139886475191687);
+Obj x139886475191751 = makeCons(x139886475244839, x139886475191719);
+Obj x139886475191783 = makeCons(x139886475244423, x139886475191751);
+Obj x139886475191815 = makeCons(x139886475244071, x139886475191783);
+Obj x139886475191847 = makeCons(x139886475243719, x139886475191815);
+Obj x139886475191879 = makeCons(x139886475272039, x139886475191847);
+Obj x139886475191911 = makeCons(x139886475271687, x139886475191879);
+Obj x139886475191943 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139886475191911);
+Obj x139886475192455 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(27, clofun8, 1, 0));
+Obj x139886475193063 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(24, clofun8, 1, 0));
+Obj x139886475193671 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(21, clofun8, 1, 0));
+Obj x139886475182119 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(20, clofun8, 2, 0));
+Obj x139886475597863 = primSet(co, symcora_47lib_47toc_35parse, makeNative(38, clofun7, 3, 0));
+Obj x139886475567335 = primSet(co, symcora_47lib_47toc_35union, makeNative(34, clofun7, 2, 0));
+Obj x139886475569639 = primSet(co, symcora_47lib_47toc_35diff, makeNative(30, clofun7, 2, 0));
+Obj x139886475461351 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(24, clofun7, 1, 0));
+Obj x139886474651463 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(4, clofun7, 1, 0));
+Obj x139886474552167 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(42, clofun6, 2, 0));
+Obj x139886474552583 = primSet(co, symcora_47lib_47toc_35id, makeNative(41, clofun6, 1, 0));
+Obj x139886475984647 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(25, clofun6, 2, 0));
+Obj x139886475567463 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(18, clofun6, 3, 0));
+Obj x139886475464199 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(3, clofun6, 2, 0));
+Obj x139886475243527 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(44, clofun5, 2, 0));
+Obj x139886475245703 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(40, clofun5, 2, 0));
+Obj x139886475247175 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(38, clofun5, 2, 0));
+Obj x139886475183367 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(26, clofun5, 4, 0));
+Obj x139886475184391 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(23, clofun5, 2, 0));
+Obj x139886475570439 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(40, clofun3, 4, 0));
+Obj x139886475463175 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(16, clofun3, 3, 0));
+Obj x139886475383879 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(12, clofun3, 5, 0));
+Obj x139886475384359 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(11, clofun3, 4, 0));
+Obj x139886475384743 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
+Obj x139886475385831 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(9, clofun3, 3, 0));
+Obj x139886475330023 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(5, clofun3, 3, 0));
+Obj x139886475333319 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(48, clofun2, 3, 0));
+Obj x139886475269543 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(43, clofun2, 3, 0));
+Obj x139886475271847 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(41, clofun2, 4, 0));
+Obj x139886474650055 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(30, clofun2, 3, 0));
+Obj x139886474650599 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(29, clofun2, 2, 0));
+Obj x139886474651111 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(28, clofun2, 1, 0));
+Obj x139886474651559 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(27, clofun2, 1, 0));
+Obj x139886474652135 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(26, clofun2, 1, 0));
+Obj x139886474642151 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(20, clofun2, 1, 0));
+Obj x139886474643911 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(19, clofun2, 2, 0));
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
 __arg1 = sym_45_62;
-__arg2 = makeNative(24, clofun2, 1, 0);
+__arg2 = makeNative(16, clofun2, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -466,24 +465,24 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139749078424007 = __arg1;
-Obj x139749078413383 = primSet(co, symcora_47lib_47toc_35compile, makeNative(18, clofun2, 2, 0));
-Obj x139749078416423 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(14, clofun2, 2, 0));
-Obj x139749078343239 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(10, clofun2, 3, 0));
-Obj x139749078145607 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(38, clofun1, 3, 0));
-Obj x139749078077255 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(32, clofun1, 4, 0));
-Obj x139749078052423 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(19, clofun1, 2, 0));
-Obj x139749080648519 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(6, clofun1, 3, 0));
-Obj x139749080352007 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(49, clofun0, 1, 0));
-Obj x139749079210663 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(42, clofun0, 4, 0));
-Obj x139749078842951 = primSet(co, symcora_47lib_47toc_35extract_45typecheck_45body, makeNative(32, clofun0, 2, 0));
-Obj x139749078823335 = primSet(co, symcora_47lib_47toc_35generate_45typecheck_45code, makeNative(31, clofun0, 2, 0));
-Obj x139749078776391 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code_45toplevel, makeNative(21, clofun0, 1, 0));
-Obj x139749078776871 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
-Obj x139749078649063 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
-Obj x139749078422599 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
+Obj x139886474644935 = __arg1;
+Obj x139886474580551 = primSet(co, symcora_47lib_47toc_35compile, makeNative(10, clofun2, 2, 0));
+Obj x139886474582439 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(8, clofun2, 2, 0));
+Obj x139886474551847 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(4, clofun2, 3, 0));
+Obj x139886474307143 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(32, clofun1, 3, 0));
+Obj x139886474257575 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(28, clofun1, 4, 0));
+Obj x139886474141703 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(15, clofun1, 2, 0));
+Obj x139886474144327 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(2, clofun1, 3, 0));
+Obj x139886476799943 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(46, clofun0, 1, 0));
+Obj x139886477022407 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(41, clofun0, 4, 0));
+Obj x139886476724135 = primSet(co, symcora_47lib_47toc_35extract_45typecheck_45body, makeNative(32, clofun0, 2, 0));
+Obj x139886476724487 = primSet(co, symcora_47lib_47toc_35generate_45typecheck_45code, makeNative(31, clofun0, 2, 0));
+Obj x139886476145671 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code_45toplevel, makeNative(22, clofun0, 1, 0));
+Obj x139886476146119 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
+Obj x139886476106151 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
+Obj x139886476080583 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
 __nargs = 2;
-__arg1 = x139749078422599;
+__arg1 = x139886476080583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -493,9 +492,9 @@ label5:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-Obj x139749078649575 = primGenSym();
-Obj globals = x139749078649575;
-Obj x139749078649991 = primSet(co, globals, Nil);
+Obj x139886476107047 = primGenSym();
+Obj globals = x139886476107047;
+Obj x139886476107303 = primSet(co, globals, Nil);
 pushCont(co, 6, clofun0, 3, from, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35compile);
@@ -509,11 +508,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139749078650599 = __arg1;
+Obj x139886476107655 = __arg1;
 Obj from= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun0, 3, x139749078650599, to, globals);
+pushCont(co, 7, clofun0, 3, x139886476107655, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35preprocess);
 __arg1 = from;
@@ -526,14 +525,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139749078421639 = __arg1;
-Obj x139749078650599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476079463 = __arg1;
+Obj x139886476107655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun0, 3, x139749078650599, to, globals);
+pushCont(co, 8, clofun0, 3, x139886476107655, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand);
-__arg1 = x139749078421639;
+__arg1 = x139886476079463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -543,14 +542,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139749078421671 = __arg1;
-Obj x139749078650599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476079495 = __arg1;
+Obj x139886476107655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 9, clofun0, 2, to, globals);
 __nargs = 2;
-__arg0 = x139749078650599;
-__arg1 = x139749078421671;
+__arg0 = x139886476107655;
+__arg1 = x139886476079495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -560,10 +559,10 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139749078421735 = __arg1;
+Obj x139886476079527 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj bc = x139749078421735;
+Obj bc = x139886476079527;
 pushCont(co, 10, clofun0, 2, bc, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35open_45output_45file);
@@ -577,10 +576,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139749078421991 = __arg1;
+Obj x139886476079911 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stream = x139749078421991;
+Obj stream = x139886476079911;
 pushCont(co, 11, clofun0, 1, stream);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45c);
@@ -596,7 +595,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139749078422375 = __arg1;
+Obj x139886476080295 = __arg1;
 Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35close_45output_45file);
@@ -624,9 +623,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139749078777639 = __arg1;
-Obj sexp = x139749078777639;
-pushCont(co, 14, clofun0, 1, sexp);
+Obj x139886476146663 = __arg1;
+Obj sexp = x139886476146663;
+Obj x139886476185639 = makeNative(21, clofun0, 1, 1, sexp);
+pushCont(co, 14, clofun0, 2, x139886476185639, sexp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35pair_63);
 __arg1 = sexp;
@@ -639,99 +639,53 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139749078769991 = __arg1;
-Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139749078769991) {
-Obj x139749078770503 = PRIM_CAR(sexp);
-Obj x139749078770535 = PRIM_EQ(symbegin, x139749078770503);
-if (True == x139749078770535) {
-if (True == True) {
-Obj x139749078770887 = PRIM_CDR(sexp);
-Obj sexp1 = x139749078770887;
-pushCont(co, 20, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078771847 = makeCons(sexp, Nil);
-Obj sexp1 = x139749078771847;
+Obj x139886476148455 = __arg1;
+Obj x139886476185639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886476148455) {
+Obj x139886476103975 = PRIM_CAR(sexp);
+Obj x139886476104007 = PRIM_EQ(symbegin, x139886476103975);
+if (True == x139886476104007) {
 pushCont(co, 19, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj x139749078772615 = PRIM_CDR(sexp);
-Obj sexp1 = x139749078772615;
-pushCont(co, 18, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
+__arg0 = x139886476185639;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078773703 = makeCons(sexp, Nil);
-Obj sexp1 = x139749078773703;
 pushCont(co, 17, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
+__arg0 = x139886476185639;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
 } else {
-if (True == False) {
-Obj x139749078647559 = PRIM_CDR(sexp);
-Obj sexp1 = x139749078647559;
-pushCont(co, 16, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078648295 = makeCons(sexp, Nil);
-Obj sexp1 = x139749078648295;
 pushCont(co, 15, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = sexp;
+__arg0 = x139886476185639;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 }
 
 label15:
 {
-Obj x139749078648775 = __arg1;
+Obj x139886476105671 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 16, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -742,7 +696,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139749078647815 = __arg1;
+Obj x139886476106055 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
@@ -756,10 +710,11 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139749078647111 = __arg1;
+Obj x139886476105287 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 18, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -770,7 +725,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139749078773063 = __arg1;
+Obj x139886476105575 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
@@ -784,10 +739,11 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139749078772135 = __arg1;
+Obj x139886476104071 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 20, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -798,7 +754,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139749078771143 = __arg1;
+Obj x139886476105191 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
@@ -812,20 +768,40 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139749080445127 = __arg1;
-Obj x139749080445351 = makeNative(24, clofun0, 0, 1, x139749080445127);
-Obj x139749078773799 = PRIM_ISCONS(x139749080445127);
-if (True == x139749078773799) {
-Obj x139749078774375 = PRIM_CAR(x139749080445127);
-Obj x139749078774407 = PRIM_EQ(sympackage, x139749078774375);
-if (True == x139749078774407) {
-Obj x139749078774695 = PRIM_CDR(x139749080445127);
-Obj more = x139749078774695;
-Obj x139749078775271 = makeCons(sympackage, more);
+Obj x139886476185959 = __arg1;
+if (True == x139886476185959) {
+Obj x139886476147655 = PRIM_CDR(closureRef(co, 0));
+__nargs = 2;
+__arg1 = x139886476147655;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476147879 = makeCons(closureRef(co, 0), Nil);
+__nargs = 2;
+__arg1 = x139886476147879;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label22:
+{
+Obj x139886476185799 = __arg1;
+Obj x139886476187271 = makeNative(25, clofun0, 0, 1, x139886476185799);
+Obj x139886476188135 = PRIM_ISCONS(x139886476185799);
+if (True == x139886476188135) {
+Obj x139886476188615 = PRIM_CAR(x139886476185799);
+Obj x139886476188647 = PRIM_EQ(sympackage, x139886476188615);
+if (True == x139886476188647) {
+Obj x139886476189319 = PRIM_CDR(x139886476185799);
+Obj more = x139886476189319;
+Obj x139886476144743 = makeCons(sympackage, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = x139749078775271;
-__arg2 = makeNative(22, clofun0, 1, 0);
+__arg1 = x139886476144743;
+__arg2 = makeNative(23, clofun0, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -833,7 +809,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080445351;
+__arg0 = x139886476187271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -842,7 +818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080445351;
+__arg0 = x139886476187271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -851,7 +827,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label22:
+label23:
 {
 Obj body = __arg1;
 __nargs = 5;
@@ -859,22 +835,7 @@ __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = body;
 __arg2 = Nil;
 __arg3 = Nil;
-co->args[4] = makeNative(23, clofun0, 2, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label23:
-{
-Obj type = __arg1;
-Obj code = __arg2;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
-__arg1 = type;
-__arg2 = code;
+co->args[4] = makeNative(24, clofun0, 2, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -884,19 +845,34 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139749080445959 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
-Obj x139749078806823 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078806823) {
-Obj x139749078807463 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078807719 = PRIM_EQ(symbegin, x139749078807463);
-if (True == x139749078807719) {
-Obj x139749078808231 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749078808231;
-Obj x139749078808935 = makeCons(symbegin, more);
+Obj type = __arg1;
+Obj code = __arg2;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label25:
+{
+Obj x139886476188871 = makeNative(28, clofun0, 0, 1, closureRef(co, 0));
+Obj x139886476725575 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476725575) {
+Obj x139886476725831 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476725863 = PRIM_EQ(symbegin, x139886476725831);
+if (True == x139886476725863) {
+Obj x139886476726055 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886476726055;
+Obj x139886476726215 = makeCons(symbegin, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = x139749078808935;
-__arg2 = makeNative(25, clofun0, 1, 0);
+__arg1 = x139886476726215;
+__arg2 = makeNative(26, clofun0, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -904,7 +880,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080445959;
+__arg0 = x139886476188871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -913,7 +889,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080445959;
+__arg0 = x139886476188871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -922,7 +898,7 @@ goto *jumpTable[ps.label];
 }
 }
 
-label25:
+label26:
 {
 Obj body = __arg1;
 __nargs = 5;
@@ -930,22 +906,7 @@ __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = body;
 __arg2 = Nil;
 __arg3 = Nil;
-co->args[4] = makeNative(26, clofun0, 2, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label26:
-{
-Obj type = __arg1;
-Obj code = __arg2;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
-__arg1 = type;
-__arg2 = code;
+co->args[4] = makeNative(27, clofun0, 2, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -955,27 +916,8 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139749080446503 = makeNative(30, clofun0, 0, 0);
-Obj single = closureRef(co, 0);
-Obj x139749078825735 = makeCons(single, Nil);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = x139749078825735;
-__arg2 = Nil;
-__arg3 = Nil;
-co->args[4] = makeNative(28, clofun0, 2, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label28:
-{
 Obj type = __arg1;
 Obj code = __arg2;
-PUSH_CONT_0(co, 29, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
 __arg1 = type;
@@ -987,27 +929,47 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label29:
+label28:
 {
-Obj x139749078826759 = __arg1;
-Obj x139749078806567 = makeCons(symbegin, x139749078826759);
-__nargs = 2;
-__arg1 = x139749078806567;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label30:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Obj x139886476725127 = makeCons(closureRef(co, 0), Nil);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
+__arg1 = x139886476725127;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(29, clofun0, 2, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj type = __arg1;
+Obj code = __arg2;
+PUSH_CONT_0(co, 30, clofun0);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886476725351 = __arg1;
+Obj x139886476725383 = makeCons(symbegin, x139886476725351);
+__nargs = 2;
+__arg1 = x139886476725383;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label31:
@@ -1035,29 +997,28 @@ goto *jumpTable[co->ctx.pc.label];
 
 label32:
 {
-Obj x139749080476327 = __arg1;
-Obj x139749080476359 = __arg2;
-Obj x139749080476743 = makeNative(34, clofun0, 0, 2, x139749080476327, x139749080476359);
-Obj x139749078980679 = PRIM_ISCONS(x139749080476327);
-if (True == x139749078980679) {
-Obj x139749078981479 = PRIM_CAR(x139749080476327);
-Obj x139749078981511 = PRIM_EQ(sympackage, x139749078981479);
-if (True == x139749078981511) {
-Obj x139749078839367 = PRIM_CDR(x139749080476327);
-Obj x139749078839399 = PRIM_ISCONS(x139749078839367);
-if (True == x139749078839399) {
-Obj x139749078839943 = PRIM_CDR(x139749080476327);
-Obj x139749078840231 = PRIM_CAR(x139749078839943);
-Obj name = x139749078840231;
-Obj x139749078840935 = PRIM_CDR(x139749080476327);
-Obj x139749078840999 = PRIM_CDR(x139749078840935);
-Obj more = x139749078840999;
-Obj k = x139749080476359;
+Obj x139886476186727 = __arg1;
+Obj x139886476186759 = __arg2;
+Obj x139886476189095 = makeNative(34, clofun0, 0, 2, x139886476186727, x139886476186759);
+Obj x139886476799303 = PRIM_ISCONS(x139886476186727);
+if (True == x139886476799303) {
+Obj x139886476799591 = PRIM_CAR(x139886476186727);
+Obj x139886476799687 = PRIM_EQ(sympackage, x139886476799591);
+if (True == x139886476799687) {
+Obj x139886476799911 = PRIM_CDR(x139886476186727);
+Obj x139886476799975 = PRIM_ISCONS(x139886476799911);
+if (True == x139886476799975) {
+Obj x139886476723335 = PRIM_CDR(x139886476186727);
+Obj x139886476723367 = PRIM_CAR(x139886476723335);
+Obj name = x139886476723367;
+Obj x139886476723591 = PRIM_CDR(x139886476186727);
+Obj x139886476723623 = PRIM_CDR(x139886476723591);
+Obj more = x139886476723623;
 pushCont(co, 33, clofun0, 1, name);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
 __arg1 = more;
-__arg2 = k;
+__arg2 = x139886476186759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1065,16 +1026,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080476743;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080476743;
+__arg0 = x139886476189095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1083,7 +1035,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080476743;
+__arg0 = x139886476189095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476189095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1094,12 +1055,12 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139749078842183 = __arg1;
+Obj x139886476723847 = __arg1;
 Obj name= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749078842215 = makeCons(name, x139749078842183);
-Obj x139749078842247 = makeCons(sympackage, x139749078842215);
+Obj x139886476723879 = makeCons(name, x139886476723847);
+Obj x139886476723911 = makeCons(sympackage, x139886476723879);
 __nargs = 2;
-__arg1 = x139749078842247;
+__arg1 = x139886476723911;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1107,39 +1068,38 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj x139749080461543 = makeNative(36, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079146119 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079146119) {
-Obj x139749079069159 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079069191 = PRIM_ISCONS(x139749079069159);
-if (True == x139749079069191) {
-Obj x139749079070311 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079070343 = PRIM_CAR(x139749079070311);
-Obj x139749079070375 = PRIM_EQ(symimport, x139749079070343);
-if (True == x139749079070375) {
-Obj x139749079071655 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079071687 = PRIM_CDR(x139749079071655);
-Obj x139749079071719 = PRIM_ISCONS(x139749079071687);
-if (True == x139749079071719) {
-Obj x139749079072743 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079044103 = PRIM_CDR(x139749079072743);
-Obj x139749079044135 = PRIM_CAR(x139749079044103);
-Obj pkg = x139749079044135;
-Obj x139749079045639 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079045927 = PRIM_CDR(x139749079045639);
-Obj x139749079045959 = PRIM_CDR(x139749079045927);
-Obj x139749079046087 = PRIM_EQ(Nil, x139749079045959);
-if (True == x139749079046087) {
-Obj x139749079046471 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079046471;
-Obj k = closureRef(co, 1);
-Obj x139749079047687 = makeCons(pkg, Nil);
-Obj x139749079047719 = makeCons(symimport, x139749079047687);
-pushCont(co, 35, clofun0, 1, x139749079047719);
+Obj x139886476147143 = makeNative(36, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886477008647 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477008647) {
+Obj x139886476795975 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476796007 = PRIM_ISCONS(x139886476795975);
+if (True == x139886476796007) {
+Obj x139886476796359 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476796391 = PRIM_CAR(x139886476796359);
+Obj x139886476796423 = PRIM_EQ(symimport, x139886476796391);
+if (True == x139886476796423) {
+Obj x139886476796903 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476796935 = PRIM_CDR(x139886476796903);
+Obj x139886476796967 = PRIM_ISCONS(x139886476796935);
+if (True == x139886476796967) {
+Obj x139886476797383 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476797415 = PRIM_CDR(x139886476797383);
+Obj x139886476797447 = PRIM_CAR(x139886476797415);
+Obj pkg = x139886476797447;
+Obj x139886476797863 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476797895 = PRIM_CDR(x139886476797863);
+Obj x139886476797927 = PRIM_CDR(x139886476797895);
+Obj x139886476797959 = PRIM_EQ(Nil, x139886476797927);
+if (True == x139886476797959) {
+Obj x139886476798215 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886476798215;
+Obj x139886476798471 = makeCons(pkg, Nil);
+Obj x139886476798503 = makeCons(symimport, x139886476798471);
+pushCont(co, 35, clofun0, 1, x139886476798503);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
 __arg1 = more;
-__arg2 = k;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1147,16 +1107,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080461543;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461543;
+__arg0 = x139886476147143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1165,7 +1116,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080461543;
+__arg0 = x139886476147143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1174,7 +1125,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080461543;
+__arg0 = x139886476147143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1183,7 +1134,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080461543;
+__arg0 = x139886476147143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476147143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1194,11 +1154,11 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139749078978919 = __arg1;
-Obj x139749079047719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749078978951 = makeCons(x139749079047719, x139749078978919);
+Obj x139886476798663 = __arg1;
+Obj x139886476798503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476798695 = makeCons(x139886476798503, x139886476798663);
 __nargs = 2;
-__arg1 = x139749078978951;
+__arg1 = x139886476798695;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1206,28 +1166,27 @@ goto *jumpTable[co->ctx.pc.label];
 
 label36:
 {
-Obj x139749080462919 = makeNative(38, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079156807 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079156807) {
-Obj x139749079157575 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079157607 = PRIM_ISCONS(x139749079157575);
-if (True == x139749079157607) {
-Obj x139749079158727 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079158759 = PRIM_CAR(x139749079158727);
-Obj x139749079142471 = PRIM_EQ(symexport, x139749079158759);
-if (True == x139749079142471) {
-Obj x139749079143367 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079143399 = PRIM_CDR(x139749079143367);
-Obj symbols = x139749079143399;
-Obj x139749079143719 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079143719;
-Obj k = closureRef(co, 1);
-Obj x139749079144583 = makeCons(symexport, symbols);
-pushCont(co, 37, clofun0, 1, x139749079144583);
+Obj x139886476106407 = makeNative(38, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886477006407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477006407) {
+Obj x139886477006695 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477006759 = PRIM_ISCONS(x139886477006695);
+if (True == x139886477006759) {
+Obj x139886477007111 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477007143 = PRIM_CAR(x139886477007111);
+Obj x139886477007175 = PRIM_EQ(symexport, x139886477007143);
+if (True == x139886477007175) {
+Obj x139886477007463 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477007495 = PRIM_CDR(x139886477007463);
+Obj symbols = x139886477007495;
+Obj x139886477007751 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886477007751;
+Obj x139886477007911 = makeCons(symexport, symbols);
+pushCont(co, 37, clofun0, 1, x139886477007911);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
 __arg1 = more;
-__arg2 = k;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1235,16 +1194,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080462919;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080462919;
+__arg0 = x139886476106407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1253,7 +1203,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080462919;
+__arg0 = x139886476106407;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476106407;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1264,11 +1223,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139749079145031 = __arg1;
-Obj x139749079144583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079145063 = makeCons(x139749079144583, x139749079145031);
+Obj x139886477008135 = __arg1;
+Obj x139886477007911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886477008167 = makeCons(x139886477007911, x139886477008135);
 __nargs = 2;
-__arg1 = x139749079145063;
+__arg1 = x139886477008167;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1276,20 +1235,19 @@ goto *jumpTable[co->ctx.pc.label];
 
 label38:
 {
-Obj x139749080463975 = makeNative(40, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079173511 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079173511) {
-Obj x139749079174567 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079174599 = PRIM_EQ(symbegin, x139749079174567);
-if (True == x139749079174599) {
-Obj x139749079175111 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079175111;
-Obj k = closureRef(co, 1);
+Obj x139886476080903 = makeNative(40, clofun0, 0, 2, closureRef(co, 1), closureRef(co, 0));
+Obj x139886477004871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477004871) {
+Obj x139886477005223 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477005287 = PRIM_EQ(symbegin, x139886477005223);
+if (True == x139886477005287) {
+Obj x139886477005479 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886477005479;
 PUSH_CONT_0(co, 39, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
 __arg1 = more;
-__arg2 = k;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1297,7 +1255,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080463975;
+__arg0 = x139886476080903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1306,7 +1264,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080463975;
+__arg0 = x139886476080903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1317,10 +1275,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139749079155911 = __arg1;
-Obj x139749079156071 = makeCons(symbegin, x139749079155911);
+Obj x139886477005895 = __arg1;
+Obj x139886477005927 = makeCons(symbegin, x139886477005895);
 __nargs = 2;
-__arg1 = x139749079156071;
+__arg1 = x139886477005927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1328,12 +1286,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label40:
 {
-Obj x139749080464775 = makeNative(41, clofun0, 0, 0);
-Obj other = closureRef(co, 0);
-Obj k = closureRef(co, 1);
 __nargs = 2;
-__arg0 = k;
-__arg1 = other;
+__arg0 = closureRef(co, 0);
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1343,32 +1298,45 @@ goto *jumpTable[ps.label];
 
 label41:
 {
+Obj x139886476104999 = __arg1;
+Obj x139886476105031 = __arg2;
+Obj x139886476105063 = __arg3;
+Obj x139886476105095 = co->args[4];
+Obj x139886477021479 = PRIM_EQ(Nil, x139886476104999);
+if (True == x139886477021479) {
+pushCont(co, 44, clofun0, 2, x139886476105063, x139886476105095);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886476105031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label42:
-{
-Obj x139749080649479 = __arg1;
-Obj x139749080649511 = __arg2;
-Obj x139749080649543 = __arg3;
-Obj x139749080649575 = co->args[4];
-Obj x139749080523431 = makeNative(45, clofun0, 0, 4, x139749080649479, x139749080649511, x139749080649543, x139749080649575);
-Obj x139749079208423 = PRIM_EQ(Nil, x139749080649479);
-if (True == x139749079208423) {
-Obj type = x139749080649511;
-Obj code = x139749080649543;
-Obj k = x139749080649575;
-pushCont(co, 43, clofun0, 2, code, k);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = type;
+} else {
+Obj x139886476082887 = makeNative(42, clofun0, 0, 4, x139886476104999, x139886476105031, x139886476105063, x139886476105095);
+Obj x139886476722695 = PRIM_ISCONS(x139886476104999);
+if (True == x139886476722695) {
+Obj x139886476722919 = PRIM_CAR(x139886476104999);
+Obj x139886476722951 = PRIM_ISCONS(x139886476722919);
+if (True == x139886476722951) {
+Obj x139886477021287 = PRIM_CAR(x139886476104999);
+Obj x139886477021319 = PRIM_CAR(x139886477021287);
+Obj x139886477021351 = PRIM_EQ(sym_58type, x139886477021319);
+if (True == x139886477021351) {
+Obj x139886477021607 = PRIM_CAR(x139886476104999);
+Obj x139886477021671 = PRIM_CDR(x139886477021607);
+Obj exp = x139886477021671;
+Obj x139886477021863 = PRIM_CDR(x139886476104999);
+Obj more = x139886477021863;
+Obj x139886477022087 = makeCons(symbegin, exp);
+Obj x139886477022119 = makeCons(x139886477022087, x139886476105031);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
+__arg1 = more;
+__arg2 = x139886477022119;
+__arg3 = x139886476105063;
+co->args[4] = x139886476105095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1376,7 +1344,85 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080523431;
+__arg0 = x139886476082887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476082887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476082887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label42:
+{
+Obj x139886475596263 = makeNative(43, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886477023943 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477023943) {
+Obj x139886477024199 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477024231 = PRIM_ISCONS(x139886477024199);
+if (True == x139886477024231) {
+Obj x139886477024551 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477024583 = PRIM_CAR(x139886477024551);
+Obj x139886477024615 = PRIM_EQ(sym_58declare, x139886477024583);
+if (True == x139886477024615) {
+Obj x139886477024871 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477024903 = PRIM_CDR(x139886477024871);
+Obj exp = x139886477024903;
+Obj x139886477025095 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886477025095;
+Obj x139886476722215 = makeCons(symdeclare, exp);
+Obj x139886476722279 = makeCons(x139886476722215, closureRef(co, 1));
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
+__arg1 = more;
+__arg2 = x139886476722279;
+__arg3 = closureRef(co, 2);
+co->args[4] = closureRef(co, 3);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475596263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475596263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475596263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1387,206 +1433,34 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139749079209895 = __arg1;
-Obj code= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 44, clofun0, 2, k, x139749079209895);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = code;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label44:
-{
-Obj x139749079210407 = __arg1;
-Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079209895= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = k;
-__arg1 = x139749079209895;
-__arg2 = x139749079210407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj x139749080524551 = makeNative(46, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749079246311 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079246311) {
-Obj x139749079247239 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079247303 = PRIM_ISCONS(x139749079247239);
-if (True == x139749079247303) {
-Obj x139749079248775 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079248807 = PRIM_CAR(x139749079248775);
-Obj x139749079248839 = PRIM_EQ(sym_58type, x139749079248807);
-if (True == x139749079248839) {
-Obj x139749079229127 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079229159 = PRIM_CDR(x139749079229127);
-Obj exp = x139749079229159;
-Obj x139749079229895 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079229895;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj x139749079231335 = makeCons(symbegin, exp);
-Obj x139749079231719 = makeCons(x139749079231335, type);
+Obj x139886477022183 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477022183) {
+Obj x139886477022375 = PRIM_CAR(closureRef(co, 0));
+Obj exp = x139886477022375;
+Obj x139886477022567 = PRIM_CDR(closureRef(co, 0));
+Obj more = x139886477022567;
+Obj x139886477023111 = makeCons(exp, Nil);
+Obj x139886477023143 = makeCons(symbackquote, x139886477023111);
+Obj x139886477023175 = makeCons(x139886477023143, Nil);
+Obj x139886477023207 = makeCons(symmacroexpand, x139886477023175);
+Obj x139886477023367 = makeCons(symcora_47lib_47infer_35tvar, Nil);
+Obj x139886477023399 = makeCons(x139886477023367, Nil);
+Obj x139886477023431 = makeCons(x139886477023207, x139886477023399);
+Obj x139886477023463 = makeCons(symcora_47lib_47infer_35check_45type_33, x139886477023431);
+Obj x139886477023527 = makeCons(x139886477023463, closureRef(co, 1));
+Obj x139886477023655 = makeCons(exp, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = x139749079231719;
-__arg3 = code;
-co->args[4] = k;
+__arg2 = x139886477023527;
+__arg3 = x139886477023655;
+co->args[4] = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080524551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080524551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080524551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label46:
-{
-Obj x139749080526087 = makeNative(47, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749079784551 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079784551) {
-Obj x139749079785159 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079785191 = PRIM_ISCONS(x139749079785159);
-if (True == x139749079785191) {
-Obj x139749079757895 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079757927 = PRIM_CAR(x139749079757895);
-Obj x139749079758023 = PRIM_EQ(sym_58declare, x139749079757927);
-if (True == x139749079758023) {
-Obj x139749079758791 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079758823 = PRIM_CDR(x139749079758791);
-Obj exp = x139749079758823;
-Obj x139749079759303 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079759303;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj x139749079760679 = makeCons(symdeclare, exp);
-Obj x139749079760871 = makeCons(x139749079760679, type);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = more;
-__arg2 = x139749079760871;
-__arg3 = code;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080526087;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080526087;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080526087;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label47:
-{
-Obj x139749080474535 = makeNative(48, clofun0, 0, 0);
-Obj x139749080354759 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080354759) {
-Obj x139749079970119 = PRIM_CAR(closureRef(co, 0));
-Obj exp = x139749079970119;
-Obj x139749079971367 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139749079971367;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj x139749079782087 = makeCons(exp, Nil);
-Obj x139749079782119 = makeCons(symbackquote, x139749079782087);
-Obj x139749079782215 = makeCons(x139749079782119, Nil);
-Obj x139749079782247 = makeCons(symmacroexpand, x139749079782215);
-Obj x139749079782983 = makeCons(symcora_47lib_47infer_35tvar, Nil);
-Obj x139749079783079 = makeCons(x139749079782983, Nil);
-Obj x139749079783303 = makeCons(x139749079782247, x139749079783079);
-Obj x139749079783335 = makeCons(symcora_47lib_47infer_35check_45type_33, x139749079783303);
-Obj x139749079783431 = makeCons(x139749079783335, type);
-Obj x139749079783815 = makeCons(exp, code);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = more;
-__arg2 = x139749079783431;
-__arg3 = x139749079783815;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080474535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label48:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
@@ -1596,25 +1470,57 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
-label49:
+label44:
 {
-Obj x139749080363271 = __arg1;
-Obj x139749080363495 = makeNative(0, clofun1, 0, 1, x139749080363271);
-Obj x139749080363047 = PRIM_ISCONS(x139749080363271);
-if (True == x139749080363047) {
-Obj x139749080364007 = PRIM_CAR(x139749080363271);
-Obj x139749080364039 = PRIM_EQ(sympackage, x139749080364007);
-if (True == x139749080364039) {
-Obj x139749080364967 = PRIM_CDR(x139749080363271);
-Obj x139749080365031 = PRIM_ISCONS(x139749080364967);
-if (True == x139749080365031) {
-Obj x139749080366055 = PRIM_CDR(x139749080363271);
-Obj x139749080366087 = PRIM_CAR(x139749080366055);
-Obj __ = x139749080366087;
-Obj x139749080367079 = PRIM_CDR(x139749080363271);
-Obj x139749080350823 = PRIM_CDR(x139749080367079);
-Obj remain = x139749080350823;
+Obj x139886477021639 = __arg1;
+Obj x139886476105063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476105095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun0, 2, x139886476105095, x139886477021639);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886476105063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x139886477021735 = __arg1;
+Obj x139886476105095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886477021639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = x139886476105095;
+__arg1 = x139886477021639;
+__arg2 = x139886477021735;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x139886476080999 = __arg1;
+Obj x139886476081959 = makeNative(47, clofun0, 0, 1, x139886476080999);
+Obj x139886476798631 = PRIM_ISCONS(x139886476080999);
+if (True == x139886476798631) {
+Obj x139886476798855 = PRIM_CAR(x139886476080999);
+Obj x139886476798887 = PRIM_EQ(sympackage, x139886476798855);
+if (True == x139886476798887) {
+Obj x139886476799111 = PRIM_CDR(x139886476080999);
+Obj x139886476799143 = PRIM_ISCONS(x139886476799111);
+if (True == x139886476799143) {
+Obj x139886476799367 = PRIM_CDR(x139886476080999);
+Obj x139886476799399 = PRIM_CAR(x139886476799367);
+Obj x139886476799623 = PRIM_CDR(x139886476080999);
+Obj x139886476799655 = PRIM_CDR(x139886476799623);
+Obj remain = x139886476799655;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -1625,7 +1531,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080363495;
+__arg0 = x139886476081959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1634,7 +1540,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080363495;
+__arg0 = x139886476081959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1643,7 +1549,181 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080363495;
+__arg0 = x139886476081959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label47:
+{
+Obj x139886476186087 = makeNative(48, clofun0, 0, 1, closureRef(co, 0));
+Obj x139886476797799 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476797799) {
+Obj x139886476798055 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476798087 = PRIM_EQ(symbegin, x139886476798055);
+if (True == x139886476798087) {
+Obj x139886476798279 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139886476798279;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg1 = remain;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476186087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label48:
+{
+Obj x139886476187879 = makeNative(49, clofun0, 0, 1, closureRef(co, 0));
+Obj x139886476796199 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476796199) {
+Obj x139886476796455 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476796487 = PRIM_ISCONS(x139886476796455);
+if (True == x139886476796487) {
+Obj x139886476796807 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476796839 = PRIM_CAR(x139886476796807);
+Obj x139886476796871 = PRIM_EQ(symexport, x139886476796839);
+if (True == x139886476796871) {
+Obj x139886476797127 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476797159 = PRIM_CDR(x139886476797127);
+Obj x139886476797351 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139886476797351;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg1 = remain;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476187879;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187879;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187879;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label49:
+{
+Obj x139886476144967 = makeNative(1, clofun1, 0, 0);
+Obj x139886474145639 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474145639) {
+Obj x139886474065383 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474065415 = PRIM_ISCONS(x139886474065383);
+if (True == x139886474065415) {
+Obj x139886474065831 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474065863 = PRIM_CAR(x139886474065831);
+Obj x139886474065895 = PRIM_EQ(symimport, x139886474065863);
+if (True == x139886474065895) {
+Obj x139886474066279 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474066311 = PRIM_CDR(x139886474066279);
+Obj x139886474066343 = PRIM_ISCONS(x139886474066311);
+if (True == x139886474066343) {
+Obj x139886474066695 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474066727 = PRIM_CDR(x139886474066695);
+Obj x139886474066759 = PRIM_CAR(x139886474066727);
+Obj pkg = x139886474066759;
+Obj x139886474067175 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474067207 = PRIM_CDR(x139886474067175);
+Obj x139886474067239 = PRIM_CDR(x139886474067207);
+Obj x139886474067271 = PRIM_EQ(Nil, x139886474067239);
+if (True == x139886474067271) {
+Obj x139886474067527 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x139886474067527;
+pushCont(co, 0, clofun1, 1, remain);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35import);
+__arg1 = pkg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476144967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476144967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476144967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476144967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476144967;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1674,182 +1754,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749080364551 = makeNative(1, clofun1, 0, 1, closureRef(co, 0));
-Obj x139749080388839 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080388839) {
-Obj x139749080389639 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080389703 = PRIM_EQ(symbegin, x139749080389639);
-if (True == x139749080389703) {
-Obj x139749080390215 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139749080390215;
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080364551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label1:
-{
-Obj x139749080646279 = makeNative(2, clofun1, 0, 1, closureRef(co, 0));
-Obj x139749080445191 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080445191) {
-Obj x139749080445863 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080445895 = PRIM_ISCONS(x139749080445863);
-if (True == x139749080445895) {
-Obj x139749080447271 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080447495 = PRIM_CAR(x139749080447271);
-Obj x139749080447527 = PRIM_EQ(symexport, x139749080447495);
-if (True == x139749080447527) {
-Obj x139749080448135 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080448199 = PRIM_CDR(x139749080448135);
-Obj more = x139749080448199;
-Obj x139749080448839 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139749080448839;
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080646279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080646279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080646279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj x139749080647239 = makeNative(4, clofun1, 0, 1, closureRef(co, 0));
-Obj x139749080525095 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080525095) {
-Obj x139749080525671 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080525735 = PRIM_ISCONS(x139749080525671);
-if (True == x139749080525735) {
-Obj x139749080473959 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080474087 = PRIM_CAR(x139749080473959);
-Obj x139749080474151 = PRIM_EQ(symimport, x139749080474087);
-if (True == x139749080474151) {
-Obj x139749080475719 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080475751 = PRIM_CDR(x139749080475719);
-Obj x139749080475783 = PRIM_ISCONS(x139749080475751);
-if (True == x139749080475783) {
-Obj x139749080476903 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080477095 = PRIM_CDR(x139749080476903);
-Obj x139749080477319 = PRIM_CAR(x139749080477095);
-Obj pkg = x139749080477319;
-Obj x139749080462407 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080462439 = PRIM_CDR(x139749080462407);
-Obj x139749080462535 = PRIM_CDR(x139749080462439);
-Obj x139749080462567 = PRIM_EQ(Nil, x139749080462535);
-if (True == x139749080462567) {
-Obj x139749080463079 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139749080463079;
-pushCont(co, 3, clofun1, 1, remain);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35import);
-__arg1 = pkg;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080647239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080647239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080647239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080647239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080647239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label3:
-{
-Obj x139749080463463 = __arg1;
+Obj x139886474067783 = __arg1;
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -1861,10 +1766,8 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label1:
 {
-Obj x139749080648295 = makeNative(5, clofun1, 0, 0);
-Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1872,24 +1775,12 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label5:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
+label2:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
 Obj globals = __arg3;
-pushCont(co, 7, clofun1, 3, bc, globals, to);
+pushCont(co, 3, clofun1, 3, bc, globals, to);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
 __arg1 = Nil;
@@ -1903,14 +1794,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label3:
 {
-Obj x139749078040807 = __arg1;
+Obj x139886474142087 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups = x139749078040807;
-pushCont(co, 8, clofun1, 3, globals, to, groups);
+Obj groups = x139886474142087;
+pushCont(co, 4, clofun1, 3, globals, to, groups);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
 __arg1 = bc;
@@ -1921,14 +1812,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label4:
 {
-Obj x139749078041063 = __arg1;
+Obj x139886474142247 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj maxid = x139749078041063;
-pushCont(co, 9, clofun1, 4, globals, to, maxid, groups);
+Obj maxid = x139886474142247;
+pushCont(co, 5, clofun1, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -1940,14 +1831,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label5:
 {
-Obj x139749078041351 = __arg1;
+Obj x139886474142439 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 10, clofun1, 4, globals, to, maxid, groups);
+pushCont(co, 6, clofun1, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -1959,17 +1850,17 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label6:
 {
-Obj x139749078041639 = __arg1;
+Obj x139886474142599 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 11, clofun1, 4, globals, to, maxid, groups);
+pushCont(co, 7, clofun1, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(16, clofun1, 1, 2, maxid, to);
+__arg1 = makeNative(12, clofun1, 1, 2, maxid, to);
 __arg2 = groups;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1978,14 +1869,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label7:
 {
-Obj x139749080645671 = __arg1;
+Obj x139886474143431 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 12, clofun1, 4, globals, to, maxid, groups);
+pushCont(co, 8, clofun1, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -1997,14 +1888,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label8:
 {
-Obj x139749080646087 = __arg1;
+Obj x139886474143687 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 13, clofun1, 3, to, maxid, groups);
+pushCont(co, 9, clofun1, 3, to, maxid, groups);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35value);
 __arg1 = globals;
@@ -2015,17 +1906,17 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label9:
 {
-Obj x139749080647175 = __arg1;
+Obj x139886474143911 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 14, clofun1, 3, to, maxid, groups);
+pushCont(co, 10, clofun1, 3, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45entry);
 __arg1 = to;
-__arg2 = x139749080647175;
+__arg2 = x139886474143911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2033,15 +1924,15 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label10:
 {
-Obj x139749080647431 = __arg1;
+Obj x139886474143943 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(15, clofun1, 1, 2, to, maxid);
+__arg1 = makeNative(11, clofun1, 1, 2, to, maxid);
 __arg2 = groups;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2050,7 +1941,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label11:
 {
 Obj group = __arg1;
 __nargs = 4;
@@ -2065,10 +1956,10 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label12:
 {
 Obj group = __arg1;
-PUSH_CONT_0(co, 17, clofun1);
+PUSH_CONT_0(co, 13, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
 __arg1 = group;
@@ -2079,14 +1970,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label13:
 {
-Obj x139749078042375 = __arg1;
-PUSH_CONT_0(co, 18, clofun1);
+Obj x139886474143175 = __arg1;
+PUSH_CONT_0(co, 14, clofun1);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = closureRef(co, 1);
-__arg2 = x139749078042375;
+__arg2 = x139886474143175;
 __arg3 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2095,9 +1986,9 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label14:
 {
-Obj x139749078042439 = __arg1;
+Obj x139886474143303 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 1);
@@ -2109,14 +2000,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label15:
 {
 Obj to = __arg1;
 Obj globals = __arg2;
-pushCont(co, 20, clofun1, 2, globals, to);
+pushCont(co, 16, clofun1, 2, globals, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(29, clofun1, 1, 1, to);
+__arg1 = makeNative(25, clofun1, 1, 1, to);
 __arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2125,12 +2016,12 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label16:
 {
-Obj x139749078050023 = __arg1;
+Obj x139886474258727 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 21, clofun1, 2, globals, to);
+pushCont(co, 17, clofun1, 2, globals, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2142,15 +2033,15 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label17:
 {
-Obj x139749078050311 = __arg1;
+Obj x139886474258887 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 22, clofun1, 1, to);
+pushCont(co, 18, clofun1, 1, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(23, clofun1, 1, 1, to);
+__arg1 = makeNative(19, clofun1, 1, 1, to);
 __arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2159,9 +2050,9 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label18:
 {
-Obj x139749078052199 = __arg1;
+Obj x139886474260391 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2174,10 +2065,10 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
+label19:
 {
 Obj sym = __arg1;
-pushCont(co, 24, clofun1, 1, sym);
+pushCont(co, 20, clofun1, 1, sym);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -2189,11 +2080,11 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label24:
+label20:
 {
-Obj x139749078050887 = __arg1;
+Obj x139886474259399 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 25, clofun1, 1, sym);
+pushCont(co, 21, clofun1, 1, sym);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = closureRef(co, 0);
@@ -2205,11 +2096,11 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label21:
 {
-Obj x139749078051175 = __arg1;
+Obj x139886474259623 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 26, clofun1, 1, sym);
+pushCont(co, 22, clofun1, 1, sym);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -2221,11 +2112,11 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label22:
 {
-Obj x139749078051463 = __arg1;
+Obj x139886474259879 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 27, clofun1);
+PUSH_CONT_0(co, 23, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35symbol_45_62string);
 __arg1 = sym;
@@ -2236,14 +2127,14 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label27:
+label23:
 {
-Obj x139749078051911 = __arg1;
-PUSH_CONT_0(co, 28, clofun1);
+Obj x139886474260199 = __arg1;
+PUSH_CONT_0(co, 24, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
-__arg2 = x139749078051911;
+__arg2 = x139886474260199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2251,9 +2142,9 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label24:
 {
-Obj x139749078051943 = __arg1;
+Obj x139886474260231 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -2265,10 +2156,10 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label29:
+label25:
 {
 Obj sym = __arg1;
-pushCont(co, 30, clofun1, 1, sym);
+pushCont(co, 26, clofun1, 1, sym);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -2280,11 +2171,11 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label26:
 {
-Obj x139749078049479 = __arg1;
+Obj x139886474258247 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 31, clofun1);
+PUSH_CONT_0(co, 27, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = closureRef(co, 0);
@@ -2296,9 +2187,9 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
+label27:
 {
-Obj x139749078049767 = __arg1;
+Obj x139886474258567 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -2310,112 +2201,49 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label32:
+label28:
 {
-Obj x139749080388071 = __arg1;
-Obj x139749080388103 = __arg2;
-Obj x139749080388135 = __arg3;
-Obj x139749080388167 = co->args[4];
-Obj x139749080388935 = makeNative(35, clofun1, 0, 4, x139749080388071, x139749080388103, x139749080388135, x139749080388167);
-Obj res = x139749080388071;
-Obj idx = x139749080388103;
-Obj acc = x139749080388135;
-Obj x139749078076071 = PRIM_EQ(Nil, x139749080388167);
-if (True == x139749078076071) {
-pushCont(co, 33, clofun1, 2, acc, res);
+Obj x139886476186823 = __arg1;
+Obj x139886476187015 = __arg2;
+Obj x139886476187047 = __arg3;
+Obj x139886476187079 = co->args[4];
+Obj x139886474307687 = PRIM_EQ(Nil, x139886476187079);
+if (True == x139886474307687) {
+pushCont(co, 30, clofun1, 2, x139886476187047, x139886476186823);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = acc;
+__arg1 = x139886476187047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080388935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label33:
-{
-Obj x139749078076647 = __arg1;
-Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749078076679 = primNot(x139749078076647);
-if (True == x139749078076679) {
-pushCont(co, 34, clofun1, 1, res);
+Obj x139886474309063 = PRIM_ISCONS(x139886476187079);
+if (True == x139886474309063) {
+Obj x139886474309415 = PRIM_CAR(x139886476187079);
+Obj bc = x139886474309415;
+Obj x139886474256487 = PRIM_CDR(x139886476187079);
+Obj more = x139886474256487;
+Obj x139886474256679 = PRIM_EQ(x139886476187015, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+if (True == x139886474256679) {
+pushCont(co, 29, clofun1, 3, x139886476186823, bc, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = acc;
+__arg1 = x139886476187047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = res;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj x139749078077031 = __arg1;
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749078077095 = makeCons(x139749078077031, res);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139749078077095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label35:
-{
-Obj x139749080389959 = makeNative(37, clofun1, 0, 0);
-Obj res = closureRef(co, 0);
-Obj idx = closureRef(co, 1);
-Obj acc = closureRef(co, 2);
-Obj x139749078146791 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139749078146791) {
-Obj x139749078147047 = PRIM_CAR(closureRef(co, 3));
-Obj bc = x139749078147047;
-Obj x139749078073575 = PRIM_CDR(closureRef(co, 3));
-Obj more = x139749078073575;
-Obj x139749078073863 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-if (True == x139749078073863) {
-pushCont(co, 36, clofun1, 3, res, bc, more);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = acc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078075175 = PRIM_ADD(idx, MAKE_NUMBER(1));
-Obj x139749078075431 = makeCons(bc, acc);
+Obj x139886474257383 = PRIM_ADD(x139886476187015, MAKE_NUMBER(1));
+Obj x139886474257479 = makeCons(bc, x139886476187047);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = res;
-__arg2 = x139749078075175;
-__arg3 = x139749078075431;
+__arg1 = x139886476186823;
+__arg2 = x139886474257383;
+__arg3 = x139886474257479;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2424,39 +2252,6 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-__nargs = 1;
-__arg0 = x139749080389959;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label36:
-{
-Obj x139749078074375 = __arg1;
-Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078074439 = makeCons(x139749078074375, res);
-Obj x139749078074759 = makeCons(bc, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = x139749078074439;
-__arg2 = MAKE_NUMBER(0);
-__arg3 = Nil;
-co->args[4] = x139749078074759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label37:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
@@ -2466,13 +2261,79 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
-label38:
+label29:
+{
+Obj x139886474257095 = __arg1;
+Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886474257127 = makeCons(x139886474257095, x139886476186823);
+Obj x139886474257223 = makeCons(bc, more);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
+__arg1 = x139886474257127;
+__arg2 = MAKE_NUMBER(0);
+__arg3 = Nil;
+co->args[4] = x139886474257223;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886474308199 = __arg1;
+Obj x139886476187047= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886474308231 = primNot(x139886474308199);
+if (True == x139886474308231) {
+pushCont(co, 31, clofun1, 1, x139886476186823);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886476187047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886476186823;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label31:
+{
+Obj x139886474308775 = __arg1;
+Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886474308807 = makeCons(x139886474308775, x139886476186823);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886474308807;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label32:
 {
 Obj to = __arg1;
 Obj group = __arg2;
 Obj maxid = __arg3;
-pushCont(co, 39, clofun1, 3, maxid, group, to);
+pushCont(co, 33, clofun1, 3, maxid, group, to);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
 __arg1 = group;
@@ -2483,17 +2344,17 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label33:
 {
-Obj x139749078176071 = __arg1;
+Obj x139886474552391 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 40, clofun1, 3, maxid, group, to);
+pushCont(co, 34, clofun1, 3, maxid, group, to);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = to;
-__arg2 = x139749078176071;
+__arg2 = x139886474552391;
 __arg3 = maxid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2502,13 +2363,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label34:
 {
-Obj x139749078176135 = __arg1;
+Obj x139886474552423 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 41, clofun1, 3, maxid, group, to);
+pushCont(co, 35, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2520,13 +2381,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label41:
+label35:
 {
-Obj x139749078176423 = __arg1;
+Obj x139886474552679 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 42, clofun1, 3, maxid, group, to);
+pushCont(co, 36, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2538,13 +2399,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label36:
 {
-Obj x139749078176711 = __arg1;
+Obj x139886474552871 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 43, clofun1, 3, maxid, group, to);
+pushCont(co, 37, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2556,13 +2417,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label43:
+label37:
 {
-Obj x139749078176999 = __arg1;
+Obj x139886474553095 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 44, clofun1, 3, maxid, group, to);
+pushCont(co, 38, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2574,13 +2435,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label44:
+label38:
 {
-Obj x139749078177287 = __arg1;
+Obj x139886474553255 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 45, clofun1, 3, maxid, group, to);
+pushCont(co, 39, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2592,13 +2453,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label39:
 {
-Obj x139749078177575 = __arg1;
+Obj x139886474553511 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 46, clofun1, 3, maxid, group, to);
+pushCont(co, 40, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2610,13 +2471,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label40:
 {
-Obj x139749078177863 = __arg1;
+Obj x139886474553735 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 47, clofun1, 3, maxid, group, to);
+pushCont(co, 41, clofun1, 3, maxid, group, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2628,13 +2489,13 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label47:
+label41:
 {
-Obj x139749078178151 = __arg1;
+Obj x139886474553895 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 48, clofun1, 3, maxid, group, to);
+pushCont(co, 42, clofun1, 3, maxid, group, to);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = group;
@@ -2645,18 +2506,120 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label48:
+label42:
 {
-Obj x139749078178631 = __arg1;
+Obj x139886474554279 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 49, clofun1, 3, maxid, group, to);
+pushCont(co, 43, clofun1, 3, maxid, group, to);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = x139749078178631;
+__arg3 = x139886474554279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x139886474554311 = __arg1;
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 44, clofun1, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = to;
+__arg2 = makeCString("};\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139886474554631 = __arg1;
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 45, clofun1, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = to;
+__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x139886474554791 = __arg1;
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 46, clofun1, 1, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
+__arg1 = makeNative(3, clofun2, 1, 2, to, maxid);
+__arg2 = group;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x139886474555367 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 47, clofun1, 1, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = to;
+__arg2 = makeCString("fail:\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x139886474305767 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 48, clofun1, 1, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = to;
+__arg2 = makeCString("co->nargs = __nargs;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x139886474306055 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 49, clofun1, 1, to);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = to;
+__arg2 = makeCString("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2666,15 +2629,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139749078178663 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 0, clofun2, 3, maxid, group, to);
+Obj x139886474306215 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun2, 1, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
-__arg2 = makeCString("};\n\n");
+__arg2 = makeCString("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2704,109 +2665,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749078178951 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 1, clofun2, 3, maxid, group, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj x139749078179239 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 2, clofun2, 1, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(9, clofun2, 1, 2, to, maxid);
-__arg2 = group;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x139749078143655 = __arg1;
+Obj x139886474306503 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 3, clofun2, 1, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("fail:\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139749078143943 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 4, clofun2, 1, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("co->nargs = __nargs;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x139749078144231 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 5, clofun2, 1, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("co->args[0] = __arg0;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj x139749078144519 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 6, clofun2, 1, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("co->args[1] = __arg1;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x139749078144807 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 7, clofun2, 1, to);
+pushCont(co, 1, clofun2, 1, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2818,11 +2679,11 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label1:
 {
-Obj x139749078145095 = __arg1;
+Obj x139886474306663 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 8, clofun2, 1, to);
+pushCont(co, 2, clofun2, 1, to);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2834,9 +2695,9 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label2:
 {
-Obj x139749078145383 = __arg1;
+Obj x139886474306983 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2849,7 +2710,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label3:
 {
 Obj x = __arg1;
 __nargs = 4;
@@ -2864,14 +2725,14 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label4:
 {
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj x139749078341383 = PRIM_EQ(i, MAKE_NUMBER(0));
-if (True == x139749078341383) {
-pushCont(co, 13, clofun2, 2, to, n);
+Obj x139886474583047 = PRIM_EQ(i, MAKE_NUMBER(0));
+if (True == x139886474583047) {
+pushCont(co, 7, clofun2, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2882,9 +2743,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078342183 = PRIM_LT(i, n);
-if (True == x139749078342183) {
-pushCont(co, 11, clofun2, 3, i, to, n);
+Obj x139886474583623 = PRIM_LT(i, n);
+if (True == x139886474583623) {
+pushCont(co, 5, clofun2, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = to;
@@ -2904,13 +2765,13 @@ goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label11:
+label5:
 {
-Obj x139749078342471 = __arg1;
+Obj x139886474583943 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 12, clofun2, 3, i, to, n);
+pushCont(co, 6, clofun2, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = to;
@@ -2922,17 +2783,17 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label6:
 {
-Obj x139749078342759 = __arg1;
+Obj x139886474551367 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078343175 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x139886474551687 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
-__arg2 = x139749078343175;
+__arg2 = x139886474551687;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2941,9 +2802,9 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label7:
 {
-Obj x139749078341671 = __arg1;
+Obj x139886474583239 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2958,43 +2819,27 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label8:
 {
-Obj x139749080446631 = __arg1;
-Obj x139749080446663 = __arg2;
-Obj x139749080447047 = makeNative(15, clofun2, 0, 2, x139749080446631, x139749080446663);
-Obj fn = x139749080446631;
-Obj x139749078416199 = PRIM_EQ(Nil, x139749080446663);
-if (True == x139749078416199) {
+Obj x139886476147399 = __arg1;
+Obj x139886476147527 = __arg2;
+Obj x139886474581191 = PRIM_EQ(Nil, x139886476147527);
+if (True == x139886474581191) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080447047;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139749080447687 = makeNative(17, clofun2, 0, 0);
-Obj fn = closureRef(co, 0);
-Obj x139749078414631 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749078414631) {
-Obj x139749078414919 = PRIM_CAR(closureRef(co, 1));
-Obj x = x139749078414919;
-Obj x139749078415207 = PRIM_CDR(closureRef(co, 1));
-Obj y = x139749078415207;
-pushCont(co, 16, clofun2, 2, fn, y);
+Obj x139886474581351 = PRIM_ISCONS(x139886476147527);
+if (True == x139886474581351) {
+Obj x139886474581607 = PRIM_CAR(x139886476147527);
+Obj x = x139886474581607;
+Obj x139886474581895 = PRIM_CDR(x139886476147527);
+Obj y = x139886474581895;
+pushCont(co, 9, clofun2, 2, x139886476147399, y);
 __nargs = 2;
-__arg0 = fn;
+__arg0 = x139886476147399;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3002,34 +2847,6 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080447687;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj x139749078415463 = __arg1;
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = fn;
-__arg2 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
@@ -3039,12 +2856,30 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
-label18:
+label9:
+{
+Obj x139886474582119 = __arg1;
+Obj x139886476147399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
+__arg1 = x139886476147399;
+__arg2 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
 {
 Obj globals = __arg1;
 Obj exp = __arg2;
-pushCont(co, 19, clofun2, 1, exp);
+pushCont(co, 11, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35parse_45pass);
 __arg1 = globals;
@@ -3055,13 +2890,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label11:
 {
-Obj x139749078425479 = __arg1;
+Obj x139886474580391 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 20, clofun2);
+PUSH_CONT_0(co, 12, clofun2);
 __nargs = 2;
-__arg0 = x139749078425479;
+__arg0 = x139886474580391;
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3070,13 +2905,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label12:
 {
-Obj x139749078425543 = __arg1;
-PUSH_CONT_0(co, 21, clofun2);
+Obj x139886474580423 = __arg1;
+PUSH_CONT_0(co, 13, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert_45pass);
-__arg1 = x139749078425543;
+__arg1 = x139886474580423;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3084,13 +2919,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label13:
 {
-Obj x139749078425575 = __arg1;
-PUSH_CONT_0(co, 22, clofun2);
+Obj x139886474580455 = __arg1;
+PUSH_CONT_0(co, 14, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45pass);
-__arg1 = x139749078425575;
+__arg1 = x139886474580455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3098,13 +2933,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label14:
 {
-Obj x139749078413319 = __arg1;
-PUSH_CONT_0(co, 23, clofun2);
+Obj x139886474580487 = __arg1;
+PUSH_CONT_0(co, 15, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack_45pass);
-__arg1 = x139749078413319;
+__arg1 = x139886474580487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3112,12 +2947,12 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
+label15:
 {
-Obj x139749078413351 = __arg1;
+Obj x139886474580519 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda_45pass);
-__arg1 = x139749078413351;
+__arg1 = x139886474580519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3125,10 +2960,10 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label24:
+label16:
 {
 Obj exp = __arg1;
-pushCont(co, 25, clofun2, 1, exp);
+pushCont(co, 17, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35cadr);
 __arg1 = exp;
@@ -3139,12 +2974,12 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label17:
 {
-Obj x139749078423495 = __arg1;
+Obj x139886474644423 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj obj = x139749078423495;
-pushCont(co, 26, clofun2, 1, obj);
+Obj obj = x139886474644423;
+pushCont(co, 18, clofun2, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35cddr);
 __arg1 = exp;
@@ -3155,11 +2990,11 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label18:
 {
-Obj x139749078423751 = __arg1;
+Obj x139886474644775 = __arg1;
 Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fns = x139749078423751;
+Obj fns = x139886474644775;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
 __arg1 = obj;
@@ -3171,45 +3006,29 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label27:
+label19:
 {
-Obj x139749080464839 = __arg1;
-Obj x139749080464871 = __arg2;
-Obj x139749080465255 = makeNative(28, clofun2, 0, 2, x139749080464839, x139749080464871);
-Obj obj = x139749080464839;
-Obj x139749078422567 = PRIM_EQ(Nil, x139749080464871);
-if (True == x139749078422567) {
+Obj x139886476186151 = __arg1;
+Obj x139886476186183 = __arg2;
+Obj x139886474642727 = PRIM_EQ(Nil, x139886476186183);
+if (True == x139886474642727) {
 __nargs = 2;
-__arg1 = obj;
+__arg1 = x139886476186151;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080465255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label28:
-{
-Obj x139749080445383 = makeNative(29, clofun2, 0, 0);
-Obj obj = closureRef(co, 0);
-Obj x139749078650151 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749078650151) {
-Obj x139749078650471 = PRIM_CAR(closureRef(co, 1));
-Obj hd = x139749078650471;
-Obj x139749078650791 = PRIM_CDR(closureRef(co, 1));
-Obj more = x139749078650791;
-Obj x139749078422023 = makeCons(obj, Nil);
-Obj x139749078422055 = makeCons(hd, x139749078422023);
+Obj x139886474642983 = PRIM_ISCONS(x139886476186183);
+if (True == x139886474642983) {
+Obj x139886474643143 = PRIM_CAR(x139886476186183);
+Obj hd = x139886474643143;
+Obj x139886474643367 = PRIM_CDR(x139886476186183);
+Obj more = x139886474643367;
+Obj x139886474643655 = makeCons(x139886476186151, Nil);
+Obj x139886474643687 = makeCons(hd, x139886474643655);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = x139749078422055;
+__arg1 = x139886474643687;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3217,18 +3036,6 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080445383;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label29:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
@@ -3238,11 +3045,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
-label30:
+label20:
 {
 Obj exp = __arg1;
-pushCont(co, 31, clofun2, 1, exp);
+pushCont(co, 21, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35vector);
 __arg1 = MAKE_NUMBER(2);
@@ -3253,12 +3062,12 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
+label21:
 {
-Obj x139749078772935 = __arg1;
+Obj x139886474652615 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = x139749078772935;
-pushCont(co, 32, clofun2, 2, exp, v);
+Obj v = x139886474652615;
+pushCont(co, 22, clofun2, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
 __arg1 = v;
@@ -3271,12 +3080,12 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label32:
+label22:
 {
-Obj x139749078773287 = __arg1;
+Obj x139886474652903 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 33, clofun2, 2, exp, v);
+pushCont(co, 23, clofun2, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
 __arg1 = v;
@@ -3289,12 +3098,12 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label33:
+label23:
 {
-Obj x139749078646823 = __arg1;
+Obj x139886474653191 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 34, clofun2, 1, v);
+pushCont(co, 24, clofun2, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
 __arg1 = v;
@@ -3306,20 +3115,20 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label34:
+label24:
 {
-Obj x139749078647207 = __arg1;
+Obj x139886474653447 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1 = x139749078647207;
-Obj x139749078648423 = makeCons(e1, Nil);
-Obj x139749078648455 = makeCons(Nil, x139749078648423);
-Obj x139749078648487 = makeCons(Nil, x139749078648455);
-Obj x139749078648519 = makeCons(symlambda, x139749078648487);
-pushCont(co, 35, clofun2, 1, v);
+Obj e1 = x139886474653447;
+Obj x139886474641767 = makeCons(e1, Nil);
+Obj x139886474641799 = makeCons(Nil, x139886474641767);
+Obj x139886474641831 = makeCons(Nil, x139886474641799);
+Obj x139886474641863 = makeCons(symlambda, x139886474641831);
+pushCont(co, 25, clofun2, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = x139749078648519;
+__arg2 = x139886474641863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3327,9 +3136,9 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label35:
+label25:
 {
-Obj x139749078648551 = __arg1;
+Obj x139886474641927 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -3342,7 +3151,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label36:
+label26:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -3356,7 +3165,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label37:
+label27:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -3370,7 +3179,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label38:
+label28:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -3384,7 +3193,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label29:
 {
 Obj globals = __arg1;
 Obj exp = __arg2;
@@ -3400,82 +3209,80 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label30:
 {
-Obj x139749080476967 = __arg1;
-Obj x139749080476999 = __arg2;
-Obj x139749080477031 = __arg3;
-Obj x139749080477639 = makeNative(48, clofun2, 0, 3, x139749080476967, x139749080476999, x139749080477031);
-Obj w = x139749080476967;
-Obj x139749079046439 = PRIM_ISCONS(x139749080476999);
-if (True == x139749079046439) {
-Obj x139749079046695 = PRIM_CAR(x139749080476999);
-Obj label = x139749079046695;
-Obj x139749079047591 = PRIM_CDR(x139749080476999);
-Obj x139749079047623 = PRIM_ISCONS(x139749079047591);
-if (True == x139749079047623) {
-Obj x139749078979143 = PRIM_CDR(x139749080476999);
-Obj x139749078979175 = PRIM_CAR(x139749078979143);
-Obj x139749078979207 = PRIM_ISCONS(x139749078979175);
-if (True == x139749078979207) {
-Obj x139749078980839 = PRIM_CDR(x139749080476999);
-Obj x139749078980871 = PRIM_CAR(x139749078980839);
-Obj x139749078980903 = PRIM_CAR(x139749078980871);
-Obj x139749078980935 = PRIM_EQ(symlambda, x139749078980903);
-if (True == x139749078980935) {
-Obj x139749078982311 = PRIM_CDR(x139749080476999);
-Obj x139749078982407 = PRIM_CAR(x139749078982311);
-Obj x139749078982439 = PRIM_CDR(x139749078982407);
-Obj x139749078982471 = PRIM_ISCONS(x139749078982439);
-if (True == x139749078982471) {
-Obj x139749078840295 = PRIM_CDR(x139749080476999);
-Obj x139749078840327 = PRIM_CAR(x139749078840295);
-Obj x139749078840359 = PRIM_CDR(x139749078840327);
-Obj x139749078840391 = PRIM_CAR(x139749078840359);
-Obj params = x139749078840391;
-Obj x139749078841543 = PRIM_CDR(x139749080476999);
-Obj x139749078841575 = PRIM_CAR(x139749078841543);
-Obj x139749078841767 = PRIM_CDR(x139749078841575);
-Obj x139749078841831 = PRIM_CDR(x139749078841767);
-Obj x139749078841863 = PRIM_ISCONS(x139749078841831);
-if (True == x139749078841863) {
-Obj x139749078843143 = PRIM_CDR(x139749080476999);
-Obj x139749078843175 = PRIM_CAR(x139749078843143);
-Obj x139749078843207 = PRIM_CDR(x139749078843175);
-Obj x139749078843239 = PRIM_CDR(x139749078843207);
-Obj x139749078843271 = PRIM_CAR(x139749078843239);
-Obj actives = x139749078843271;
-Obj x139749078824295 = PRIM_CDR(x139749080476999);
-Obj x139749078824391 = PRIM_CAR(x139749078824295);
-Obj x139749078824551 = PRIM_CDR(x139749078824391);
-Obj x139749078824583 = PRIM_CDR(x139749078824551);
-Obj x139749078824615 = PRIM_CDR(x139749078824583);
-Obj x139749078824647 = PRIM_ISCONS(x139749078824615);
-if (True == x139749078824647) {
-Obj x139749078826151 = PRIM_CDR(x139749080476999);
-Obj x139749078826183 = PRIM_CAR(x139749078826151);
-Obj x139749078826215 = PRIM_CDR(x139749078826183);
-Obj x139749078826247 = PRIM_CDR(x139749078826215);
-Obj x139749078826439 = PRIM_CDR(x139749078826247);
-Obj x139749078826471 = PRIM_CAR(x139749078826439);
-Obj body = x139749078826471;
-Obj x139749078807911 = PRIM_CDR(x139749080476999);
-Obj x139749078807975 = PRIM_CAR(x139749078807911);
-Obj x139749078808007 = PRIM_CDR(x139749078807975);
-Obj x139749078808039 = PRIM_CDR(x139749078808007);
-Obj x139749078808071 = PRIM_CDR(x139749078808039);
-Obj x139749078808103 = PRIM_CDR(x139749078808071);
-Obj x139749078808135 = PRIM_EQ(Nil, x139749078808103);
-if (True == x139749078808135) {
-Obj x139749078809095 = PRIM_CDR(x139749080476999);
-Obj x139749078809127 = PRIM_CDR(x139749078809095);
-Obj x139749078809159 = PRIM_EQ(Nil, x139749078809127);
-if (True == x139749078809159) {
-Obj maxid = x139749080477031;
-pushCont(co, 41, clofun2, 6, actives, maxid, label, params, body, w);
+Obj x139886476081543 = __arg1;
+Obj x139886476081575 = __arg2;
+Obj x139886476081607 = __arg3;
+Obj x139886475981511 = makeNative(38, clofun2, 0, 1, x139886476081575);
+Obj x139886475244903 = PRIM_ISCONS(x139886476081575);
+if (True == x139886475244903) {
+Obj x139886475245319 = PRIM_CAR(x139886476081575);
+Obj label = x139886475245319;
+Obj x139886475245927 = PRIM_CDR(x139886476081575);
+Obj x139886475245959 = PRIM_ISCONS(x139886475245927);
+if (True == x139886475245959) {
+Obj x139886475246471 = PRIM_CDR(x139886476081575);
+Obj x139886475246503 = PRIM_CAR(x139886475246471);
+Obj x139886475246631 = PRIM_ISCONS(x139886475246503);
+if (True == x139886475246631) {
+Obj x139886475190375 = PRIM_CDR(x139886476081575);
+Obj x139886475190407 = PRIM_CAR(x139886475190375);
+Obj x139886475190439 = PRIM_CAR(x139886475190407);
+Obj x139886475190471 = PRIM_EQ(symlambda, x139886475190439);
+if (True == x139886475190471) {
+Obj x139886475192007 = PRIM_CDR(x139886476081575);
+Obj x139886475192039 = PRIM_CAR(x139886475192007);
+Obj x139886475192167 = PRIM_CDR(x139886475192039);
+Obj x139886475192199 = PRIM_ISCONS(x139886475192167);
+if (True == x139886475192199) {
+Obj x139886475192775 = PRIM_CDR(x139886476081575);
+Obj x139886475192871 = PRIM_CAR(x139886475192775);
+Obj x139886475192935 = PRIM_CDR(x139886475192871);
+Obj x139886475192999 = PRIM_CAR(x139886475192935);
+Obj params = x139886475192999;
+Obj x139886475193767 = PRIM_CDR(x139886476081575);
+Obj x139886475193799 = PRIM_CAR(x139886475193767);
+Obj x139886475193927 = PRIM_CDR(x139886475193799);
+Obj x139886475193959 = PRIM_CDR(x139886475193927);
+Obj x139886475193991 = PRIM_ISCONS(x139886475193959);
+if (True == x139886475193991) {
+Obj x139886475182599 = PRIM_CDR(x139886476081575);
+Obj x139886475182631 = PRIM_CAR(x139886475182599);
+Obj x139886475182663 = PRIM_CDR(x139886475182631);
+Obj x139886475182791 = PRIM_CDR(x139886475182663);
+Obj x139886475182823 = PRIM_CAR(x139886475182791);
+Obj actives = x139886475182823;
+Obj x139886475183783 = PRIM_CDR(x139886476081575);
+Obj x139886475183815 = PRIM_CAR(x139886475183783);
+Obj x139886475183847 = PRIM_CDR(x139886475183815);
+Obj x139886475183879 = PRIM_CDR(x139886475183847);
+Obj x139886475183943 = PRIM_CDR(x139886475183879);
+Obj x139886475183975 = PRIM_ISCONS(x139886475183943);
+if (True == x139886475183975) {
+Obj x139886475184743 = PRIM_CDR(x139886476081575);
+Obj x139886475184775 = PRIM_CAR(x139886475184743);
+Obj x139886475184839 = PRIM_CDR(x139886475184775);
+Obj x139886475184903 = PRIM_CDR(x139886475184839);
+Obj x139886475184999 = PRIM_CDR(x139886475184903);
+Obj x139886475185031 = PRIM_CAR(x139886475184999);
+Obj body = x139886475185031;
+Obj x139886475185927 = PRIM_CDR(x139886476081575);
+Obj x139886475185991 = PRIM_CAR(x139886475185927);
+Obj x139886475186023 = PRIM_CDR(x139886475185991);
+Obj x139886475186055 = PRIM_CDR(x139886475186023);
+Obj x139886475186087 = PRIM_CDR(x139886475186055);
+Obj x139886475186151 = PRIM_CDR(x139886475186087);
+Obj x139886475124743 = PRIM_EQ(Nil, x139886475186151);
+if (True == x139886475124743) {
+Obj x139886475125319 = PRIM_CDR(x139886476081575);
+Obj x139886475125351 = PRIM_CDR(x139886475125319);
+Obj x139886475125415 = PRIM_EQ(Nil, x139886475125351);
+if (True == x139886475125415) {
+pushCont(co, 31, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476081543;
 __arg2 = makeCString("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3484,7 +3291,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3493,7 +3300,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3502,7 +3309,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3511,7 +3318,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3520,7 +3327,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3529,7 +3336,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3538,7 +3345,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3547,7 +3354,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3556,7 +3363,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477639;
+__arg0 = x139886475981511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3565,20 +3372,20 @@ goto *jumpTable[ps.label];
 }
 }
 
-label41:
+label31:
 {
-Obj x139749078809607 = __arg1;
+Obj x139886475125767 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139749078810471 = PRIM_SUB(maxid, label);
-pushCont(co, 42, clofun2, 6, actives, maxid, label, params, body, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x139886475126055 = PRIM_SUB(x139886476081607, label);
+pushCont(co, 32, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139749078810471;
+__arg1 = x139886475126055;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3587,20 +3394,20 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label32:
 {
-Obj x139749078810535 = __arg1;
+Obj x139886475126087 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 43, clofun2, 6, actives, maxid, label, params, body, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 33, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = x139749078810535;
+__arg1 = x139886476081543;
+__arg2 = x139886475126087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3608,19 +3415,19 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label43:
+label33:
 {
-Obj x139749078810567 = __arg1;
+Obj x139886475126279 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 44, clofun2, 6, actives, maxid, label, params, body, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 34, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476081543;
 __arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3629,20 +3436,20 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label44:
+label34:
 {
-Obj x139749078774023 = __arg1;
+Obj x139886475126663 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 45, clofun2, 6, actives, maxid, label, params, body, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 35, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
 __arg1 = globalRef(symcora_47lib_47toc_35local_45from_45params);
-__arg2 = w;
+__arg2 = x139886476081543;
 __arg3 = MAKE_NUMBER(1);
 co->args[4] = params;
 co->ctx.frees = __arg0;
@@ -3652,20 +3459,20 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label35:
 {
-Obj x139749078774471 = __arg1;
+Obj x139886475127047 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 46, clofun2, 5, maxid, label, params, body, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 36, clofun2, 5, x139886476081607, label, params, body, x139886476081543);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
 __arg1 = globalRef(symcora_47lib_47toc_35local_45from_45cont);
-__arg2 = w;
+__arg2 = x139886476081543;
 __arg3 = MAKE_NUMBER(0);
 co->args[4] = actives;
 co->ctx.frees = __arg0;
@@ -3675,21 +3482,21 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label36:
 {
-Obj x139749078774823 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475127335 = __arg1;
+Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139749078775431 = makeCons(maxid, label);
-pushCont(co, 47, clofun2, 1, w);
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x139886475127655 = makeCons(x139886476081607, label);
+pushCont(co, 37, clofun2, 1, x139886476081543);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = x139749078775431;
+__arg1 = x139886475127655;
 __arg2 = params;
-__arg3 = w;
+__arg3 = x139886476081543;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3698,13 +3505,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label47:
+label37:
 {
-Obj x139749078775655 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475127687 = __arg1;
+Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476081543;
 __arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3713,13 +3520,9 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label48:
+label38:
 {
-Obj x139749080463591 = makeNative(1, clofun3, 0, 0);
-Obj w = closureRef(co, 0);
-Obj other = closureRef(co, 1);
-Obj maxid = closureRef(co, 2);
-pushCont(co, 49, clofun2, 1, other);
+PUSH_CONT_0(co, 39, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35display);
 __arg1 = makeCString("wrong format of toplevel\n");
@@ -3730,14 +3533,214 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label49:
+label39:
 {
-Obj x139749079045095 = __arg1;
-Obj other= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 0, clofun3);
+Obj x139886475243943 = __arg1;
+PUSH_CONT_0(co, 40, clofun2);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35display);
-__arg1 = other;
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x139886475244455 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47io_35display);
+__arg1 = makeCString("\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label41:
+{
+Obj x139886476188423 = __arg1;
+Obj x139886476188455 = __arg2;
+Obj x139886476188487 = __arg3;
+Obj x139886476188519 = co->args[4];
+Obj x139886475270055 = PRIM_EQ(Nil, x139886476188519);
+if (True == x139886475270055) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475270439 = PRIM_ISCONS(x139886476188519);
+if (True == x139886475270439) {
+Obj x139886475270823 = PRIM_CAR(x139886476188519);
+Obj a = x139886475270823;
+Obj x139886475271111 = PRIM_CDR(x139886476188519);
+Obj b = x139886475271111;
+pushCont(co, 42, clofun2, 4, x139886476188487, x139886476188423, x139886476188455, b);
+__nargs = 4;
+__arg0 = x139886476188423;
+__arg1 = x139886476188455;
+__arg2 = x139886476188487;
+__arg3 = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label42:
+{
+Obj x139886475271335 = __arg1;
+Obj x139886476188487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476188423= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476188455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475271591 = PRIM_ADD(x139886476188487, MAKE_NUMBER(1));
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
+__arg1 = x139886476188423;
+__arg2 = x139886476188455;
+__arg3 = x139886475271591;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj w = __arg1;
+Obj i = __arg2;
+Obj var = __arg3;
+pushCont(co, 44, clofun2, 3, var, i, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139886475268231 = __arg1;
+Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 45, clofun2, 2, i, w);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = symignore;
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x139886475268711 = __arg1;
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun2, 2, i, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString("= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x139886475268967 = __arg1;
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 47, clofun2, 1, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x139886475269223 = __arg1;
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString("];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj w = __arg1;
+Obj i = __arg2;
+Obj var = __arg3;
+pushCont(co, 49, clofun2, 3, var, i, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label49:
+{
+Obj x139886475330887 = __arg1;
+Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 0, clofun3, 2, i, w);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = symignore;
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3767,255 +3770,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749079045447 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35display);
-__arg1 = makeCString("\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x139749080526695 = __arg1;
-Obj x139749080526727 = __arg2;
-Obj x139749080526759 = __arg3;
-Obj x139749080526791 = co->args[4];
-Obj x139749080474311 = makeNative(3, clofun3, 0, 4, x139749080526695, x139749080526727, x139749080526759, x139749080526791);
-Obj fn = x139749080526695;
-Obj w = x139749080526727;
-Obj idx = x139749080526759;
-Obj x139749079071367 = PRIM_EQ(Nil, x139749080526791);
-if (True == x139749079071367) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080474311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label3:
-{
-Obj x139749080475495 = makeNative(5, clofun3, 0, 0);
-Obj fn = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj idx = closureRef(co, 2);
-Obj x139749079145831 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139749079145831) {
-Obj x139749079146151 = PRIM_CAR(closureRef(co, 3));
-Obj a = x139749079146151;
-Obj x139749079068807 = PRIM_CDR(closureRef(co, 3));
-Obj b = x139749079068807;
-pushCont(co, 4, clofun3, 4, idx, fn, w, b);
-__nargs = 4;
-__arg0 = fn;
-__arg1 = w;
-__arg2 = idx;
-__arg3 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080475495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label4:
-{
-Obj x139749079069319 = __arg1;
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749079070151 = PRIM_ADD(idx, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
-__arg1 = fn;
-__arg2 = w;
-__arg3 = x139749079070151;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj w = __arg1;
-Obj i = __arg2;
-Obj var = __arg3;
-pushCont(co, 7, clofun3, 3, var, i, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x139749079158375 = __arg1;
-Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun3, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = symignore;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x139749079142599 = __arg1;
+Obj x139886475331143 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 9, clofun3, 2, i, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj x139749079143047 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 10, clofun3, 1, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x139749079143495 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj w = __arg1;
-Obj i = __arg2;
-Obj var = __arg3;
-pushCont(co, 12, clofun3, 3, var, i, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj x139749079173607 = __arg1;
-Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 13, clofun3, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = symignore;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x139749079174375 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079174887 = PRIM_LT(i, MAKE_NUMBER(4));
-if (True == x139749079174887) {
-pushCont(co, 16, clofun3, 2, i, w);
+Obj x139886475331815 = PRIM_LT(i, MAKE_NUMBER(4));
+if (True == x139886475331815) {
+pushCont(co, 3, clofun3, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = w;
@@ -4026,7 +3786,7 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 14, clofun3, 2, i, w);
+pushCont(co, 1, clofun3, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = w;
@@ -4039,12 +3799,12 @@ goto *jumpTable[ps.label];
 }
 }
 
-label14:
+label1:
 {
-Obj x139749079156455 = __arg1;
+Obj x139886475332839 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 15, clofun3, 1, w);
+pushCont(co, 2, clofun3, 1, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
@@ -4056,9 +3816,9 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label2:
 {
-Obj x139749079156903 = __arg1;
+Obj x139886475333095 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4071,12 +3831,12 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label3:
 {
-Obj x139749079155143 = __arg1;
+Obj x139886475332071 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 17, clofun3, 1, w);
+pushCont(co, 4, clofun3, 1, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
@@ -4088,9 +3848,9 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label4:
 {
-Obj x139749079155463 = __arg1;
+Obj x139886475332359 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4103,12 +3863,12 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label5:
 {
 Obj w = __arg1;
 Obj label = __arg2;
 Obj maxid = __arg3;
-pushCont(co, 19, clofun3, 3, label, maxid, w);
+pushCont(co, 6, clofun3, 3, label, maxid, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = w;
@@ -4120,13 +3880,13 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label6:
 {
-Obj x139749079211303 = __arg1;
+Obj x139886475386567 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 20, clofun3, 1, w);
+pushCont(co, 7, clofun3, 1, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
@@ -4139,11 +3899,11 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label7:
 {
-Obj x139749079171111 = __arg1;
+Obj x139886475329543 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 21, clofun3, 1, w);
+pushCont(co, 8, clofun3, 1, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = w;
@@ -4155,9 +3915,9 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label8:
 {
-Obj x139749079171783 = __arg1;
+Obj x139886475329895 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4170,15 +3930,15 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label9:
 {
 Obj w = __arg1;
 Obj label = __arg2;
 Obj maxid = __arg3;
-Obj x139749079208999 = PRIM_SUB(maxid, label);
-Obj x139749079209127 = primDiv(x139749079208999, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-Obj gid = x139749079209127;
-pushCont(co, 23, clofun3, 2, w, gid);
+Obj x139886475385319 = PRIM_SUB(maxid, label);
+Obj x139886475385351 = primDiv(x139886475385319, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+Obj gid = x139886475385351;
+pushCont(co, 10, clofun3, 2, w, gid);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = w;
@@ -4190,9 +3950,9 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
+label10:
 {
-Obj x139749079209863 = __arg1;
+Obj x139886475385735 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -4206,7 +3966,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label24:
+label11:
 {
 Obj self = __arg1;
 Obj env = __arg2;
@@ -4226,55 +3986,33 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label12:
 {
-Obj x139749080649063 = __arg1;
-Obj x139749080649095 = __arg2;
-Obj x139749080649127 = __arg3;
-Obj x139749080649159 = co->args[4];
-Obj x139749080649191 = co->args[5];
-Obj x139749080523207 = makeNative(26, clofun3, 0, 5, x139749080649063, x139749080649095, x139749080649127, x139749080649159, x139749080649191);
-Obj self = x139749080649063;
-Obj env = x139749080649095;
-Obj fn = x139749080649127;
-Obj w = x139749080649159;
-Obj x139749079229991 = PRIM_EQ(Nil, x139749080649191);
-if (True == x139749079229991) {
+Obj x139886476148199 = __arg1;
+Obj x139886476148231 = __arg2;
+Obj x139886476148263 = __arg3;
+Obj x139886476148295 = co->args[4];
+Obj x139886476148327 = co->args[5];
+Obj x139886475463847 = PRIM_EQ(Nil, x139886476148327);
+if (True == x139886475463847) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080523207;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label26:
-{
-Obj x139749080524519 = makeNative(30, clofun3, 0, 0);
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj fn = closureRef(co, 2);
-Obj w = closureRef(co, 3);
-Obj x139749079760839 = PRIM_ISCONS(closureRef(co, 4));
-if (True == x139749079760839) {
-Obj x139749079245287 = PRIM_CAR(closureRef(co, 4));
-Obj a = x139749079245287;
-Obj x139749079245831 = PRIM_CDR(closureRef(co, 4));
-Obj b = x139749079245831;
-pushCont(co, 27, clofun3, 5, self, env, fn, w, b);
+Obj x139886475464103 = PRIM_ISCONS(x139886476148327);
+if (True == x139886475464103) {
+Obj x139886475464359 = PRIM_CAR(x139886476148327);
+Obj a = x139886475464359;
+Obj x139886475464551 = PRIM_CDR(x139886476148327);
+Obj b = x139886475464551;
+pushCont(co, 13, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
 __nargs = 5;
-__arg0 = fn;
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
+__arg0 = x139886476148263;
+__arg1 = x139886476148199;
+__arg2 = x139886476148231;
+__arg3 = x139886476148295;
 co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4282,8 +4020,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080524519;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4291,16 +4030,17 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
+}
 
-label27:
+label13:
 {
-Obj x139749079246375 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475382855 = __arg1;
+Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 28, clofun3, 5, self, env, fn, w, b);
+pushCont(co, 14, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = b;
@@ -4311,20 +4051,20 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label14:
 {
-Obj x139749079247495 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475383239 = __arg1;
+Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139749079247527 = primNot(x139749079247495);
-if (True == x139749079247527) {
-pushCont(co, 29, clofun3, 5, self, env, fn, w, b);
+Obj x139886475383271 = primNot(x139886475383239);
+if (True == x139886475383271) {
+pushCont(co, 15, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476148295;
 __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4335,10 +4075,10 @@ goto *jumpTable[ps.label];
 Nil;
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list_45h);
-__arg1 = self;
-__arg2 = env;
-__arg3 = fn;
-co->args[4] = w;
+__arg1 = x139886476148199;
+__arg2 = x139886476148231;
+__arg3 = x139886476148263;
+co->args[4] = x139886476148295;
 co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4348,20 +4088,20 @@ goto *jumpTable[ps.label];
 }
 }
 
-label29:
+label15:
 {
-Obj x139749079248007 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475383463 = __arg1;
+Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list_45h);
-__arg1 = self;
-__arg2 = env;
-__arg3 = fn;
-co->args[4] = w;
+__arg1 = x139886476148199;
+__arg2 = x139886476148231;
+__arg3 = x139886476148263;
+co->args[4] = x139886476148295;
 co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4370,46 +4110,32 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label16:
 {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label31:
-{
-Obj x139749080646439 = __arg1;
-Obj x139749080646471 = __arg2;
-Obj x139749080646535 = __arg3;
-Obj x139749080647143 = makeNative(4, clofun4, 0, 0);
-Obj self = x139749080646439;
-Obj w = x139749080646471;
-Obj x139749080389159 = PRIM_ISCONS(x139749080646535);
-if (True == x139749080389159) {
-Obj x139749080389767 = PRIM_CAR(x139749080646535);
-Obj x139749080389799 = PRIM_EQ(sym_37continuation, x139749080389767);
-if (True == x139749080389799) {
-Obj x139749080390567 = PRIM_CDR(x139749080646535);
-Obj x139749080390695 = PRIM_ISCONS(x139749080390567);
-if (True == x139749080390695) {
-Obj x139749080391495 = PRIM_CDR(x139749080646535);
-Obj x139749080391527 = PRIM_CAR(x139749080391495);
-Obj label = x139749080391527;
-Obj x139749080363751 = PRIM_CDR(x139749080646535);
-Obj x139749080363815 = PRIM_CDR(x139749080363751);
-Obj stacks = x139749080363815;
-Obj x139749080364423 = PRIM_EQ(stacks, Nil);
-if (True == x139749080364423) {
-pushCont(co, 43, clofun3, 4, label, self, stacks, w);
+Obj x139886476185991 = __arg1;
+Obj x139886476186023 = __arg2;
+Obj x139886476186055 = __arg3;
+Obj x139886476188807 = makeNative(39, clofun3, 0, 0);
+Obj x139886475506503 = PRIM_ISCONS(x139886476186055);
+if (True == x139886475506503) {
+Obj x139886475507143 = PRIM_CAR(x139886476186055);
+Obj x139886475507271 = PRIM_EQ(sym_37continuation, x139886475507143);
+if (True == x139886475507271) {
+Obj x139886475507687 = PRIM_CDR(x139886476186055);
+Obj x139886475507719 = PRIM_ISCONS(x139886475507687);
+if (True == x139886475507719) {
+Obj x139886475508103 = PRIM_CDR(x139886476186055);
+Obj x139886475508135 = PRIM_CAR(x139886475508103);
+Obj label = x139886475508135;
+Obj x139886475508487 = PRIM_CDR(x139886476186055);
+Obj x139886475508583 = PRIM_CDR(x139886475508487);
+Obj stacks = x139886475508583;
+Obj x139886475509031 = PRIM_EQ(stacks, Nil);
+if (True == x139886475509031) {
+pushCont(co, 28, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString("PUSH_CONT_0(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4417,10 +4143,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 32, clofun3, 4, label, self, stacks, w);
+pushCont(co, 17, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4430,7 +4156,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080647143;
+__arg0 = x139886476188807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4439,7 +4165,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080647143;
+__arg0 = x139886476188807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4448,7 +4174,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080647143;
+__arg0 = x139886476188807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4457,19 +4183,19 @@ goto *jumpTable[ps.label];
 }
 }
 
-label32:
+label17:
 {
-Obj x139749079972199 = __arg1;
+Obj x139886475471815 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749079973543 = PRIM_CAR(self);
-Obj x139749079973639 = PRIM_SUB(x139749079973543, label);
-pushCont(co, 33, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475472263 = PRIM_CAR(x139886476185991);
+Obj x139886475472295 = PRIM_SUB(x139886475472263, label);
+pushCont(co, 18, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139749079973639;
+__arg1 = x139886475472295;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4478,18 +4204,18 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label33:
+label18:
 {
-Obj x139749079973735 = __arg1;
+Obj x139886475472327 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 34, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 19, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = x139749079973735;
+__arg1 = x139886476186023;
+__arg2 = x139886475472327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4497,17 +4223,17 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label34:
+label19:
 {
-Obj x139749079973767 = __arg1;
+Obj x139886475472615 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 35, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 20, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4516,20 +4242,20 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label35:
+label20:
 {
-Obj x139749079781767 = __arg1;
+Obj x139886475472839 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749079782535 = PRIM_CAR(self);
-pushCont(co, 36, clofun3, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475460871 = PRIM_CAR(x139886476185991);
+pushCont(co, 21, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = label;
-__arg3 = x139749079782535;
+__arg3 = x139886475460871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4537,18 +4263,18 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label36:
+label21:
 {
-Obj x139749079782567 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475460903 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749079783271 = PRIM_EQ(stacks, Nil);
-if (True == x139749079783271) {
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886475461319 = PRIM_EQ(stacks, Nil);
+if (True == x139886475461319) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4556,10 +4282,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 37, clofun3, 3, self, stacks, w);
+pushCont(co, 22, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4569,13 +4295,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label37:
+label22:
 {
-Obj x139749079783911 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475461671 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 38, clofun3, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 23, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = stacks;
@@ -4586,17 +4312,17 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label38:
+label23:
 {
-Obj x139749079784711 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475462055 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 39, clofun3, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 24, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = x139749079784711;
+__arg1 = x139886476186023;
+__arg2 = x139886475462055;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4604,16 +4330,16 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label24:
 {
-Obj x139749079784743 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475462087 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 40, clofun3, 1, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 25, clofun3, 1, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(41, clofun3, 1, 2, self, w);
+__arg1 = makeNative(26, clofun3, 1, 2, x139886476185991, x139886476186023);
 __arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4622,13 +4348,13 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label25:
 {
-Obj x139749079757383 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475462759 = __arg1;
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4637,10 +4363,10 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label41:
+label26:
 {
 Obj x = __arg1;
-pushCont(co, 42, clofun3, 1, x);
+pushCont(co, 27, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 1);
@@ -4652,9 +4378,9 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label27:
 {
-Obj x139749079785415 = __arg1;
+Obj x139886475462503 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -4669,19 +4395,19 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label43:
+label28:
 {
-Obj x139749080364839 = __arg1;
+Obj x139886475509127 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749080366535 = PRIM_CAR(self);
-Obj x139749080366599 = PRIM_SUB(x139749080366535, label);
-pushCont(co, 44, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475509607 = PRIM_CAR(x139886476185991);
+Obj x139886475509639 = PRIM_SUB(x139886475509607, label);
+pushCont(co, 29, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139749080366599;
+__arg1 = x139886475509639;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4690,18 +4416,18 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label44:
+label29:
 {
-Obj x139749080366663 = __arg1;
+Obj x139886475509671 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 45, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 30, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = x139749080366663;
+__arg1 = x139886476186023;
+__arg2 = x139886475509671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4709,17 +4435,17 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label30:
 {
-Obj x139749080366695 = __arg1;
+Obj x139886475509735 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 46, clofun3, 4, label, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 31, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4728,20 +4454,20 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label31:
 {
-Obj x139749080350855 = __arg1;
+Obj x139886475469063 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749080351847 = PRIM_CAR(self);
-pushCont(co, 47, clofun3, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475469479 = PRIM_CAR(x139886476185991);
+pushCont(co, 32, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = label;
-__arg3 = x139749080351847;
+__arg3 = x139886475469479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4749,18 +4475,18 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label47:
+label32:
 {
-Obj x139749080351879 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475469511 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749080352423 = PRIM_EQ(stacks, Nil);
-if (True == x139749080352423) {
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886475469895 = PRIM_EQ(stacks, Nil);
+if (True == x139886475469895) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4768,10 +4494,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 48, clofun3, 3, self, stacks, w);
+pushCont(co, 33, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476186023;
 __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4781,13 +4507,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label48:
+label33:
 {
-Obj x139749080353607 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475470311 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 49, clofun3, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 34, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = stacks;
@@ -4798,22 +4524,485 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label49:
+label34:
 {
-Obj x139749080354183 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475470663 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 0, clofun4, 3, self, stacks, w);
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 35, clofun3, 3, x139886476185991, stacks, x139886476186023);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = x139749080354183;
+__arg1 = x139886476186023;
+__arg2 = x139886475470663;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj x139886475470695 = __arg1;
+Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 36, clofun3, 1, x139886476186023);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
+__arg1 = makeNative(37, clofun3, 1, 2, x139886476185991, x139886476186023);
+__arg2 = stacks;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x139886475471559 = __arg1;
+Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = x139886476186023;
+__arg2 = makeCString(");\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x = __arg1;
+pushCont(co, 38, clofun3, 1, x);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 1);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label38:
+{
+Obj x139886475471271 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = closureRef(co, 0);
+__arg2 = Nil;
+__arg3 = closureRef(co, 1);
+co->args[4] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj self = __arg1;
+Obj env = __arg2;
+Obj w = __arg3;
+Obj x1 = co->args[4];
+Obj x139886475184807 = primIsSymbol(x1);
+if (True == x139886475184807) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
+__arg1 = w;
+__arg2 = x1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476186343 = makeNative(43, clofun3, 0, 4, self, env, x1, w);
+Obj x139886475567943 = PRIM_ISCONS(x1);
+if (True == x139886475567943) {
+Obj x139886475568295 = PRIM_CAR(x1);
+Obj x139886475568327 = PRIM_EQ(sym_37global, x139886475568295);
+if (True == x139886475568327) {
+Obj x139886475568583 = PRIM_CDR(x1);
+Obj x139886475568615 = PRIM_ISCONS(x139886475568583);
+if (True == x139886475568615) {
+Obj x139886475568999 = PRIM_CDR(x1);
+Obj x139886475569031 = PRIM_CAR(x139886475568999);
+Obj x = x139886475569031;
+Obj x139886475569479 = PRIM_CDR(x1);
+Obj x139886475569511 = PRIM_CDR(x139886475569479);
+Obj x139886475569575 = PRIM_EQ(Nil, x139886475569511);
+if (True == x139886475569575) {
+pushCont(co, 41, clofun3, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString("globalRef(sym");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476186343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label41:
+{
+Obj x139886475569799 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 42, clofun3, 1, w);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
+__arg1 = w;
+__arg2 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x139886475569991 = __arg1;
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x139886476187911 = makeNative(46, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886475597415 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139886475597415) {
+Obj x139886475597735 = PRIM_CAR(closureRef(co, 2));
+Obj x139886475597767 = PRIM_EQ(sym_37closure_45ref, x139886475597735);
+if (True == x139886475597767) {
+Obj x139886475598375 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475598407 = PRIM_ISCONS(x139886475598375);
+if (True == x139886475598407) {
+Obj x139886475598791 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475598823 = PRIM_CAR(x139886475598791);
+Obj idx = x139886475598823;
+Obj x139886475599335 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475599399 = PRIM_CDR(x139886475599335);
+Obj x139886475599463 = PRIM_EQ(Nil, x139886475599399);
+if (True == x139886475599463) {
+pushCont(co, 44, clofun3, 1, idx);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("closureRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187911;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label44:
+{
+Obj x139886475599751 = __arg1;
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 45, clofun3);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = closureRef(co, 3);
+__arg2 = idx;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x139886475567207 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x139886476188999 = makeNative(49, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886475982695 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139886475982695) {
+Obj x139886475983623 = PRIM_CAR(closureRef(co, 2));
+Obj x139886475983655 = PRIM_EQ(sym_37stack_45ref, x139886475983623);
+if (True == x139886475983655) {
+Obj x139886475984071 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475984103 = PRIM_ISCONS(x139886475984071);
+if (True == x139886475984103) {
+Obj x139886475984423 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475984455 = PRIM_CAR(x139886475984423);
+Obj idx = x139886475984455;
+Obj x139886475595879 = PRIM_CDR(closureRef(co, 2));
+Obj x139886475595911 = PRIM_CDR(x139886475595879);
+Obj x139886475595975 = PRIM_EQ(Nil, x139886475595911);
+if (True == x139886475595975) {
+pushCont(co, 47, clofun3, 1, idx);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("stackRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476188999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476188999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label47:
+{
+Obj x139886475596295 = __arg1;
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 48, clofun3);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = closureRef(co, 3);
+__arg2 = idx;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x139886475596615 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label49:
+{
+Obj x139886476145031 = makeNative(7, clofun4, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139886476105767 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x139886476105767) {
+Obj x139886476106215 = PRIM_CAR(closureRef(co, 2));
+Obj x139886476106247 = PRIM_EQ(sym_37const, x139886476106215);
+if (True == x139886476106247) {
+Obj x139886476106983 = PRIM_CDR(closureRef(co, 2));
+Obj x139886476107015 = PRIM_ISCONS(x139886476106983);
+if (True == x139886476107015) {
+Obj x139886476107367 = PRIM_CDR(closureRef(co, 2));
+Obj x139886476107399 = PRIM_CAR(x139886476107367);
+Obj x = x139886476107399;
+Obj x139886476079335 = PRIM_CDR(closureRef(co, 2));
+Obj x139886476079367 = PRIM_CDR(x139886476079335);
+Obj x139886476079399 = PRIM_EQ(Nil, x139886476079367);
+if (True == x139886476079399) {
+Obj x139886476079559 = primIsSymbol(x);
+if (True == x139886476079559) {
+pushCont(co, 6, clofun4, 1, x);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("sym");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 0, clofun4, 1, x);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35number_63);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145031;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145031;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145031;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145031;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -4838,473 +5027,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749080354407 = __arg1;
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 1, clofun4, 1, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(2, clofun4, 1, 2, self, w);
-__arg2 = stacks;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj x139749079971527 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(");\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x = __arg1;
-pushCont(co, 3, clofun4, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 1);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139749079971015 = __arg1;
+Obj x139886476080551 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 0);
-__arg2 = Nil;
-__arg3 = closureRef(co, 1);
-co->args[4] = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj self = __arg1;
-Obj env = __arg2;
-Obj w = __arg3;
-Obj x1 = co->args[4];
-Obj x139749080464519 = primIsSymbol(x1);
-if (True == x139749080464519) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = w;
-__arg2 = x1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749080444999 = makeNative(8, clofun4, 0, 4, self, env, x1, w);
-Obj x139749080463271 = PRIM_ISCONS(x1);
-if (True == x139749080463271) {
-Obj x139749080463943 = PRIM_CAR(x1);
-Obj x139749080464007 = PRIM_EQ(sym_37global, x139749080463943);
-if (True == x139749080464007) {
-Obj x139749080464679 = PRIM_CDR(x1);
-Obj x139749080464807 = PRIM_ISCONS(x139749080464679);
-if (True == x139749080464807) {
-Obj x139749080445031 = PRIM_CDR(x1);
-Obj x139749080445159 = PRIM_CAR(x139749080445031);
-Obj x = x139749080445159;
-Obj x139749080446087 = PRIM_CDR(x1);
-Obj x139749080446119 = PRIM_CDR(x139749080446087);
-Obj x139749080446151 = PRIM_EQ(Nil, x139749080446119);
-if (True == x139749080446151) {
-pushCont(co, 6, clofun4, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("globalRef(sym");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080444999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080444999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080444999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080444999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label6:
-{
-Obj x139749080446791 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 7, clofun4, 1, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = w;
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x139749080447303 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x139749080445511 = makeNative(11, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749080525703 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080525703) {
-Obj x139749080526823 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080473607 = PRIM_EQ(sym_37closure_45ref, x139749080526823);
-if (True == x139749080473607) {
-Obj x139749080474695 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080474727 = PRIM_ISCONS(x139749080474695);
-if (True == x139749080474727) {
-Obj x139749080475559 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080475591 = PRIM_CAR(x139749080475559);
-Obj idx = x139749080475591;
-Obj x139749080476647 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080476679 = PRIM_CDR(x139749080476647);
-Obj x139749080476711 = PRIM_EQ(Nil, x139749080476679);
-if (True == x139749080476711) {
-pushCont(co, 9, clofun4, 1, idx);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("closureRef(co, ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080445511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj x139749080477383 = __arg1;
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 10, clofun4);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = idx;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x139749080461767 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x139749080446055 = makeNative(14, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749078341063 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749078341063) {
-Obj x139749080646247 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080646311 = PRIM_EQ(sym_37stack_45ref, x139749080646247);
-if (True == x139749080646311) {
-Obj x139749080647207 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080647367 = PRIM_ISCONS(x139749080647207);
-if (True == x139749080647367) {
-Obj x139749080648167 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080648199 = PRIM_CAR(x139749080648167);
-Obj idx = x139749080648199;
-Obj x139749080522823 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080522855 = PRIM_CDR(x139749080522823);
-Obj x139749080523015 = PRIM_EQ(Nil, x139749080522855);
-if (True == x139749080523015) {
-pushCont(co, 12, clofun4, 1, idx);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("stackRef(co, ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080446055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj x139749080523399 = __arg1;
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 13, clofun4);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = idx;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x139749080524135 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x139749080446599 = makeNative(22, clofun4, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139749078423783 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749078423783) {
-Obj x139749078424231 = PRIM_CAR(closureRef(co, 2));
-Obj x139749078424263 = PRIM_EQ(sym_37const, x139749078424231);
-if (True == x139749078424263) {
-Obj x139749078424679 = PRIM_CDR(closureRef(co, 2));
-Obj x139749078424711 = PRIM_ISCONS(x139749078424679);
-if (True == x139749078424711) {
-Obj x139749078425127 = PRIM_CDR(closureRef(co, 2));
-Obj x139749078425159 = PRIM_CAR(x139749078425127);
-Obj x = x139749078425159;
-Obj x139749078413479 = PRIM_CDR(closureRef(co, 2));
-Obj x139749078413511 = PRIM_CDR(x139749078413479);
-Obj x139749078413543 = PRIM_EQ(Nil, x139749078413511);
-if (True == x139749078413543) {
-Obj x139749078413799 = primIsSymbol(x);
-if (True == x139749078413799) {
-pushCont(co, 21, clofun4, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("sym");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 15, clofun4, 1, x);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35number_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446599;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446599;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446599;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080446599;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139749078414535 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139749078414535) {
-pushCont(co, 19, clofun4, 1, x);
+if (True == x139886476080551) {
+pushCont(co, 4, clofun4, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5315,9 +5041,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078415559 = primIsString(x);
-if (True == x139749078415559) {
-pushCont(co, 16, clofun4, 1, x);
+Obj x139886476081639 = primIsString(x);
+if (True == x139886476081639) {
+pushCont(co, 1, clofun4, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5328,8 +5054,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078416807 = PRIM_EQ(x, Nil);
-if (True == x139749078416807) {
+Obj x139886476083175 = PRIM_EQ(x, Nil);
+if (True == x139886476083175) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5340,8 +5066,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078417287 = PRIM_EQ(x, True);
-if (True == x139749078417287) {
+Obj x139886475981095 = PRIM_EQ(x, True);
+if (True == x139886475981095) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5352,8 +5078,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749078339943 = PRIM_EQ(x, False);
-if (True == x139749078339943) {
+Obj x139886475981703 = PRIM_EQ(x, False);
+if (True == x139886475981703) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5379,11 +5105,11 @@ goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label1:
 {
-Obj x139749078415847 = __arg1;
+Obj x139886476082119 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 17, clofun4);
+PUSH_CONT_0(co, 2, clofun4);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35escape_45str);
 __arg1 = x;
@@ -5394,14 +5120,14 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label2:
 {
-Obj x139749078416295 = __arg1;
-PUSH_CONT_0(co, 18, clofun4);
+Obj x139886476082695 = __arg1;
+PUSH_CONT_0(co, 3, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = x139749078416295;
+__arg2 = x139886476082695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5409,9 +5135,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label3:
 {
-Obj x139749078416327 = __arg1;
+Obj x139886476082727 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5423,11 +5149,11 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label4:
 {
-Obj x139749078414823 = __arg1;
+Obj x139886476080871 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 20, clofun4);
+PUSH_CONT_0(co, 5, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
@@ -5439,9 +5165,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label5:
 {
-Obj x139749078415111 = __arg1;
+Obj x139886476081255 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5453,9 +5179,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label6:
 {
-Obj x139749078414087 = __arg1;
+Obj x139886476079975 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
@@ -5468,45 +5194,45 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label7:
 {
-Obj x139749080447111 = makeNative(33, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749078774919 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078774919) {
-Obj x139749078775495 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078775527 = PRIM_EQ(symlet, x139749078775495);
-if (True == x139749078775527) {
-Obj x139749078775975 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078776007 = PRIM_ISCONS(x139749078775975);
-if (True == x139749078776007) {
-Obj x139749078776423 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078776455 = PRIM_CAR(x139749078776423);
-Obj a = x139749078776455;
-Obj x139749078777159 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078777191 = PRIM_CDR(x139749078777159);
-Obj x139749078777223 = PRIM_ISCONS(x139749078777191);
-if (True == x139749078777223) {
-Obj x139749078769671 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078769703 = PRIM_CDR(x139749078769671);
-Obj x139749078769735 = PRIM_CAR(x139749078769703);
-Obj b = x139749078769735;
-Obj x139749078770567 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078770599 = PRIM_CDR(x139749078770567);
-Obj x139749078770631 = PRIM_CDR(x139749078770599);
-Obj x139749078770663 = PRIM_ISCONS(x139749078770631);
-if (True == x139749078770663) {
-Obj x139749078771559 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078771591 = PRIM_CDR(x139749078771559);
-Obj x139749078771623 = PRIM_CDR(x139749078771591);
-Obj x139749078771655 = PRIM_CAR(x139749078771623);
-Obj c = x139749078771655;
-Obj x139749078772711 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078772743 = PRIM_CDR(x139749078772711);
-Obj x139749078772775 = PRIM_CDR(x139749078772743);
-Obj x139749078772807 = PRIM_CDR(x139749078772775);
-Obj x139749078772839 = PRIM_EQ(Nil, x139749078772807);
-if (True == x139749078772839) {
-pushCont(co, 23, clofun4, 3, b, a, c);
+Obj x139886476146343 = makeNative(18, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886477005255 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886477005255) {
+Obj x139886477005511 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477005671 = PRIM_EQ(symlet, x139886477005511);
+if (True == x139886477005671) {
+Obj x139886477005959 = PRIM_CDR(closureRef(co, 0));
+Obj x139886477005991 = PRIM_ISCONS(x139886477005959);
+if (True == x139886477005991) {
+Obj x139886477007655 = PRIM_CDR(closureRef(co, 0));
+Obj x139886477007687 = PRIM_CAR(x139886477007655);
+Obj a = x139886477007687;
+Obj x139886477008007 = PRIM_CDR(closureRef(co, 0));
+Obj x139886477008039 = PRIM_CDR(x139886477008007);
+Obj x139886477008071 = PRIM_ISCONS(x139886477008039);
+if (True == x139886477008071) {
+Obj x139886477008391 = PRIM_CDR(closureRef(co, 0));
+Obj x139886477008423 = PRIM_CDR(x139886477008391);
+Obj x139886477008455 = PRIM_CAR(x139886477008423);
+Obj b = x139886477008455;
+Obj x139886477008839 = PRIM_CDR(closureRef(co, 0));
+Obj x139886477008871 = PRIM_CDR(x139886477008839);
+Obj x139886476186119 = PRIM_CDR(x139886477008871);
+Obj x139886476186215 = PRIM_ISCONS(x139886476186119);
+if (True == x139886476186215) {
+Obj x139886476187367 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476187399 = PRIM_CDR(x139886476187367);
+Obj x139886476187431 = PRIM_CDR(x139886476187399);
+Obj x139886476187783 = PRIM_CAR(x139886476187431);
+Obj c = x139886476187783;
+Obj x139886476188775 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188839 = PRIM_CDR(x139886476188775);
+Obj x139886476189063 = PRIM_CDR(x139886476188839);
+Obj x139886476189127 = PRIM_CDR(x139886476189063);
+Obj x139886476189159 = PRIM_EQ(Nil, x139886476189127);
+if (True == x139886476189159) {
+pushCont(co, 8, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
 __arg1 = a;
@@ -5518,7 +5244,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5527,7 +5253,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5536,7 +5262,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5545,7 +5271,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5554,7 +5280,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5563,7 +5289,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080447111;
+__arg0 = x139886476146343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5572,16 +5298,16 @@ goto *jumpTable[ps.label];
 }
 }
 
-label23:
+label8:
 {
-Obj x139749078773127 = __arg1;
+Obj x139886476189351 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj idx = x139749078773127;
-Obj x139749078773639 = PRIM_LT(idx, MAKE_NUMBER(0));
-if (True == x139749078773639) {
-pushCont(co, 28, clofun4, 3, b, a, c);
+Obj idx = x139886476189351;
+Obj x139886476144807 = PRIM_LT(idx, MAKE_NUMBER(0));
+if (True == x139886476144807) {
+pushCont(co, 13, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5593,7 +5319,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
-pushCont(co, 24, clofun4, 3, b, a, c);
+pushCont(co, 9, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = closureRef(co, 3);
@@ -5606,13 +5332,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label24:
+label9:
 {
-Obj x139749078649031 = __arg1;
+Obj x139886476147367 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 25, clofun4, 3, b, a, c);
+pushCont(co, 10, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5624,13 +5350,13 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label25:
+label10:
 {
-Obj x139749078649319 = __arg1;
+Obj x139886476147783 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 26, clofun4, 2, a, c);
+pushCont(co, 11, clofun4, 2, a, c);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -5644,12 +5370,12 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label11:
 {
-Obj x139749078649767 = __arg1;
+Obj x139886476148167 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 27, clofun4, 2, a, c);
+pushCont(co, 12, clofun4, 2, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5661,16 +5387,16 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label27:
+label12:
 {
-Obj x139749078650055 = __arg1;
+Obj x139886476148711 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749078650567 = makeCons(a, closureRef(co, 2));
+Obj x139886476104391 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = x139749078650567;
+__arg2 = x139886476104391;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -5680,13 +5406,13 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label13:
 {
-Obj x139749078646887 = __arg1;
+Obj x139886476144999 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 29, clofun4, 3, b, a, c);
+pushCont(co, 14, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = closureRef(co, 3);
@@ -5698,13 +5424,13 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label29:
+label14:
 {
-Obj x139749078647239 = __arg1;
+Obj x139886476145543 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 30, clofun4, 3, b, a, c);
+pushCont(co, 15, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5716,13 +5442,13 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label15:
 {
-Obj x139749078647527 = __arg1;
+Obj x139886476145735 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 31, clofun4, 2, a, c);
+pushCont(co, 16, clofun4, 2, a, c);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -5736,12 +5462,12 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
+label16:
 {
-Obj x139749078647879 = __arg1;
+Obj x139886476146247 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 32, clofun4, 2, a, c);
+pushCont(co, 17, clofun4, 2, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5753,16 +5479,16 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label32:
+label17:
 {
-Obj x139749078648199 = __arg1;
+Obj x139886476146567 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749078648615 = makeCons(a, closureRef(co, 2));
+Obj x139886476147111 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = x139749078648615;
+__arg2 = x139886476147111;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -5772,34 +5498,34 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label33:
+label18:
 {
-Obj x139749080448167 = makeNative(40, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749078823847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078823847) {
-Obj x139749078824327 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078824359 = PRIM_ISCONS(x139749078824327);
-if (True == x139749078824359) {
-Obj x139749078825159 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078825191 = PRIM_CAR(x139749078825159);
-Obj x139749078825223 = PRIM_EQ(sym_37builtin, x139749078825191);
-if (True == x139749078825223) {
-Obj x139749078825991 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078826023 = PRIM_CDR(x139749078825991);
-Obj x139749078826055 = PRIM_ISCONS(x139749078826023);
-if (True == x139749078826055) {
-Obj x139749078826791 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078826823 = PRIM_CDR(x139749078826791);
-Obj x139749078826855 = PRIM_CAR(x139749078826823);
-Obj f = x139749078826855;
-Obj x139749078807591 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078807623 = PRIM_CDR(x139749078807591);
-Obj x139749078807655 = PRIM_CDR(x139749078807623);
-Obj x139749078807687 = PRIM_EQ(Nil, x139749078807655);
-if (True == x139749078807687) {
-Obj x139749078807943 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139749078807943;
-pushCont(co, 34, clofun4, 2, f, args);
+Obj x139886476104807 = makeNative(25, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886474067079 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474067079) {
+Obj x139886474067335 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474067367 = PRIM_ISCONS(x139886474067335);
+if (True == x139886474067367) {
+Obj x139886474067687 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474067719 = PRIM_CAR(x139886474067687);
+Obj x139886474067751 = PRIM_EQ(sym_37builtin, x139886474067719);
+if (True == x139886474067751) {
+Obj x139886474038215 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474038407 = PRIM_CDR(x139886474038215);
+Obj x139886474038663 = PRIM_ISCONS(x139886474038407);
+if (True == x139886474038663) {
+Obj x139886477005095 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477005127 = PRIM_CDR(x139886477005095);
+Obj x139886477005159 = PRIM_CAR(x139886477005127);
+Obj f = x139886477005159;
+Obj x139886477005543 = PRIM_CAR(closureRef(co, 0));
+Obj x139886477005575 = PRIM_CDR(x139886477005543);
+Obj x139886477005607 = PRIM_CDR(x139886477005575);
+Obj x139886477005639 = PRIM_EQ(Nil, x139886477005607);
+if (True == x139886477005639) {
+Obj x139886477005831 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886477005831;
+pushCont(co, 19, clofun4, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62name);
 __arg1 = f;
@@ -5810,7 +5536,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080448167;
+__arg0 = x139886476104807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5819,7 +5545,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448167;
+__arg0 = x139886476104807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5828,7 +5554,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448167;
+__arg0 = x139886476104807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5837,7 +5563,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448167;
+__arg0 = x139886476104807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5846,7 +5572,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448167;
+__arg0 = x139886476104807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5855,16 +5581,16 @@ goto *jumpTable[ps.label];
 }
 }
 
-label34:
+label19:
 {
-Obj x139749078808423 = __arg1;
+Obj x139886477006087 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 35, clofun4, 2, f, args);
+pushCont(co, 20, clofun4, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = x139749078808423;
+__arg2 = x139886477006087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5872,14 +5598,14 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label35:
+label20:
 {
-Obj x139749078808455 = __arg1;
+Obj x139886477006119 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749078809031 = PRIM_EQ(f, symset);
-if (True == x139749078809031) {
-pushCont(co, 38, clofun4, 1, args);
+Obj x139886477006343 = PRIM_EQ(f, symset);
+if (True == x139886477006343) {
+pushCont(co, 23, clofun4, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5890,7 +5616,7 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 36, clofun4, 1, args);
+pushCont(co, 21, clofun4, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5903,11 +5629,11 @@ goto *jumpTable[ps.label];
 }
 }
 
-label36:
+label21:
 {
-Obj x139749078810151 = __arg1;
+Obj x139886477006951 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 37, clofun4);
+PUSH_CONT_0(co, 22, clofun4);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
 __arg1 = closureRef(co, 1);
@@ -5921,9 +5647,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label37:
+label22:
 {
-Obj x139749078810599 = __arg1;
+Obj x139886477007207 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5935,11 +5661,11 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label38:
+label23:
 {
-Obj x139749078809255 = __arg1;
+Obj x139886477006471 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 39, clofun4);
+PUSH_CONT_0(co, 24, clofun4);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
 __arg1 = closureRef(co, 1);
@@ -5953,9 +5679,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label24:
 {
-Obj x139749078809671 = __arg1;
+Obj x139886477006727 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5967,45 +5693,45 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label25:
 {
-Obj x139749080448967 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749079044935 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079044935) {
-Obj x139749079045479 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079045511 = PRIM_EQ(symif, x139749079045479);
-if (True == x139749079045511) {
-Obj x139749079046279 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079046311 = PRIM_ISCONS(x139749079046279);
-if (True == x139749079046311) {
-Obj x139749079047111 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079047143 = PRIM_CAR(x139749079047111);
-Obj a = x139749079047143;
-Obj x139749079047847 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079047879 = PRIM_CDR(x139749079047847);
-Obj x139749079047911 = PRIM_ISCONS(x139749079047879);
-if (True == x139749079047911) {
-Obj x139749078979271 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078979303 = PRIM_CDR(x139749078979271);
-Obj x139749078979335 = PRIM_CAR(x139749078979303);
-Obj b = x139749078979335;
-Obj x139749078980711 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078980743 = PRIM_CDR(x139749078980711);
-Obj x139749078980775 = PRIM_CDR(x139749078980743);
-Obj x139749078980807 = PRIM_ISCONS(x139749078980775);
-if (True == x139749078980807) {
-Obj x139749078981831 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078981863 = PRIM_CDR(x139749078981831);
-Obj x139749078981895 = PRIM_CDR(x139749078981863);
-Obj x139749078981927 = PRIM_CAR(x139749078981895);
-Obj c = x139749078981927;
-Obj x139749078839975 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078840007 = PRIM_CDR(x139749078839975);
-Obj x139749078840039 = PRIM_CDR(x139749078840007);
-Obj x139749078840167 = PRIM_CDR(x139749078840039);
-Obj x139749078840199 = PRIM_EQ(Nil, x139749078840167);
-if (True == x139749078840199) {
-pushCont(co, 41, clofun4, 3, a, b, c);
+Obj x139886476106695 = makeNative(32, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886474142407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474142407) {
+Obj x139886474142663 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474142695 = PRIM_EQ(symif, x139886474142663);
+if (True == x139886474142695) {
+Obj x139886474142951 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474142983 = PRIM_ISCONS(x139886474142951);
+if (True == x139886474142983) {
+Obj x139886474143239 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474143271 = PRIM_CAR(x139886474143239);
+Obj a = x139886474143271;
+Obj x139886474143591 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474143623 = PRIM_CDR(x139886474143591);
+Obj x139886474143655 = PRIM_ISCONS(x139886474143623);
+if (True == x139886474143655) {
+Obj x139886474143975 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474144007 = PRIM_CDR(x139886474143975);
+Obj x139886474144039 = PRIM_CAR(x139886474144007);
+Obj b = x139886474144039;
+Obj x139886474144423 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474144455 = PRIM_CDR(x139886474144423);
+Obj x139886474144487 = PRIM_CDR(x139886474144455);
+Obj x139886474144519 = PRIM_ISCONS(x139886474144487);
+if (True == x139886474144519) {
+Obj x139886474144903 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474144935 = PRIM_CDR(x139886474144903);
+Obj x139886474144967 = PRIM_CDR(x139886474144935);
+Obj x139886474144999 = PRIM_CAR(x139886474144967);
+Obj c = x139886474144999;
+Obj x139886474145447 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474145479 = PRIM_CDR(x139886474145447);
+Obj x139886474145511 = PRIM_CDR(x139886474145479);
+Obj x139886474145543 = PRIM_CDR(x139886474145511);
+Obj x139886474145575 = PRIM_EQ(Nil, x139886474145543);
+if (True == x139886474145575) {
+pushCont(co, 26, clofun4, 3, a, b, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6017,7 +5743,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6026,7 +5752,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6035,7 +5761,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6044,7 +5770,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6053,7 +5779,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6062,7 +5788,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080448967;
+__arg0 = x139886476106695;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6071,13 +5797,13 @@ goto *jumpTable[ps.label];
 }
 }
 
-label41:
+label26:
 {
-Obj x139749078840519 = __arg1;
+Obj x139886474145767 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 42, clofun4, 2, b, c);
+pushCont(co, 27, clofun4, 2, b, c);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6091,12 +5817,12 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label27:
 {
-Obj x139749078840967 = __arg1;
+Obj x139886474065479 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 43, clofun4, 2, b, c);
+pushCont(co, 28, clofun4, 2, b, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6108,12 +5834,12 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label43:
+label28:
 {
-Obj x139749078841255 = __arg1;
+Obj x139886474065703 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 44, clofun4, 1, c);
+pushCont(co, 29, clofun4, 1, c);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6127,11 +5853,11 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label44:
+label29:
 {
-Obj x139749078841799 = __arg1;
+Obj x139886474065959 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 45, clofun4, 1, c);
+pushCont(co, 30, clofun4, 1, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6143,11 +5869,11 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label30:
 {
-Obj x139749078842151 = __arg1;
+Obj x139886474066151 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 46, clofun4);
+PUSH_CONT_0(co, 31, clofun4);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6161,9 +5887,9 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label31:
 {
-Obj x139749078842567 = __arg1;
+Obj x139886474066407 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6175,33 +5901,33 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label47:
+label32:
 {
-Obj x139749080388487 = makeNative(11, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749079174471 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079174471) {
-Obj x139749079154695 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079154727 = PRIM_EQ(sym_37closure, x139749079154695);
-if (True == x139749079154727) {
-Obj x139749079155527 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079155783 = PRIM_ISCONS(x139749079155527);
-if (True == x139749079155783) {
-Obj x139749079156327 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079156359 = PRIM_CAR(x139749079156327);
-Obj label = x139749079156359;
-Obj x139749079157127 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079157191 = PRIM_CDR(x139749079157127);
-Obj x139749079157223 = PRIM_ISCONS(x139749079157191);
-if (True == x139749079157223) {
-Obj x139749079158183 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079158215 = PRIM_CDR(x139749079158183);
-Obj x139749079158247 = PRIM_CAR(x139749079158215);
-Obj nargs = x139749079158247;
-Obj x139749079142695 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079142727 = PRIM_CDR(x139749079142695);
-Obj x139749079142759 = PRIM_CDR(x139749079142727);
-Obj frees = x139749079142759;
-pushCont(co, 48, clofun4, 3, label, nargs, frees);
+Obj x139886476081127 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886474306695 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474306695) {
+Obj x139886474307079 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474307111 = PRIM_EQ(sym_37closure, x139886474307079);
+if (True == x139886474307111) {
+Obj x139886474307495 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474307527 = PRIM_ISCONS(x139886474307495);
+if (True == x139886474307527) {
+Obj x139886474307783 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474307815 = PRIM_CAR(x139886474307783);
+Obj label = x139886474307815;
+Obj x139886474308423 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474308455 = PRIM_CDR(x139886474308423);
+Obj x139886474308487 = PRIM_ISCONS(x139886474308455);
+if (True == x139886474308487) {
+Obj x139886474308967 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474308999 = PRIM_CDR(x139886474308967);
+Obj x139886474309031 = PRIM_CAR(x139886474308999);
+Obj nargs = x139886474309031;
+Obj x139886474309543 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474309575 = PRIM_CDR(x139886474309543);
+Obj x139886474256423 = PRIM_CDR(x139886474309575);
+Obj frees = x139886474256423;
+pushCont(co, 33, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6213,7 +5939,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080388487;
+__arg0 = x139886476081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6222,7 +5948,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080388487;
+__arg0 = x139886476081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6231,7 +5957,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080388487;
+__arg0 = x139886476081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6240,7 +5966,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080388487;
+__arg0 = x139886476081127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6249,19 +5975,352 @@ goto *jumpTable[ps.label];
 }
 }
 
-label48:
+label33:
 {
-Obj x139749079143111 = __arg1;
+Obj x139886474256615 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749079144167 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079144231 = PRIM_SUB(x139749079144167, label);
-pushCont(co, 49, clofun4, 3, label, nargs, frees);
+Obj x139886474258375 = PRIM_CAR(closureRef(co, 1));
+Obj x139886474258407 = PRIM_SUB(x139886474258375, label);
+pushCont(co, 34, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139749079144231;
+__arg1 = x139886474258407;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label34:
+{
+Obj x139886474258439 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 35, clofun4, 3, label, nargs, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = closureRef(co, 3);
+__arg2 = x139886474258439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj x139886474258471 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 36, clofun4, 3, label, nargs, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x139886474258663 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886474258951 = PRIM_CAR(closureRef(co, 1));
+pushCont(co, 37, clofun4, 2, nargs, frees);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
+__arg1 = closureRef(co, 3);
+__arg2 = label;
+__arg3 = x139886474258951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x139886474258983 = __arg1;
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 38, clofun4, 2, nargs, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label38:
+{
+Obj x139886474259175 = __arg1;
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 39, clofun4, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = closureRef(co, 3);
+__arg2 = nargs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+Obj x139886474259367 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 40, clofun4, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x139886474259559 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 41, clofun4, 1, frees);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35length);
+__arg1 = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label41:
+{
+Obj x139886474259815 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 42, clofun4, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = closureRef(co, 3);
+__arg2 = x139886474259815;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x139886474259847 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 43, clofun4, 1, frees);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35null_63);
+__arg1 = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x139886474260135 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886474260167 = primNot(x139886474260135);
+if (True == x139886474260167) {
+pushCont(co, 44, clofun4, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label44:
+{
+Obj x139886474260359 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 45, clofun4);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x139886474141767 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x139886475981127 = makeNative(49, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139886474552775 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474552775) {
+Obj x139886474553031 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474553063 = PRIM_EQ(symdo, x139886474553031);
+if (True == x139886474553063) {
+Obj x139886474553351 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474553383 = PRIM_ISCONS(x139886474553351);
+if (True == x139886474553383) {
+Obj x139886474553639 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474553671 = PRIM_CAR(x139886474553639);
+Obj a = x139886474553671;
+Obj x139886474553991 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474554055 = PRIM_CDR(x139886474553991);
+Obj x139886474554087 = PRIM_ISCONS(x139886474554055);
+if (True == x139886474554087) {
+Obj x139886474554471 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474554503 = PRIM_CDR(x139886474554471);
+Obj x139886474554535 = PRIM_CAR(x139886474554503);
+Obj b = x139886474554535;
+Obj x139886474554983 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474555015 = PRIM_CDR(x139886474554983);
+Obj x139886474555047 = PRIM_CDR(x139886474555015);
+Obj x139886474555079 = PRIM_EQ(Nil, x139886474555047);
+if (True == x139886474555079) {
+pushCont(co, 47, clofun4, 1, b);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475981127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label47:
+{
+Obj x139886474305607 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 48, clofun4, 1, b);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x139886474305799 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6271,20 +6330,68 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139749079144391 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 0, clofun5, 3, label, nargs, frees);
+Obj x139886475983271 = makeNative(8, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj x139886474580679 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474580679) {
+Obj x139886474581095 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474581127 = PRIM_EQ(symreturn, x139886474581095);
+if (True == x139886474581127) {
+Obj x139886474581383 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474581415 = PRIM_ISCONS(x139886474581383);
+if (True == x139886474581415) {
+Obj x139886474581767 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474581799 = PRIM_CAR(x139886474581767);
+Obj x = x139886474581799;
+Obj x139886474582247 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474582279 = PRIM_CDR(x139886474582247);
+Obj x139886474582311 = PRIM_EQ(Nil, x139886474582279);
+if (True == x139886474582311) {
+pushCont(co, 0, clofun5, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = x139749079144391;
+__arg2 = makeCString("__nargs = 2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475983271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -6309,390 +6416,9 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749079144423 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 1, clofun5, 3, label, nargs, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj x139749079144903 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749079145479 = PRIM_CAR(closureRef(co, 1));
-pushCont(co, 2, clofun5, 2, nargs, frees);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = closureRef(co, 3);
-__arg2 = label;
-__arg3 = x139749079145479;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x139749079145607 = __arg1;
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 3, clofun5, 2, nargs, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139749079145959 = __arg1;
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 4, clofun5, 1, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = nargs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x139749079146439 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 5, clofun5, 1, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj x139749079069063 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 6, clofun5, 1, frees);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = frees;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x139749079069735 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 7, clofun5, 1, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = x139749079069735;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x139749079069799 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 8, clofun5, 1, frees);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = frees;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj x139749079070407 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079070535 = primNot(x139749079070407);
-if (True == x139749079070535) {
-pushCont(co, 9, clofun5, 1, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj x139749079070855 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 10, clofun5);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = frees;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x139749079071527 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x139749080389255 = makeNative(14, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139749079230279 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079230279) {
-Obj x139749079231047 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079231175 = PRIM_EQ(symdo, x139749079231047);
-if (True == x139749079231175) {
-Obj x139749079231911 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079231943 = PRIM_ISCONS(x139749079231911);
-if (True == x139749079231943) {
-Obj x139749079208135 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079208167 = PRIM_CAR(x139749079208135);
-Obj a = x139749079208167;
-Obj x139749079209159 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079209191 = PRIM_CDR(x139749079209159);
-Obj x139749079209319 = PRIM_ISCONS(x139749079209191);
-if (True == x139749079209319) {
-Obj x139749079210311 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079210343 = PRIM_CDR(x139749079210311);
-Obj x139749079210375 = PRIM_CAR(x139749079210343);
-Obj b = x139749079210375;
-Obj x139749079211591 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079211623 = PRIM_CDR(x139749079211591);
-Obj x139749079211655 = PRIM_CDR(x139749079211623);
-Obj x139749079211687 = PRIM_EQ(Nil, x139749079211655);
-if (True == x139749079211687) {
-pushCont(co, 12, clofun5, 1, b);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080389255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj x139749079171655 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 13, clofun5, 1, b);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x139749079172071 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x139749080389991 = makeNative(23, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139749079756999 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079756999) {
-Obj x139749079757735 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079757799 = PRIM_EQ(symreturn, x139749079757735);
-if (True == x139749079757799) {
-Obj x139749079758471 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079758503 = PRIM_ISCONS(x139749079758471);
-if (True == x139749079758503) {
-Obj x139749079759111 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079759175 = PRIM_CAR(x139749079759111);
-Obj x = x139749079759175;
-Obj x139749079760231 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079760263 = PRIM_CDR(x139749079760231);
-Obj x139749079760295 = PRIM_EQ(Nil, x139749079760263);
-if (True == x139749079760295) {
-pushCont(co, 15, clofun5, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("__nargs = 2;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080389991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080389991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139749079760647 = __arg1;
+Obj x139886474582599 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 16, clofun5, 1, x);
+pushCont(co, 1, clofun5, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6704,11 +6430,11 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label1:
 {
-Obj x139749079245159 = __arg1;
+Obj x139886474582791 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 17, clofun5);
+PUSH_CONT_0(co, 2, clofun5);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 2);
@@ -6722,10 +6448,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label2:
 {
-Obj x139749079245735 = __arg1;
-PUSH_CONT_0(co, 18, clofun5);
+Obj x139886474583143 = __arg1;
+PUSH_CONT_0(co, 3, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6737,10 +6463,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label3:
 {
-Obj x139749079246183 = __arg1;
-PUSH_CONT_0(co, 19, clofun5);
+Obj x139886474583463 = __arg1;
+PUSH_CONT_0(co, 4, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6752,10 +6478,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label4:
 {
-Obj x139749079246727 = __arg1;
-PUSH_CONT_0(co, 20, clofun5);
+Obj x139886474583655 = __arg1;
+PUSH_CONT_0(co, 5, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6767,17 +6493,17 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label5:
 {
-Obj x139749079247271 = __arg1;
-Obj x139749079248103 = PRIM_CDR(closureRef(co, 2));
-Obj x139749079248423 = PRIM_CAR(closureRef(co, 2));
-PUSH_CONT_0(co, 21, clofun5);
+Obj x139886474583975 = __arg1;
+Obj x139886474551623 = PRIM_CDR(closureRef(co, 2));
+Obj x139886474551879 = PRIM_CAR(closureRef(co, 2));
+PUSH_CONT_0(co, 6, clofun5);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
-__arg2 = x139749079248103;
-__arg3 = x139749079248423;
+__arg2 = x139886474551623;
+__arg3 = x139886474551879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6785,10 +6511,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label6:
 {
-Obj x139749079248487 = __arg1;
-PUSH_CONT_0(co, 22, clofun5);
+Obj x139886474551911 = __arg1;
+PUSH_CONT_0(co, 7, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6800,9 +6526,9 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label7:
 {
-Obj x139749079228519 = __arg1;
+Obj x139886474552103 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6814,24 +6540,24 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
+label8:
 {
-Obj x139749080390535 = makeNative(24, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139749079973703 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079973703) {
-Obj x139749079781895 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079781959 = PRIM_EQ(symtailcall, x139749079781895);
-if (True == x139749079781959) {
-Obj x139749079782471 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079782503 = PRIM_ISCONS(x139749079782471);
-if (True == x139749079782503) {
-Obj x139749079783111 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079783239 = PRIM_CAR(x139749079783111);
-Obj exp = x139749079783239;
-Obj x139749079784071 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079784135 = PRIM_CDR(x139749079784071);
-Obj x139749079784167 = PRIM_EQ(Nil, x139749079784135);
-if (True == x139749079784167) {
+Obj x139886475984551 = makeNative(9, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x139886474643719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474643719) {
+Obj x139886474644071 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474644103 = PRIM_EQ(symtailcall, x139886474644071);
+if (True == x139886474644103) {
+Obj x139886474644455 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474644487 = PRIM_ISCONS(x139886474644455);
+if (True == x139886474644487) {
+Obj x139886474644871 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474644903 = PRIM_CAR(x139886474644871);
+Obj exp = x139886474644903;
+Obj x139886474645351 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474645383 = PRIM_CDR(x139886474645351);
+Obj x139886474645415 = PRIM_EQ(Nil, x139886474645383);
+if (True == x139886474645415) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6845,7 +6571,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080390535;
+__arg0 = x139886475984551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6854,7 +6580,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080390535;
+__arg0 = x139886475984551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6863,7 +6589,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080390535;
+__arg0 = x139886475984551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6872,7 +6598,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080390535;
+__arg0 = x139886475984551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6881,34 +6607,34 @@ goto *jumpTable[ps.label];
 }
 }
 
-label24:
+label9:
 {
-Obj x139749080391047 = makeNative(26, clofun5, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139749080366471 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080366471) {
-Obj x139749080350759 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080350791 = PRIM_EQ(symcall, x139749080350759);
-if (True == x139749080350791) {
-Obj x139749080351527 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080351623 = PRIM_ISCONS(x139749080351527);
-if (True == x139749080351623) {
-Obj x139749080352167 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080352199 = PRIM_CAR(x139749080352167);
-Obj exp = x139749080352199;
-Obj x139749080353351 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080353415 = PRIM_CDR(x139749080353351);
-Obj x139749080353511 = PRIM_ISCONS(x139749080353415);
-if (True == x139749080353511) {
-Obj x139749080354215 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080354247 = PRIM_CDR(x139749080354215);
-Obj x139749080354279 = PRIM_CAR(x139749080354247);
-Obj cont = x139749080354279;
-Obj x139749079971239 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079971271 = PRIM_CDR(x139749079971239);
-Obj x139749079971303 = PRIM_CDR(x139749079971271);
-Obj x139749079971335 = PRIM_EQ(Nil, x139749079971303);
-if (True == x139749079971335) {
-pushCont(co, 25, clofun5, 1, exp);
+Obj x139886475596551 = makeNative(11, clofun5, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj x139886474652327 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474652327) {
+Obj x139886474652647 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474652679 = PRIM_EQ(symcall, x139886474652647);
+if (True == x139886474652679) {
+Obj x139886474652999 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474653031 = PRIM_ISCONS(x139886474652999);
+if (True == x139886474653031) {
+Obj x139886474653383 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474653415 = PRIM_CAR(x139886474653383);
+Obj exp = x139886474653415;
+Obj x139886474641511 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474641543 = PRIM_CDR(x139886474641511);
+Obj x139886474641575 = PRIM_ISCONS(x139886474641543);
+if (True == x139886474641575) {
+Obj x139886474641959 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474641991 = PRIM_CDR(x139886474641959);
+Obj x139886474642023 = PRIM_CAR(x139886474641991);
+Obj cont = x139886474642023;
+Obj x139886474642503 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474642535 = PRIM_CDR(x139886474642503);
+Obj x139886474642567 = PRIM_CDR(x139886474642535);
+Obj x139886474642599 = PRIM_EQ(Nil, x139886474642567);
+if (True == x139886474642599) {
+pushCont(co, 10, clofun5, 1, exp);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45cont);
 __arg1 = closureRef(co, 1);
@@ -6921,7 +6647,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080391047;
+__arg0 = x139886475596551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6930,7 +6656,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080391047;
+__arg0 = x139886475596551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6939,7 +6665,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080391047;
+__arg0 = x139886475596551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6948,7 +6674,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080391047;
+__arg0 = x139886475596551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6957,7 +6683,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080391047;
+__arg0 = x139886475596551;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6966,9 +6692,9 @@ goto *jumpTable[ps.label];
 }
 }
 
-label25:
+label10:
 {
-Obj x139749079971783 = __arg1;
+Obj x139886474642855 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -6983,16 +6709,15 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label26:
+label11:
 {
-Obj x139749080363239 = makeNative(38, clofun5, 0, 0);
-Obj x139749080448007 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080448007) {
-Obj x139749080448295 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139749080448295;
-Obj x139749080448871 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139749080448871;
-pushCont(co, 27, clofun5, 2, f, args);
+Obj x139886475126503 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475126503) {
+Obj x139886475126727 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139886475126727;
+Obj x139886475127111 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886475127111;
+pushCont(co, 12, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7003,8 +6728,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080363239;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7013,12 +6739,12 @@ goto *jumpTable[ps.label];
 }
 }
 
-label27:
+label12:
 {
-Obj x139749080387815 = __arg1;
+Obj x139886475127399 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 28, clofun5, 2, f, args);
+pushCont(co, 13, clofun5, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
 __arg1 = args;
@@ -7029,17 +6755,17 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label28:
+label13:
 {
-Obj x139749080388967 = __arg1;
+Obj x139886475127815 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080388999 = PRIM_ADD(MAKE_NUMBER(1), x139749080388967);
-pushCont(co, 29, clofun5, 2, f, args);
+Obj x139886475127911 = PRIM_ADD(MAKE_NUMBER(1), x139886475127815);
+pushCont(co, 14, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 2);
-__arg2 = x139749080388999;
+__arg2 = x139886475127911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7047,12 +6773,12 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label29:
+label14:
 {
-Obj x139749080389031 = __arg1;
+Obj x139886475127943 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 30, clofun5, 2, f, args);
+pushCont(co, 15, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7064,19 +6790,19 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label15:
 {
-Obj x139749080389415 = __arg1;
+Obj x139886475128295 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080390247 = makeCons(f, args);
-PUSH_CONT_0(co, 31, clofun5);
+Obj x139886474649607 = makeCons(f, args);
+PUSH_CONT_0(co, 16, clofun5);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = MAKE_NUMBER(0);
-co->args[4] = x139749080390247;
+co->args[4] = x139886474649607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7084,10 +6810,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label31:
+label16:
 {
-Obj x139749080390311 = __arg1;
-PUSH_CONT_0(co, 32, clofun5);
+Obj x139886474649639 = __arg1;
+PUSH_CONT_0(co, 17, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7099,10 +6825,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label32:
+label17:
 {
-Obj x139749080390759 = __arg1;
-PUSH_CONT_0(co, 33, clofun5);
+Obj x139886474650023 = __arg1;
+PUSH_CONT_0(co, 18, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7114,10 +6840,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label33:
+label18:
 {
-Obj x139749080391271 = __arg1;
-PUSH_CONT_0(co, 34, clofun5);
+Obj x139886474650311 = __arg1;
+PUSH_CONT_0(co, 19, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7129,10 +6855,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label34:
+label19:
 {
-Obj x139749080363015 = __arg1;
-PUSH_CONT_0(co, 35, clofun5);
+Obj x139886474650631 = __arg1;
+PUSH_CONT_0(co, 20, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7144,17 +6870,17 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label35:
+label20:
 {
-Obj x139749080363591 = __arg1;
-Obj x139749080364391 = PRIM_CDR(closureRef(co, 1));
-Obj x139749080364743 = PRIM_CAR(closureRef(co, 1));
-PUSH_CONT_0(co, 36, clofun5);
+Obj x139886474650951 = __arg1;
+Obj x139886474651271 = PRIM_CDR(closureRef(co, 1));
+Obj x139886474651399 = PRIM_CAR(closureRef(co, 1));
+PUSH_CONT_0(co, 21, clofun5);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 2);
-__arg2 = x139749080364391;
-__arg3 = x139749080364743;
+__arg2 = x139886474651271;
+__arg3 = x139886474651399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7162,10 +6888,10 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label36:
+label21:
 {
-Obj x139749080364775 = __arg1;
-PUSH_CONT_0(co, 37, clofun5);
+Obj x139886474651495 = __arg1;
+PUSH_CONT_0(co, 22, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7177,9 +6903,9 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label37:
+label22:
 {
-Obj x139749080365543 = __arg1;
+Obj x139886474651687 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -7191,23 +6917,11 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label38:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label39:
+label23:
 {
 Obj sym = __arg1;
 Obj globals = __arg2;
-pushCont(co, 40, clofun5, 2, sym, globals);
+pushCont(co, 24, clofun5, 2, sym, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35value);
 __arg1 = globals;
@@ -7218,13 +6932,13 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label24:
 {
-Obj x139749080462503 = __arg1;
+Obj x139886475183911 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val = x139749080462503;
-pushCont(co, 41, clofun5, 3, sym, val, globals);
+Obj val = x139886475183911;
+pushCont(co, 25, clofun5, 3, sym, val, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = sym;
@@ -7236,76 +6950,56 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label41:
+label25:
 {
-Obj x139749080462983 = __arg1;
+Obj x139886475184103 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139749080462983) {
+if (True == x139886475184103) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139749080463559 = makeCons(sym, val);
-Obj x139749080463655 = primSet(co, globals, x139749080463559);
+Obj x139886475184263 = makeCons(sym, val);
+Obj x139886475184295 = primSet(co, globals, x139886475184263);
 __nargs = 2;
-__arg1 = x139749080463655;
+__arg1 = x139886475184295;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label42:
+label26:
 {
-Obj x139749080462183 = __arg1;
-Obj x139749080462215 = __arg2;
-Obj x139749080462247 = __arg3;
-Obj x139749080462279 = co->args[4];
-Obj x139749080463015 = makeNative(43, clofun5, 0, 4, x139749080462183, x139749080462215, x139749080462247, x139749080462279);
-Obj self = x139749080462183;
-Obj w = x139749080462215;
-Obj i = x139749080462247;
-Obj x139749080477543 = PRIM_EQ(Nil, x139749080462279);
-if (True == x139749080477543) {
+Obj x139886476106727 = __arg1;
+Obj x139886476106759 = __arg2;
+Obj x139886476106791 = __arg3;
+Obj x139886476106855 = co->args[4];
+Obj x139886475190503 = PRIM_EQ(Nil, x139886476106855);
+if (True == x139886475190503) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080463015;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label43:
-{
-Obj x139749080464039 = makeNative(5, clofun6, 0, 0);
-Obj self = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj i = closureRef(co, 2);
-Obj x139749080647111 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139749080647111) {
-Obj x139749080647687 = PRIM_CAR(closureRef(co, 3));
-Obj x = x139749080647687;
-Obj x139749080648103 = PRIM_CDR(closureRef(co, 3));
-Obj more = x139749080648103;
-Obj x139749080649031 = PRIM_GT(i, MAKE_NUMBER(3));
-Obj x139749080649223 = primNot(x139749080649031);
-if (True == x139749080649223) {
-pushCont(co, 0, clofun6, 5, x, i, self, w, more);
+Obj x139886475190919 = PRIM_ISCONS(x139886476106855);
+if (True == x139886475190919) {
+Obj x139886475191207 = PRIM_CAR(x139886476106855);
+Obj x = x139886475191207;
+Obj x139886475192135 = PRIM_CDR(x139886476106855);
+Obj more = x139886475192135;
+Obj x139886475192551 = PRIM_GT(x139886476106791, MAKE_NUMBER(3));
+Obj x139886475192583 = primNot(x139886475192551);
+if (True == x139886475192583) {
+pushCont(co, 33, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476106759;
 __arg2 = makeCString("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7313,10 +7007,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 44, clofun5, 5, x, i, self, w, more);
+pushCont(co, 27, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476106759;
 __arg2 = makeCString("co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7325,8 +7019,9 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-__nargs = 1;
-__arg0 = x139749080464039;
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7334,20 +7029,21 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
+}
 
-label44:
+label27:
 {
-Obj x139749080526183 = __arg1;
+Obj x139886475194087 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 45, clofun5, 5, x, i, self, w, more);
+pushCont(co, 28, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = i;
+__arg1 = x139886476106759;
+__arg2 = x139886476106791;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7355,18 +7051,18 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label45:
+label28:
 {
-Obj x139749080526663 = __arg1;
+Obj x139886475182183 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 46, clofun5, 5, x, i, self, w, more);
+pushCont(co, 29, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476106759;
 __arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7375,19 +7071,484 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label46:
+label29:
 {
-Obj x139749080473831 = __arg1;
+Obj x139886475182279 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 47, clofun5, 5, x, i, self, w, more);
+pushCont(co, 30, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
+__arg1 = x139886476106759;
 __arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886475182535 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 31, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = x139886476106727;
+__arg2 = Nil;
+__arg3 = x139886476106759;
+co->args[4] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
+Obj x139886475182759 = __arg1;
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 32, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = x139886476106759;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label32:
+{
+Obj x139886475182919 = __arg1;
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475183239 = PRIM_ADD(x139886476106791, MAKE_NUMBER(1));
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
+__arg1 = x139886476106727;
+__arg2 = x139886476106759;
+__arg3 = x139886475183239;
+co->args[4] = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label33:
+{
+Obj x139886475192743 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 34, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg1 = x139886476106759;
+__arg2 = x139886476106791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label34:
+{
+Obj x139886475192903 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 35, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = x139886476106759;
+__arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj x139886475193127 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 36, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
+__arg1 = x139886476106727;
+__arg2 = Nil;
+__arg3 = x139886476106759;
+co->args[4] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x139886475193351 = __arg1;
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 37, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg1 = x139886476106759;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x139886475193639 = __arg1;
+Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x139886475193895 = PRIM_ADD(x139886476106791, MAKE_NUMBER(1));
+__nargs = 5;
+__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
+__arg1 = x139886476106727;
+__arg2 = x139886476106759;
+__arg3 = x139886475193895;
+co->args[4] = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label38:
+{
+Obj x = __arg1;
+Obj k = __arg2;
+Obj x139886475246343 = primGenSym();
+Obj tmp = x139886475246343;
+pushCont(co, 39, clofun5, 2, x, tmp);
+__nargs = 2;
+__arg0 = k;
+__arg1 = tmp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+Obj x139886475247015 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475247047 = makeCons(x139886475247015, Nil);
+Obj x139886475247079 = makeCons(x, x139886475247047);
+Obj x139886475247111 = makeCons(tmp, x139886475247079);
+Obj x139886475247143 = makeCons(symlet, x139886475247111);
+__nargs = 2;
+__arg1 = x139886475247143;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label40:
+{
+Obj v = __arg1;
+Obj val = __arg2;
+pushCont(co, 41, clofun5, 2, val, v);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35vector_45ref);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label41:
+{
+Obj x139886475244103 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj idx = x139886475244103;
+pushCont(co, 42, clofun5, 3, val, idx, v);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35vector_45ref);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x139886475244327 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cur = x139886475244327;
+Obj x139886475244935 = makeCons(val, Nil);
+Obj x139886475244967 = makeCons(idx, x139886475244935);
+Obj x139886475244999 = makeCons(x139886475244967, cur);
+Obj cur1 = x139886475244999;
+Obj x139886475245383 = PRIM_ADD(idx, MAKE_NUMBER(1));
+pushCont(co, 43, clofun5, 2, v, cur1);
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35vector_45set_33);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(0);
+__arg3 = x139886475245383;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x139886475245415 = __arg1;
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 4;
+__arg0 = globalRef(symcora_47init_35vector_45set_33);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(1);
+__arg3 = cur1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label44:
+{
+Obj x139886476185831 = __arg1;
+Obj x139886476185863 = __arg2;
+Obj x139886476187719 = makeNative(1, clofun6, 0, 2, x139886476185831, x139886476185863);
+Obj x139886475383495 = PRIM_ISCONS(x139886476185863);
+if (True == x139886475383495) {
+Obj x139886475383655 = PRIM_CAR(x139886476185863);
+Obj clo_45or_45cont = x139886475383655;
+Obj x139886475384039 = PRIM_CDR(x139886476185863);
+Obj x139886475384071 = PRIM_ISCONS(x139886475384039);
+if (True == x139886475384071) {
+Obj x139886475384455 = PRIM_CDR(x139886476185863);
+Obj x139886475384487 = PRIM_CAR(x139886475384455);
+Obj x139886475384519 = PRIM_ISCONS(x139886475384487);
+if (True == x139886475384519) {
+Obj x139886475385031 = PRIM_CDR(x139886476185863);
+Obj x139886475385063 = PRIM_CAR(x139886475385031);
+Obj x139886475385095 = PRIM_CAR(x139886475385063);
+Obj x139886475385127 = PRIM_EQ(symlambda, x139886475385095);
+if (True == x139886475385127) {
+Obj x139886475385511 = PRIM_CDR(x139886476185863);
+Obj x139886475385543 = PRIM_CAR(x139886475385511);
+Obj x139886475385575 = PRIM_CDR(x139886475385543);
+Obj x139886475385607 = PRIM_ISCONS(x139886475385575);
+if (True == x139886475385607) {
+Obj x139886475386151 = PRIM_CDR(x139886476185863);
+Obj x139886475386183 = PRIM_CAR(x139886475386151);
+Obj x139886475386247 = PRIM_CDR(x139886475386183);
+Obj x139886475386279 = PRIM_CAR(x139886475386247);
+Obj params = x139886475386279;
+Obj x139886475329607 = PRIM_CDR(x139886476185863);
+Obj x139886475329639 = PRIM_CAR(x139886475329607);
+Obj x139886475329671 = PRIM_CDR(x139886475329639);
+Obj x139886475329703 = PRIM_CDR(x139886475329671);
+Obj x139886475329767 = PRIM_ISCONS(x139886475329703);
+if (True == x139886475329767) {
+Obj x139886475330343 = PRIM_CDR(x139886476185863);
+Obj x139886475330375 = PRIM_CAR(x139886475330343);
+Obj x139886475330471 = PRIM_CDR(x139886475330375);
+Obj x139886475330535 = PRIM_CDR(x139886475330471);
+Obj x139886475330567 = PRIM_CAR(x139886475330535);
+Obj body = x139886475330567;
+Obj x139886475331399 = PRIM_CDR(x139886476185863);
+Obj x139886475331431 = PRIM_CAR(x139886475331399);
+Obj x139886475331495 = PRIM_CDR(x139886475331431);
+Obj x139886475331527 = PRIM_CDR(x139886475331495);
+Obj x139886475331559 = PRIM_CDR(x139886475331527);
+Obj x139886475331591 = PRIM_EQ(Nil, x139886475331559);
+if (True == x139886475331591) {
+Obj x139886475332007 = PRIM_CDR(x139886476185863);
+Obj x139886475332039 = PRIM_CDR(x139886475332007);
+Obj fvs = x139886475332039;
+Obj x139886476185895 = makeNative(45, clofun5, 1, 6, body, x139886476185831, params, clo_45or_45cont, fvs, x139886476187719);
+Obj x139886475271175 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == x139886475271175) {
+__nargs = 2;
+__arg0 = x139886476185895;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475271431 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
+if (True == x139886475271431) {
+__nargs = 2;
+__arg0 = x139886476185895;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476185895;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476187719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label45:
+{
+Obj x139886476185927 = __arg1;
+if (True == x139886476185927) {
+PUSH_CONT_0(co, 46, clofun5);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = closureRef(co, 5);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label46:
+{
+Obj x139886475332807 = __arg1;
+Obj body1 = x139886475332807;
+pushCont(co, 47, clofun5, 1, body1);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35vector_45ref);
+__arg1 = closureRef(co, 1);
+__arg2 = MAKE_NUMBER(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7397,59 +7558,64 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139749080474279 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 48, clofun5, 4, i, self, w, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = self;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = x;
+Obj x139886475333063 = __arg1;
+Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cur = x139886475333063;
+Obj x139886475333383 = PRIM_EQ(closureRef(co, 3), sym_37closure);
+if (True == x139886475333383) {
+Obj x139886475268455 = makeCons(body1, Nil);
+Obj x139886475268487 = makeCons(Nil, x139886475268455);
+Obj x139886475268519 = makeCons(closureRef(co, 2), x139886475268487);
+Obj x139886475268647 = makeCons(symlambda, x139886475268519);
+pushCont(co, 49, clofun5, 1, cur);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
+__arg1 = closureRef(co, 1);
+__arg2 = x139886475268647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj x139886475270119 = makeCons(body1, Nil);
+Obj x139886475270151 = makeCons(closureRef(co, 4), x139886475270119);
+Obj x139886475270183 = makeCons(closureRef(co, 2), x139886475270151);
+Obj x139886475270215 = makeCons(symlambda, x139886475270183);
+pushCont(co, 48, clofun5, 1, cur);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
+__arg1 = closureRef(co, 1);
+__arg2 = x139886475270215;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label48:
 {
-Obj x139749080475111 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 49, clofun5, 4, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475270247 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475270567 = makeCons(cur, closureRef(co, 4));
+Obj x139886475270599 = makeCons(closureRef(co, 3), x139886475270567);
+__nargs = 2;
+__arg1 = x139886475270599;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label49:
 {
-Obj x139749080475687 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749080476519 = PRIM_ADD(i, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
-__arg1 = self;
-__arg2 = w;
-__arg3 = x139749080476519;
-co->args[4] = more;
+Obj x139886475268679 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun6, 1, cur);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35length);
+__arg1 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7479,778 +7645,41 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749080522919 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 1, clofun6, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475269159 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475269319 = makeCons(x139886475269159, closureRef(co, 4));
+Obj x139886475269383 = makeCons(cur, x139886475269319);
+Obj x139886475269415 = makeCons(closureRef(co, 3), x139886475269383);
+__nargs = 2;
+__arg1 = x139886475269415;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj x139749080523271 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 2, clofun6, 5, x, i, self, w, more);
+Obj x139886475382887 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139886475382887) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(" = ");
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = makeNative(2, clofun6, 1, 1, closureRef(co, 0));
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = closureRef(co, 1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label2:
-{
-Obj x139749080523751 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 3, clofun6, 4, i, self, w, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = self;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139749080524327 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 4, clofun6, 4, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x139749080524935 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749080525575 = PRIM_ADD(i, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
-__arg1 = self;
-__arg2 = w;
-__arg3 = x139749080525575;
-co->args[4] = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x = __arg1;
-Obj k = __arg2;
-Obj x139749078421703 = primGenSym();
-Obj tmp = x139749078421703;
-pushCont(co, 7, clofun6, 2, x, tmp);
-__nargs = 2;
-__arg0 = k;
-__arg1 = tmp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x139749078422631 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749078422695 = makeCons(x139749078422631, Nil);
-Obj x139749078422727 = makeCons(x, x139749078422695);
-Obj x139749078422759 = makeCons(tmp, x139749078422727);
-Obj x139749078422791 = makeCons(symlet, x139749078422759);
-__nargs = 2;
-__arg1 = x139749078422791;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label8:
-{
-Obj v = __arg1;
-Obj val = __arg2;
-pushCont(co, 9, clofun6, 2, val, v);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj x139749078648711 = __arg1;
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj idx = x139749078648711;
-pushCont(co, 10, clofun6, 3, val, idx, v);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x139749078648999 = __arg1;
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cur = x139749078648999;
-Obj x139749078649639 = makeCons(val, Nil);
-Obj x139749078649671 = makeCons(idx, x139749078649639);
-Obj x139749078649735 = makeCons(x139749078649671, cur);
-Obj cur1 = x139749078649735;
-Obj x139749078650247 = PRIM_ADD(idx, MAKE_NUMBER(1));
-pushCont(co, 11, clofun6, 2, v, cur1);
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-__arg3 = x139749078650247;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x139749078650279 = __arg1;
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(1);
-__arg3 = cur1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj x139749080475047 = __arg1;
-Obj x139749080475079 = __arg2;
-Obj x139749080475463 = makeNative(28, clofun6, 0, 2, x139749080475047, x139749080475079);
-Obj v = x139749080475047;
-Obj x139749079070183 = PRIM_ISCONS(x139749080475079);
-if (True == x139749079070183) {
-Obj x139749079070439 = PRIM_CAR(x139749080475079);
-Obj clo_45or_45cont = x139749079070439;
-Obj x139749079070951 = PRIM_CDR(x139749080475079);
-Obj x139749079070983 = PRIM_ISCONS(x139749079070951);
-if (True == x139749079070983) {
-Obj x139749079071943 = PRIM_CDR(x139749080475079);
-Obj x139749079071975 = PRIM_CAR(x139749079071943);
-Obj x139749079072007 = PRIM_ISCONS(x139749079071975);
-if (True == x139749079072007) {
-Obj x139749079044551 = PRIM_CDR(x139749080475079);
-Obj x139749079044583 = PRIM_CAR(x139749079044551);
-Obj x139749079044615 = PRIM_CAR(x139749079044583);
-Obj x139749079044647 = PRIM_EQ(symlambda, x139749079044615);
-if (True == x139749079044647) {
-Obj x139749079045671 = PRIM_CDR(x139749080475079);
-Obj x139749079045831 = PRIM_CAR(x139749079045671);
-Obj x139749079045863 = PRIM_CDR(x139749079045831);
-Obj x139749079045895 = PRIM_ISCONS(x139749079045863);
-if (True == x139749079045895) {
-Obj x139749079046759 = PRIM_CDR(x139749080475079);
-Obj x139749079046791 = PRIM_CAR(x139749079046759);
-Obj x139749079047047 = PRIM_CDR(x139749079046791);
-Obj x139749079047079 = PRIM_CAR(x139749079047047);
-Obj params = x139749079047079;
-Obj x139749078978631 = PRIM_CDR(x139749080475079);
-Obj x139749078978663 = PRIM_CAR(x139749078978631);
-Obj x139749078978695 = PRIM_CDR(x139749078978663);
-Obj x139749078978823 = PRIM_CDR(x139749078978695);
-Obj x139749078978855 = PRIM_ISCONS(x139749078978823);
-if (True == x139749078978855) {
-Obj x139749078980039 = PRIM_CDR(x139749080475079);
-Obj x139749078980071 = PRIM_CAR(x139749078980039);
-Obj x139749078980103 = PRIM_CDR(x139749078980071);
-Obj x139749078980135 = PRIM_CDR(x139749078980103);
-Obj x139749078980167 = PRIM_CAR(x139749078980135);
-Obj body = x139749078980167;
-Obj x139749078981543 = PRIM_CDR(x139749080475079);
-Obj x139749078981575 = PRIM_CAR(x139749078981543);
-Obj x139749078981607 = PRIM_CDR(x139749078981575);
-Obj x139749078981639 = PRIM_CDR(x139749078981607);
-Obj x139749078981671 = PRIM_CDR(x139749078981639);
-Obj x139749078981703 = PRIM_EQ(Nil, x139749078981671);
-if (True == x139749078981703) {
-Obj x139749078982343 = PRIM_CDR(x139749080475079);
-Obj x139749078982375 = PRIM_CDR(x139749078982343);
-Obj fvs = x139749078982375;
-Obj x139749078839431 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139749078839431) {
-if (True == True) {
-pushCont(co, 23, clofun6, 4, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = v;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-Obj x139749078824679 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
-if (True == x139749078824679) {
-if (True == True) {
-pushCont(co, 18, clofun6, 4, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = v;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 13, clofun6, 4, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = v;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj x139749078769767 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139749078769767;
-pushCont(co, 14, clofun6, 5, body1, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x139749078770055 = __arg1;
-Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139749078770055;
-Obj x139749078770343 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139749078770343) {
-Obj x139749078771399 = makeCons(body1, Nil);
-Obj x139749078771431 = makeCons(Nil, x139749078771399);
-Obj x139749078771463 = makeCons(params, x139749078771431);
-Obj x139749078771495 = makeCons(symlambda, x139749078771463);
-pushCont(co, 16, clofun6, 4, params, fvs, cur, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078771495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078773447 = makeCons(body1, Nil);
-Obj x139749078773479 = makeCons(fvs, x139749078773447);
-Obj x139749078773511 = makeCons(params, x139749078773479);
-Obj x139749078773543 = makeCons(symlambda, x139749078773511);
-pushCont(co, 15, clofun6, 3, cur, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078773543;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139749078773575 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078647015 = makeCons(cur, fvs);
-Obj x139749078647047 = makeCons(clo_45or_45cont, x139749078647015);
-__nargs = 2;
-__arg1 = x139749078647047;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj x139749078771527 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 17, clofun6, 3, fvs, cur, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj x139749078772263 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078772327 = makeCons(x139749078772263, fvs);
-Obj x139749078772359 = makeCons(cur, x139749078772327);
-Obj x139749078772391 = makeCons(clo_45or_45cont, x139749078772359);
-__nargs = 2;
-__arg1 = x139749078772391;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label18:
-{
-Obj x139749078824967 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139749078824967;
-pushCont(co, 19, clofun6, 5, body1, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj x139749078825383 = __arg1;
-Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139749078825383;
-Obj x139749078825671 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139749078825671) {
-Obj x139749078826887 = makeCons(body1, Nil);
-Obj x139749078826919 = makeCons(Nil, x139749078826887);
-Obj x139749078826951 = makeCons(params, x139749078826919);
-Obj x139749078826983 = makeCons(symlambda, x139749078826951);
-pushCont(co, 21, clofun6, 4, params, fvs, cur, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078826983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078808647 = makeCons(body1, Nil);
-Obj x139749078808679 = makeCons(fvs, x139749078808647);
-Obj x139749078808711 = makeCons(params, x139749078808679);
-Obj x139749078808743 = makeCons(symlambda, x139749078808711);
-pushCont(co, 20, clofun6, 3, cur, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078808743;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj x139749078808775 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078777511 = makeCons(cur, fvs);
-Obj x139749078777543 = makeCons(clo_45or_45cont, x139749078777511);
-__nargs = 2;
-__arg1 = x139749078777543;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label21:
-{
-Obj x139749078806535 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 22, clofun6, 3, fvs, cur, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label22:
-{
-Obj x139749078807431 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078807495 = makeCons(x139749078807431, fvs);
-Obj x139749078807527 = makeCons(cur, x139749078807495);
-Obj x139749078807559 = makeCons(clo_45or_45cont, x139749078807527);
-__nargs = 2;
-__arg1 = x139749078807559;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label23:
-{
-Obj x139749078839783 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = x139749078839783;
-pushCont(co, 24, clofun6, 5, body1, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label24:
-{
-Obj x139749078840135 = __arg1;
-Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = x139749078840135;
-Obj x139749078840423 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139749078840423) {
-Obj x139749078841607 = makeCons(body1, Nil);
-Obj x139749078841639 = makeCons(Nil, x139749078841607);
-Obj x139749078841671 = makeCons(params, x139749078841639);
-Obj x139749078841703 = makeCons(symlambda, x139749078841671);
-pushCont(co, 26, clofun6, 4, params, fvs, cur, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078841703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749078823463 = makeCons(body1, Nil);
-Obj x139749078823495 = makeCons(fvs, x139749078823463);
-Obj x139749078823527 = makeCons(params, x139749078823495);
-Obj x139749078823559 = makeCons(symlambda, x139749078823527);
-pushCont(co, 25, clofun6, 3, cur, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139749078823559;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label25:
-{
-Obj x139749078823591 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078824103 = makeCons(cur, fvs);
-Obj x139749078824135 = makeCons(clo_45or_45cont, x139749078824103);
-__nargs = 2;
-__arg1 = x139749078824135;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label26:
-{
-Obj x139749078841735 = __arg1;
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 27, clofun6, 3, fvs, cur, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label27:
-{
-Obj x139749078842599 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078842663 = makeCons(x139749078842599, fvs);
-Obj x139749078842695 = makeCons(cur, x139749078842663);
-Obj x139749078842727 = makeCons(clo_45or_45cont, x139749078842695);
-__nargs = 2;
-__arg1 = x139749078842727;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label28:
-{
-Obj x139749080477159 = makeNative(30, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v = closureRef(co, 0);
-Obj f_45args = closureRef(co, 1);
-Obj x139749079068839 = PRIM_ISCONS(f_45args);
-if (True == x139749079068839) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = makeNative(29, clofun6, 1, 1, v);
-__arg2 = f_45args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080477159;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label29:
 {
 Obj e = __arg1;
 __nargs = 3;
@@ -8264,41 +7693,14 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label3:
 {
-Obj x139749080461319 = makeNative(31, clofun6, 0, 0);
-Obj v = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label31:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x139749080648871 = __arg1;
-Obj x139749080648903 = __arg2;
-Obj x139749080649287 = makeNative(34, clofun6, 0, 2, x139749080648871, x139749080648903);
-Obj __ = x139749080648871;
-Obj x = x139749080648903;
-pushCont(co, 33, clofun6, 2, x, x139749080649287);
+Obj x139886475983879 = __arg1;
+Obj x139886475983911 = __arg2;
+pushCont(co, 4, clofun6, 2, x139886475983911, x139886475983879);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x;
+__arg1 = x139886475983911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8306,83 +7708,55 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label33:
+label4:
 {
-Obj x139749079144519 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080649287= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749079144519) {
+Obj x139886475567879 = __arg1;
+Obj x139886475983911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475983879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475567879) {
 __nargs = 2;
-__arg1 = x;
+__arg1 = x139886475983911;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080649287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj x139749080522887 = makeNative(35, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj x139749079143879 = primIsSymbol(var);
-if (True == x139749079143879) {
+Obj x139886475568071 = primIsSymbol(x139886475983911);
+if (True == x139886475568071) {
 __nargs = 2;
-__arg1 = var;
+__arg1 = x139886475983911;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080522887;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label35:
-{
-Obj x139749080523463 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj x139749079173319 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079173319) {
-Obj x139749079174119 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079174215 = PRIM_EQ(symlambda, x139749079174119);
-if (True == x139749079174215) {
-Obj x139749079174727 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079174791 = PRIM_ISCONS(x139749079174727);
-if (True == x139749079174791) {
-Obj x139749079154791 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079154855 = PRIM_CAR(x139749079154791);
-Obj args = x139749079154855;
-Obj x139749079155943 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079156007 = PRIM_CDR(x139749079155943);
-Obj x139749079156039 = PRIM_ISCONS(x139749079156007);
-if (True == x139749079156039) {
-Obj x139749079156647 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079156679 = PRIM_CDR(x139749079156647);
-Obj x139749079156711 = PRIM_CAR(x139749079156679);
-Obj body = x139749079156711;
-Obj x139749079157703 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079157735 = PRIM_CDR(x139749079157703);
-Obj x139749079157767 = PRIM_CDR(x139749079157735);
-Obj x139749079157799 = PRIM_EQ(Nil, x139749079157767);
-if (True == x139749079157799) {
-pushCont(co, 36, clofun6, 1, args);
+Obj x139886475460679 = makeNative(6, clofun6, 0, 2, x139886475983911, x139886475983879);
+Obj x139886475460935 = PRIM_ISCONS(x139886475983911);
+if (True == x139886475460935) {
+Obj x139886475461255 = PRIM_CAR(x139886475983911);
+Obj x139886475461287 = PRIM_EQ(symlambda, x139886475461255);
+if (True == x139886475461287) {
+Obj x139886475461575 = PRIM_CDR(x139886475983911);
+Obj x139886475461607 = PRIM_ISCONS(x139886475461575);
+if (True == x139886475461607) {
+Obj x139886475461863 = PRIM_CDR(x139886475983911);
+Obj x139886475461927 = PRIM_CAR(x139886475461863);
+Obj args = x139886475461927;
+Obj x139886475462247 = PRIM_CDR(x139886475983911);
+Obj x139886475462279 = PRIM_CDR(x139886475462247);
+Obj x139886475462311 = PRIM_ISCONS(x139886475462279);
+if (True == x139886475462311) {
+Obj x139886475462599 = PRIM_CDR(x139886475983911);
+Obj x139886475462631 = PRIM_CDR(x139886475462599);
+Obj x139886475462663 = PRIM_CAR(x139886475462631);
+Obj body = x139886475462663;
+Obj x139886475463015 = PRIM_CDR(x139886475983911);
+Obj x139886475463047 = PRIM_CDR(x139886475463015);
+Obj x139886475463079 = PRIM_CDR(x139886475463047);
+Obj x139886475463111 = PRIM_EQ(Nil, x139886475463079);
+if (True == x139886475463111) {
+pushCont(co, 5, clofun6, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs;
+__arg1 = x139886475983879;
 __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8391,7 +7765,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080523463;
+__arg0 = x139886475460679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8400,7 +7774,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080523463;
+__arg0 = x139886475460679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8409,7 +7783,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080523463;
+__arg0 = x139886475460679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8418,7 +7792,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080523463;
+__arg0 = x139886475460679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8427,58 +7801,59 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080523463;
+__arg0 = x139886475460679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+}
 }
 }
 
-label36:
+label5:
 {
-Obj x139749079142439 = __arg1;
+Obj x139886475463495 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079142503 = makeCons(x139749079142439, Nil);
-Obj x139749079142535 = makeCons(args, x139749079142503);
-Obj x139749079142567 = makeCons(symlambda, x139749079142535);
+Obj x139886475463559 = makeCons(x139886475463495, Nil);
+Obj x139886475463591 = makeCons(args, x139886475463559);
+Obj x139886475463655 = makeCons(symlambda, x139886475463591);
 __nargs = 2;
-__arg1 = x139749079142567;
+__arg1 = x139886475463655;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label37:
+label6:
 {
-Obj x139749080524711 = makeNative(43, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj x139749079248455 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079248455) {
-Obj x139749079228711 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079228871 = PRIM_EQ(symcontinuation, x139749079228711);
-if (True == x139749079228871) {
-Obj x139749079229351 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079229415 = PRIM_ISCONS(x139749079229351);
-if (True == x139749079229415) {
-Obj x139749079230151 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079230183 = PRIM_CAR(x139749079230151);
-Obj val = x139749079230183;
-Obj x139749079231079 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079231111 = PRIM_CDR(x139749079231079);
-Obj x139749079231143 = PRIM_ISCONS(x139749079231111);
-if (True == x139749079231143) {
-Obj x139749079232103 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079232135 = PRIM_CDR(x139749079232103);
-Obj x139749079232167 = PRIM_CAR(x139749079232135);
-Obj body = x139749079232167;
-Obj x139749079208647 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079208679 = PRIM_CDR(x139749079208647);
-Obj x139749079208839 = PRIM_CDR(x139749079208679);
-Obj x139749079208871 = PRIM_EQ(Nil, x139749079208839);
-if (True == x139749079208871) {
-pushCont(co, 38, clofun6, 3, fvs, body, val);
+Obj x139886475383943 = makeNative(12, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886475509479 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475509479) {
+Obj x139886475468807 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475468839 = PRIM_EQ(symcontinuation, x139886475468807);
+if (True == x139886475468839) {
+Obj x139886475469159 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475469223 = PRIM_ISCONS(x139886475469159);
+if (True == x139886475469223) {
+Obj x139886475469575 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475469607 = PRIM_CAR(x139886475469575);
+Obj val = x139886475469607;
+Obj x139886475470119 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475470151 = PRIM_CDR(x139886475470119);
+Obj x139886475470183 = PRIM_ISCONS(x139886475470151);
+if (True == x139886475470183) {
+Obj x139886475470503 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475470567 = PRIM_CDR(x139886475470503);
+Obj x139886475470599 = PRIM_CAR(x139886475470567);
+Obj body = x139886475470599;
+Obj x139886475471047 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475471143 = PRIM_CDR(x139886475471047);
+Obj x139886475471175 = PRIM_CDR(x139886475471143);
+Obj x139886475471207 = PRIM_EQ(Nil, x139886475471175);
+if (True == x139886475471207) {
+pushCont(co, 7, clofun6, 2, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = body;
@@ -8489,7 +7864,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080524711;
+__arg0 = x139886475383943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8498,7 +7873,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080524711;
+__arg0 = x139886475383943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8507,7 +7882,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080524711;
+__arg0 = x139886475383943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8516,7 +7891,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080524711;
+__arg0 = x139886475383943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8525,7 +7900,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080524711;
+__arg0 = x139886475383943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8534,16 +7909,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label38:
+label7:
 {
-Obj x139749079209447 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 39, clofun6, 3, fvs, body, val);
+Obj x139886475471495 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 8, clofun6, 2, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139749079209447;
+__arg1 = x139886475471495;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8552,17 +7926,16 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label39:
+label8:
 {
-Obj x139749079209511 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = x139749079209511;
-pushCont(co, 40, clofun6, 3, fvs1, body, val);
+Obj x139886475471527 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fvs1 = x139886475471527;
+pushCont(co, 9, clofun6, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs;
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8570,16 +7943,16 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label40:
+label9:
 {
-Obj x139749079210119 = __arg1;
+Obj x139886475471879 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 41, clofun6, 3, fvs1, body, val);
+pushCont(co, 10, clofun6, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079210119;
+__arg1 = x139886475471879;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8588,14 +7961,14 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label41:
+label10:
 {
-Obj x139749079210279 = __arg1;
+Obj x139886475471911 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs2 = x139749079210279;
-pushCont(co, 42, clofun6, 2, val, fvs2);
+Obj fvs2 = x139886475471911;
+pushCont(co, 11, clofun6, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
 __arg1 = fvs1;
@@ -8607,55 +7980,54 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label42:
+label11:
 {
-Obj x139749079171079 = __arg1;
+Obj x139886475472359 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079171143 = makeCons(x139749079171079, Nil);
-Obj x139749079171175 = makeCons(val, x139749079171143);
-Obj x139749079171207 = makeCons(symlambda, x139749079171175);
-Obj x139749079171271 = makeCons(x139749079171207, fvs2);
-Obj x139749079171303 = makeCons(sym_37continuation, x139749079171271);
+Obj x139886475472391 = makeCons(x139886475472359, Nil);
+Obj x139886475472487 = makeCons(val, x139886475472391);
+Obj x139886475472519 = makeCons(symlambda, x139886475472487);
+Obj x139886475472551 = makeCons(x139886475472519, fvs2);
+Obj x139886475472583 = makeCons(sym_37continuation, x139886475472551);
 __nargs = 2;
-__arg1 = x139749079171303;
+__arg1 = x139886475472583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label43:
+label12:
 {
-Obj x139749080525959 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj x139749079784839 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079784839) {
-Obj x139749079785319 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079785383 = PRIM_EQ(symcall, x139749079785319);
-if (True == x139749079785383) {
-Obj x139749079757415 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079757447 = PRIM_ISCONS(x139749079757415);
-if (True == x139749079757447) {
-Obj x139749079758087 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079758119 = PRIM_CAR(x139749079758087);
-Obj exp = x139749079758119;
-Obj x139749079758887 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079758919 = PRIM_CDR(x139749079758887);
-Obj x139749079758951 = PRIM_ISCONS(x139749079758919);
-if (True == x139749079758951) {
-Obj x139749079759719 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079759751 = PRIM_CDR(x139749079759719);
-Obj x139749079759943 = PRIM_CAR(x139749079759751);
-Obj cont = x139749079759943;
-Obj x139749079244903 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079244935 = PRIM_CDR(x139749079244903);
-Obj x139749079244967 = PRIM_CDR(x139749079244935);
-Obj x139749079244999 = PRIM_EQ(Nil, x139749079244967);
-if (True == x139749079244999) {
-pushCont(co, 44, clofun6, 3, exp, fvs, cont);
+Obj x139886475331079 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886475569927 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475569927) {
+Obj x139886475570183 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475570215 = PRIM_EQ(symcall, x139886475570183);
+if (True == x139886475570215) {
+Obj x139886475570503 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475570535 = PRIM_ISCONS(x139886475570503);
+if (True == x139886475570535) {
+Obj x139886475571047 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475505991 = PRIM_CAR(x139886475571047);
+Obj exp = x139886475505991;
+Obj x139886475506695 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475506759 = PRIM_CDR(x139886475506695);
+Obj x139886475506791 = PRIM_ISCONS(x139886475506759);
+if (True == x139886475506791) {
+Obj x139886475507335 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475507367 = PRIM_CDR(x139886475507335);
+Obj x139886475507399 = PRIM_CAR(x139886475507367);
+Obj cont = x139886475507399;
+Obj x139886475507879 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475507911 = PRIM_CDR(x139886475507879);
+Obj x139886475507943 = PRIM_CDR(x139886475507911);
+Obj x139886475508007 = PRIM_EQ(Nil, x139886475507943);
+if (True == x139886475508007) {
+pushCont(co, 13, clofun6, 2, exp, cont);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs;
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8663,16 +8035,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080525959;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525959;
+__arg0 = x139886475331079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8681,7 +8044,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080525959;
+__arg0 = x139886475331079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8690,7 +8053,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080525959;
+__arg0 = x139886475331079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8699,7 +8062,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080525959;
+__arg0 = x139886475331079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475331079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8708,17 +8080,1120 @@ goto *jumpTable[ps.label];
 }
 }
 
-label44:
+label13:
 {
-Obj x139749079246023 = __arg1;
+Obj x139886475508391 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 45, clofun6, 2, fvs, cont);
+Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 14, clofun6, 1, cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079246023;
+__arg1 = x139886475508391;
 __arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj x139886475508423 = __arg1;
+Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 15, clofun6, 1, x139886475508423);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
+__arg1 = closureRef(co, 1);
+__arg2 = cont;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj x139886475508679 = __arg1;
+Obj x139886475508423= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475508711 = makeCons(x139886475508679, Nil);
+Obj x139886475508743 = makeCons(x139886475508423, x139886475508711);
+Obj x139886475508775 = makeCons(symcall, x139886475508743);
+__nargs = 2;
+__arg1 = x139886475508775;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label16:
+{
+Obj x139886475568839 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475568839) {
+Obj x139886475569063 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139886475569063;
+Obj x139886475569319 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886475569319;
+pushCont(co, 17, clofun6, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label17:
+{
+Obj x139886475569543 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475569671 = makeCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886475569543;
+__arg2 = x139886475569671;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj x139886476187527 = __arg1;
+Obj x139886476187559 = __arg2;
+Obj x139886476187687 = __arg3;
+Obj x139886475595943 = PRIM_EQ(Nil, x139886476187527);
+if (True == x139886475595943) {
+pushCont(co, 20, clofun6, 1, x139886476187687);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35reverse);
+__arg1 = x139886476187559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475599239 = PRIM_ISCONS(x139886476187527);
+if (True == x139886475599239) {
+Obj x139886475599431 = PRIM_CAR(x139886476187527);
+Obj hd = x139886475599431;
+Obj x139886475599623 = PRIM_CDR(x139886476187527);
+Obj tl = x139886475599623;
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = hd;
+__arg2 = makeNative(19, clofun6, 1, 3, tl, x139886476187559, x139886476187687);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label19:
+{
+Obj hd1 = __arg1;
+Obj x139886475567303 = makeCons(hd1, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
+__arg1 = closureRef(co, 0);
+__arg2 = x139886475567303;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj x139886475596167 = __arg1;
+Obj x139886476187687= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj exp = x139886475596167;
+Obj x139886476185735 = makeNative(23, clofun6, 1, 2, exp, x139886476187687);
+Obj x139886475598663 = PRIM_CAR(exp);
+pushCont(co, 21, clofun6, 2, exp, x139886476185735);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35pair_63);
+__arg1 = x139886475598663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label21:
+{
+Obj x139886475598695 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476185735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475598695) {
+pushCont(co, 22, clofun6, 1, x139886476185735);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35caar);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476185735;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label22:
+{
+Obj x139886475598983 = __arg1;
+Obj x139886476185735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475599015 = PRIM_EQ(x139886475598983, sym_37builtin);
+if (True == x139886475599015) {
+__nargs = 2;
+__arg0 = x139886476185735;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476185735;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label23:
+{
+Obj x139886476185767 = __arg1;
+if (True == x139886476185767) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886475596935 = PRIM_EQ(closureRef(co, 1), globalRef(symcora_47lib_47toc_35id));
+if (True == x139886475596935) {
+Obj x139886475597127 = makeCons(closureRef(co, 0), Nil);
+Obj x139886475597159 = makeCons(symtailcall, x139886475597127);
+__nargs = 2;
+__arg1 = x139886475597159;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475597319 = primGenSym();
+Obj val = x139886475597319;
+Obj x139886475597927 = makeCons(val, Nil);
+pushCont(co, 24, clofun6, 1, x139886475597927);
+__nargs = 2;
+__arg0 = closureRef(co, 1);
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label24:
+{
+Obj x139886475598119 = __arg1;
+Obj x139886475597927= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475598151 = makeCons(x139886475598119, Nil);
+Obj x139886475598183 = makeCons(x139886475597927, x139886475598151);
+Obj x139886475598247 = makeCons(symcontinuation, x139886475598183);
+Obj x139886475598279 = makeCons(x139886475598247, Nil);
+Obj x139886475598311 = makeCons(closureRef(co, 0), x139886475598279);
+Obj x139886475598343 = makeCons(symcall, x139886475598311);
+__nargs = 2;
+__arg1 = x139886475598343;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label25:
+{
+Obj x139886475463463 = __arg1;
+Obj x139886475463527 = __arg2;
+Obj x139886476185607 = makeNative(27, clofun6, 1, 2, x139886475463463, x139886475463527);
+Obj x139886475984359 = primIsSymbol(x139886475463463);
+if (True == x139886475984359) {
+__nargs = 2;
+__arg0 = x139886476185607;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 26, clofun6, 1, x139886476185607);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
+__arg1 = x139886475463463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label26:
+{
+Obj x139886475984615 = __arg1;
+Obj x139886476185607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886475984615) {
+__nargs = 2;
+__arg0 = x139886476185607;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476185607;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label27:
+{
+Obj x139886476185703 = __arg1;
+if (True == x139886476185703) {
+__nargs = 2;
+__arg0 = closureRef(co, 1);
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+PUSH_CONT_0(co, 28, clofun6);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label28:
+{
+Obj x139886474553287 = __arg1;
+if (True == x139886474553287) {
+__nargs = 2;
+__arg1 = closureRef(co, 0);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476145799 = makeNative(32, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886476079879 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476079879) {
+Obj x139886476080359 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476080391 = PRIM_EQ(symif, x139886476080359);
+if (True == x139886476080391) {
+Obj x139886476080743 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476080775 = PRIM_ISCONS(x139886476080743);
+if (True == x139886476080775) {
+Obj x139886476081191 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476081223 = PRIM_CAR(x139886476081191);
+Obj a = x139886476081223;
+Obj x139886476081671 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476081703 = PRIM_CDR(x139886476081671);
+Obj x139886476081735 = PRIM_ISCONS(x139886476081703);
+if (True == x139886476081735) {
+Obj x139886476082247 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476082503 = PRIM_CDR(x139886476082247);
+Obj x139886476082535 = PRIM_CAR(x139886476082503);
+Obj b = x139886476082535;
+Obj x139886476082951 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476082983 = PRIM_CDR(x139886476082951);
+Obj x139886476083047 = PRIM_CDR(x139886476082983);
+Obj x139886476083079 = PRIM_ISCONS(x139886476083047);
+if (True == x139886476083079) {
+Obj x139886475981159 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475981255 = PRIM_CDR(x139886475981159);
+Obj x139886475981287 = PRIM_CDR(x139886475981255);
+Obj x139886475981319 = PRIM_CAR(x139886475981287);
+Obj c = x139886475981319;
+Obj x139886475981991 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475982023 = PRIM_CDR(x139886475981991);
+Obj x139886475982055 = PRIM_CDR(x139886475982023);
+Obj x139886475982087 = PRIM_CDR(x139886475982055);
+Obj x139886475982119 = PRIM_EQ(Nil, x139886475982087);
+if (True == x139886475982119) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = a;
+__arg2 = makeNative(29, clofun6, 1, 3, b, c, closureRef(co, 1));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label29:
+{
+Obj ra = __arg1;
+pushCont(co, 30, clofun6, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj x139886475982727 = __arg1;
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 31, clofun6, 2, x139886475982727, ra);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
+Obj x139886475983207 = __arg1;
+Obj x139886475982727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475983239 = makeCons(x139886475983207, Nil);
+Obj x139886475983303 = makeCons(x139886475982727, x139886475983239);
+Obj x139886475983367 = makeCons(ra, x139886475983303);
+Obj x139886475983399 = makeCons(symif, x139886475983367);
+__nargs = 2;
+__arg1 = x139886475983399;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label32:
+{
+Obj x139886476081063 = makeNative(35, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886476147847 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476147847) {
+Obj x139886476148359 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476148391 = PRIM_EQ(symdo, x139886476148359);
+if (True == x139886476148391) {
+Obj x139886476103719 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476103751 = PRIM_ISCONS(x139886476103719);
+if (True == x139886476103751) {
+Obj x139886476104455 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476104935 = PRIM_CAR(x139886476104455);
+Obj a = x139886476104935;
+Obj x139886476105383 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476105415 = PRIM_CDR(x139886476105383);
+Obj x139886476105447 = PRIM_ISCONS(x139886476105415);
+if (True == x139886476105447) {
+Obj x139886476105863 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476105895 = PRIM_CDR(x139886476105863);
+Obj x139886476105927 = PRIM_CAR(x139886476105895);
+Obj b = x139886476105927;
+Obj x139886476106471 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476106503 = PRIM_CDR(x139886476106471);
+Obj x139886476106535 = PRIM_CDR(x139886476106503);
+Obj x139886476106567 = PRIM_EQ(Nil, x139886476106535);
+if (True == x139886476106567) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = a;
+__arg2 = makeNative(33, clofun6, 1, 2, b, closureRef(co, 1));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476081063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476081063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476081063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476081063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476081063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label33:
+{
+Obj ra = __arg1;
+Obj x139886476107079 = primIsSymbol(ra);
+if (True == x139886476107079) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 34, clofun6, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label34:
+{
+Obj x139886476107687 = __arg1;
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476107719 = makeCons(x139886476107687, Nil);
+Obj x139886476107751 = makeCons(ra, x139886476107719);
+Obj x139886476079111 = makeCons(symdo, x139886476107751);
+__nargs = 2;
+__arg1 = x139886476079111;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label35:
+{
+Obj x139886475984039 = makeNative(38, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886474257767 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474257767) {
+Obj x139886474258023 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474258055 = PRIM_EQ(symlet, x139886474258023);
+if (True == x139886474258055) {
+Obj x139886476186439 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476186471 = PRIM_ISCONS(x139886476186439);
+if (True == x139886476186471) {
+Obj x139886476187239 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476187303 = PRIM_CAR(x139886476187239);
+Obj a = x139886476187303;
+Obj x139886476188039 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188071 = PRIM_CDR(x139886476188039);
+Obj x139886476188103 = PRIM_ISCONS(x139886476188071);
+if (True == x139886476188103) {
+Obj x139886476188679 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188711 = PRIM_CDR(x139886476188679);
+Obj x139886476188743 = PRIM_CAR(x139886476188711);
+Obj b = x139886476188743;
+Obj x139886476189383 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476189415 = PRIM_CDR(x139886476189383);
+Obj x139886476189447 = PRIM_CDR(x139886476189415);
+Obj x139886476189479 = PRIM_ISCONS(x139886476189447);
+if (True == x139886476189479) {
+Obj x139886476145063 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476145095 = PRIM_CDR(x139886476145063);
+Obj x139886476145127 = PRIM_CDR(x139886476145095);
+Obj x139886476145159 = PRIM_CAR(x139886476145127);
+Obj c = x139886476145159;
+Obj x139886476145831 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476145863 = PRIM_CDR(x139886476145831);
+Obj x139886476145927 = PRIM_CDR(x139886476145863);
+Obj x139886476145959 = PRIM_CDR(x139886476145927);
+Obj x139886476145991 = PRIM_EQ(Nil, x139886476145959);
+if (True == x139886476145991) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = b;
+__arg2 = makeNative(36, clofun6, 1, 3, a, c, closureRef(co, 1));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475984039;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label36:
+{
+Obj rb = __arg1;
+pushCont(co, 37, clofun6, 1, rb);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label37:
+{
+Obj x139886476146791 = __arg1;
+Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476146823 = makeCons(x139886476146791, Nil);
+Obj x139886476146855 = makeCons(rb, x139886476146823);
+Obj x139886476146887 = makeCons(closureRef(co, 0), x139886476146855);
+Obj x139886476146919 = makeCons(symlet, x139886476146887);
+__nargs = 2;
+__arg1 = x139886476146919;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label38:
+{
+Obj x139886475469287 = makeNative(40, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886474554855 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474554855) {
+Obj x139886474555111 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474555143 = PRIM_EQ(sym_37closure, x139886474555111);
+if (True == x139886474555143) {
+Obj x139886474305543 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474305575 = PRIM_ISCONS(x139886474305543);
+if (True == x139886474305575) {
+Obj x139886474305895 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474305927 = PRIM_CAR(x139886474305895);
+Obj x139886474305959 = PRIM_ISCONS(x139886474305927);
+if (True == x139886474305959) {
+Obj x139886474306343 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474306375 = PRIM_CAR(x139886474306343);
+Obj x139886474306407 = PRIM_CAR(x139886474306375);
+Obj x139886474306439 = PRIM_EQ(symlambda, x139886474306407);
+if (True == x139886474306439) {
+Obj x139886474306823 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474306855 = PRIM_CAR(x139886474306823);
+Obj x139886474306887 = PRIM_CDR(x139886474306855);
+Obj x139886474306919 = PRIM_ISCONS(x139886474306887);
+if (True == x139886474306919) {
+Obj x139886474307303 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474307335 = PRIM_CAR(x139886474307303);
+Obj x139886474307367 = PRIM_CDR(x139886474307335);
+Obj x139886474307399 = PRIM_CAR(x139886474307367);
+Obj args = x139886474307399;
+Obj x139886474307847 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474307879 = PRIM_CAR(x139886474307847);
+Obj x139886474307911 = PRIM_CDR(x139886474307879);
+Obj x139886474307943 = PRIM_CDR(x139886474307911);
+Obj x139886474307975 = PRIM_ISCONS(x139886474307943);
+if (True == x139886474307975) {
+Obj x139886474308551 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474308583 = PRIM_CAR(x139886474308551);
+Obj x139886474308615 = PRIM_CDR(x139886474308583);
+Obj x139886474308647 = PRIM_CDR(x139886474308615);
+Obj x139886474308679 = PRIM_CAR(x139886474308647);
+Obj body = x139886474308679;
+Obj x139886474309191 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474309223 = PRIM_CAR(x139886474309191);
+Obj x139886474309255 = PRIM_CDR(x139886474309223);
+Obj x139886474309287 = PRIM_CDR(x139886474309255);
+Obj x139886474309319 = PRIM_CDR(x139886474309287);
+Obj x139886474309351 = PRIM_EQ(Nil, x139886474309319);
+if (True == x139886474309351) {
+Obj x139886474309607 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474256391 = PRIM_CDR(x139886474309607);
+Obj frees = x139886474256391;
+pushCont(co, 39, clofun6, 2, args, frees);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify);
+__arg1 = body;
+__arg2 = globalRef(symcora_47lib_47toc_35id);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label39:
+{
+Obj x139886474256903 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886474256935 = makeCons(x139886474256903, Nil);
+Obj x139886474256967 = makeCons(args, x139886474256935);
+Obj x139886474256999 = makeCons(symlambda, x139886474256967);
+Obj x139886474257031 = makeCons(x139886474256999, frees);
+Obj x139886474257063 = makeCons(sym_37closure, x139886474257031);
+__nargs = 2;
+__arg0 = closureRef(co, 1);
+__arg1 = x139886474257063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x139886474554023 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474554023) {
+Obj x139886474554215 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139886474554215;
+Obj x139886474554407 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886474554407;
+Obj x139886474554567 = makeCons(f, args);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
+__arg1 = x139886474554567;
+__arg2 = Nil;
+__arg3 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label41:
+{
+Obj x = __arg1;
+Obj x139886474552519 = makeCons(x, Nil);
+Obj x139886474552551 = makeCons(symreturn, x139886474552519);
+__nargs = 2;
+__arg1 = x139886474552551;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label42:
+{
+Obj x139886476187751 = __arg1;
+Obj x139886476187815 = __arg2;
+pushCont(co, 43, clofun6, 2, x139886476187815, x139886476187751);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
+__arg1 = x139886476187815;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x139886474652039 = __arg1;
+Obj x139886476187815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886474652039) {
+__nargs = 2;
+__arg1 = x139886476187815;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886474652199 = primIsSymbol(x139886476187815);
+if (True == x139886474652199) {
+pushCont(co, 3, clofun7, 1, x139886476187815);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35index);
+__arg1 = x139886476187815;
+__arg2 = x139886476187751;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x139886476079943 = makeNative(48, clofun6, 0, 2, x139886476187815, x139886476187751);
+Obj x139886474581447 = PRIM_ISCONS(x139886476187815);
+if (True == x139886474581447) {
+Obj x139886474581671 = PRIM_CAR(x139886476187815);
+Obj x139886474581703 = PRIM_EQ(symlambda, x139886474581671);
+if (True == x139886474581703) {
+Obj x139886474581927 = PRIM_CDR(x139886476187815);
+Obj x139886474581959 = PRIM_ISCONS(x139886474581927);
+if (True == x139886474581959) {
+Obj x139886474582183 = PRIM_CDR(x139886476187815);
+Obj x139886474582215 = PRIM_CAR(x139886474582183);
+Obj args = x139886474582215;
+Obj x139886474582503 = PRIM_CDR(x139886476187815);
+Obj x139886474582535 = PRIM_CDR(x139886474582503);
+Obj x139886474582567 = PRIM_ISCONS(x139886474582535);
+if (True == x139886474582567) {
+Obj x139886474582855 = PRIM_CDR(x139886476187815);
+Obj x139886474582887 = PRIM_CDR(x139886474582855);
+Obj x139886474582919 = PRIM_CAR(x139886474582887);
+Obj body = x139886474582919;
+Obj x139886474583271 = PRIM_CDR(x139886476187815);
+Obj x139886474583303 = PRIM_CDR(x139886474583271);
+Obj x139886474583335 = PRIM_CDR(x139886474583303);
+Obj x139886474583367 = PRIM_EQ(Nil, x139886474583335);
+if (True == x139886474583367) {
+Obj x139886474583719 = makeCons(body, Nil);
+Obj x139886474583751 = makeCons(args, x139886474583719);
+Obj x139886474583783 = makeCons(symlambda, x139886474583751);
+pushCont(co, 44, clofun6, 3, body, args, x139886476187751);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = x139886474583783;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476079943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label44:
+{
+Obj x139886474583815 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj fvs1 = x139886474583815;
+pushCont(co, 45, clofun6, 3, args, x139886476187751, fvs1);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg1 = fvs1;
+__arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8728,14 +9203,17 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139749079246087 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun6, 1, x139749079246087);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs;
-__arg2 = cont;
+Obj x139886474551463 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x139886474551495 = makeCons(x139886474551463, Nil);
+Obj x139886474551527 = makeCons(args, x139886474551495);
+Obj x139886474551559 = makeCons(symlambda, x139886474551527);
+pushCont(co, 46, clofun6, 2, fvs1, x139886474551559);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg1 = x139886476187751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8745,32 +9223,77 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139749079246759 = __arg1;
-Obj x139749079246087= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079246887 = makeCons(x139749079246759, Nil);
-Obj x139749079246919 = makeCons(x139749079246087, x139749079246887);
-Obj x139749079246951 = makeCons(symcall, x139749079246919);
+Obj x139886474551719 = __arg1;
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886474551559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 47, clofun6, 1, x139886474551559);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886474551719;
+__arg2 = fvs1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x139886474551751 = __arg1;
+Obj x139886474551559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886474551783 = makeCons(x139886474551559, x139886474551751);
+Obj x139886474551815 = makeCons(sym_37closure, x139886474551783);
 __nargs = 2;
-__arg1 = x139749079246951;
+__arg1 = x139886474551815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label47:
+label48:
 {
-Obj x139749080473927 = makeNative(49, clofun6, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj x139749079782823 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079782823) {
-Obj x139749079783207 = PRIM_CAR(closureRef(co, 1));
-Obj f = x139749079783207;
-Obj x139749079783527 = PRIM_CDR(closureRef(co, 1));
-Obj args = x139749079783527;
-pushCont(co, 48, clofun6, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs;
+Obj x139886475983335 = makeNative(1, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x139886474642631 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474642631) {
+Obj x139886474642887 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474642919 = PRIM_EQ(symlet, x139886474642887);
+if (True == x139886474642919) {
+Obj x139886474643175 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474643207 = PRIM_ISCONS(x139886474643175);
+if (True == x139886474643207) {
+Obj x139886474643463 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474643495 = PRIM_CAR(x139886474643463);
+Obj a = x139886474643495;
+Obj x139886474643815 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474643847 = PRIM_CDR(x139886474643815);
+Obj x139886474643879 = PRIM_ISCONS(x139886474643847);
+if (True == x139886474643879) {
+Obj x139886474644199 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474644231 = PRIM_CDR(x139886474644199);
+Obj x139886474644263 = PRIM_CAR(x139886474644231);
+Obj b = x139886474644263;
+Obj x139886474644647 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474644679 = PRIM_CDR(x139886474644647);
+Obj x139886474644711 = PRIM_CDR(x139886474644679);
+Obj x139886474644743 = PRIM_ISCONS(x139886474644711);
+if (True == x139886474644743) {
+Obj x139886474645127 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474645159 = PRIM_CDR(x139886474645127);
+Obj x139886474645191 = PRIM_CDR(x139886474645159);
+Obj x139886474645223 = PRIM_CAR(x139886474645191);
+Obj c = x139886474645223;
+Obj x139886474580135 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474580167 = PRIM_CDR(x139886474580135);
+Obj x139886474580199 = PRIM_CDR(x139886474580167);
+Obj x139886474580231 = PRIM_CDR(x139886474580199);
+Obj x139886474580263 = PRIM_EQ(Nil, x139886474580231);
+if (True == x139886474580263) {
+pushCont(co, 49, clofun6, 2, c, a);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg1 = closureRef(co, 1);
+__arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8778,37 +9301,70 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080473927;
+__arg0 = x139886475983335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label48:
-{
-Obj x139749079783975 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079784295 = makeCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079783975;
-__arg2 = x139749079784295;
+} else {
+__nargs = 1;
+__arg0 = x139886475983335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label49:
 {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Obj x139886474580583 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun7, 2, x139886474580583, a);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg1 = closureRef(co, 1);
+__arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8838,255 +9394,152 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749080645863 = __arg1;
-Obj x139749080645895 = __arg2;
-Obj x139749080645927 = __arg3;
-Obj x139749080646503 = makeNative(7, clofun7, 0, 3, x139749080645863, x139749080645895, x139749080645927);
-Obj x139749080387751 = PRIM_EQ(Nil, x139749080645863);
-if (True == x139749080387751) {
-Obj ls = x139749080645895;
-Obj next = x139749080645927;
-pushCont(co, 1, clofun7, 1, next);
+Obj x139886474580775 = __arg1;
+Obj x139886474580583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886474580807 = makeCons(x139886474580775, Nil);
+Obj x139886474580839 = makeCons(x139886474580583, x139886474580807);
+Obj x139886474580871 = makeCons(a, x139886474580839);
+Obj x139886474580903 = makeCons(symlet, x139886474580871);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = ls;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080646503;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x139886474580903;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj x139749080388359 = __arg1;
-Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp = x139749080388359;
-Obj x139749080389095 = PRIM_CAR(exp);
-pushCont(co, 2, clofun7, 2, next, exp);
+Obj x139886474641703 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474641703) {
+Obj x139886474641895 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139886474641895;
+Obj x139886474642087 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886474642087;
+pushCont(co, 2, clofun7, 2, f, args);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = x139749080389095;
+__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj x139749080389127 = __arg1;
-Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080389127) {
-pushCont(co, 4, clofun7, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35caar);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
+Obj x139886474642279 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886474642375 = makeCons(f, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
-__arg1 = exp;
-__arg2 = next;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886474642279;
+__arg2 = x139886474642375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139749080353927 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139749080353927) {
-Obj x139749080354503 = makeCons(exp, Nil);
-Obj x139749080354535 = makeCons(symtailcall, x139749080354503);
-__nargs = 2;
-__arg1 = x139749080354535;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139749079969831 = primGenSym();
-Obj val = x139749079969831;
-Obj x139749079972007 = makeCons(val, Nil);
-pushCont(co, 3, clofun7, 2, x139749079972007, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
 }
 
 label3:
 {
-Obj x139749079972551 = __arg1;
-Obj x139749079972007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079972647 = makeCons(x139749079972551, Nil);
-Obj x139749079972679 = makeCons(x139749079972007, x139749079972647);
-Obj x139749079972711 = makeCons(symcontinuation, x139749079972679);
-Obj x139749079972775 = makeCons(x139749079972711, Nil);
-Obj x139749079972903 = makeCons(exp, x139749079972775);
-Obj x139749079972935 = makeCons(symcall, x139749079972903);
+Obj x139886474652359 = __arg1;
+Obj x139886476187815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj pos = x139886474652359;
+Obj x139886474653351 = PRIM_EQ(MAKE_NUMBER(-1), pos);
+if (True == x139886474653351) {
 __nargs = 2;
-__arg1 = x139749079972935;
+__arg1 = x139886476187815;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886474653511 = makeCons(pos, Nil);
+Obj x139886474653543 = makeCons(sym_37closure_45ref, x139886474653511);
+__nargs = 2;
+__arg1 = x139886474653543;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label4:
 {
-Obj x139749080389607 = __arg1;
-Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080389671 = PRIM_EQ(x139749080389607, sym_37builtin);
-if (True == x139749080389671) {
-if (True == True) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
-__arg1 = exp;
-__arg2 = next;
+Obj x139886475383815 = __arg1;
+pushCont(co, 5, clofun7, 1, x139886475383815);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
+__arg1 = x139886475383815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139749080390375 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139749080390375) {
-Obj x139749080390919 = makeCons(exp, Nil);
-Obj x139749080390951 = makeCons(symtailcall, x139749080390919);
-__nargs = 2;
-__arg1 = x139749080390951;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139749080391399 = primGenSym();
-Obj val = x139749080391399;
-Obj x139749080364519 = makeCons(val, Nil);
-pushCont(co, 6, clofun7, 2, x139749080364519, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139749080366119 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == x139749080366119) {
-Obj x139749080366791 = makeCons(exp, Nil);
-Obj x139749080366823 = makeCons(symtailcall, x139749080366791);
-__nargs = 2;
-__arg1 = x139749080366823;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139749080350727 = primGenSym();
-Obj val = x139749080350727;
-Obj x139749080352391 = makeCons(val, Nil);
-pushCont(co, 5, clofun7, 2, x139749080352391, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
 }
 
 label5:
 {
-Obj x139749080352999 = __arg1;
-Obj x139749080352391= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080353095 = makeCons(x139749080352999, Nil);
-Obj x139749080353127 = makeCons(x139749080352391, x139749080353095);
-Obj x139749080353159 = makeCons(symcontinuation, x139749080353127);
-Obj x139749080353255 = makeCons(x139749080353159, Nil);
-Obj x139749080353287 = makeCons(exp, x139749080353255);
-Obj x139749080353319 = makeCons(symcall, x139749080353287);
+Obj x139886475461735 = __arg1;
+Obj x139886475383815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886475461735) {
 __nargs = 2;
-__arg1 = x139749080353319;
+__arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj x139749080364999 = __arg1;
-Obj x139749080364519= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080365063 = makeCons(x139749080364999, Nil);
-Obj x139749080365095 = makeCons(x139749080364519, x139749080365063);
-Obj x139749080365127 = makeCons(symcontinuation, x139749080365095);
-Obj x139749080365447 = makeCons(x139749080365127, Nil);
-Obj x139749080365479 = makeCons(exp, x139749080365447);
-Obj x139749080365511 = makeCons(symcall, x139749080365479);
+} else {
+Obj x139886475461895 = primIsSymbol(x139886475383815);
+if (True == x139886475461895) {
+Obj x139886475461991 = makeCons(x139886475383815, Nil);
 __nargs = 2;
-__arg1 = x139749080365511;
+__arg1 = x139886475461991;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-}
-
-label7:
-{
-Obj x139749080647335 = makeNative(9, clofun7, 0, 0);
-Obj x139749080446311 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080446311) {
-Obj x139749080446823 = PRIM_CAR(closureRef(co, 0));
-Obj hd = x139749080446823;
-Obj x139749080447239 = PRIM_CDR(closureRef(co, 0));
-Obj tl = x139749080447239;
-Obj ls = closureRef(co, 1);
-Obj next = closureRef(co, 2);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = hd;
-__arg2 = makeNative(8, clofun7, 1, 3, tl, ls, next);
+} else {
+Obj x139886475330055 = makeNative(7, clofun7, 0, 1, x139886475383815);
+Obj x139886475127719 = PRIM_ISCONS(x139886475383815);
+if (True == x139886475127719) {
+Obj x139886475128007 = PRIM_CAR(x139886475383815);
+Obj x139886475128039 = PRIM_EQ(symlambda, x139886475128007);
+if (True == x139886475128039) {
+Obj x139886475128359 = PRIM_CDR(x139886475383815);
+Obj x139886475128391 = PRIM_ISCONS(x139886475128359);
+if (True == x139886475128391) {
+Obj x139886475128615 = PRIM_CDR(x139886475383815);
+Obj x139886475128775 = PRIM_CAR(x139886475128615);
+Obj args = x139886475128775;
+Obj x139886474649927 = PRIM_CDR(x139886475383815);
+Obj x139886474649959 = PRIM_CDR(x139886474649927);
+Obj x139886474649991 = PRIM_ISCONS(x139886474649959);
+if (True == x139886474649991) {
+Obj x139886474650375 = PRIM_CDR(x139886475383815);
+Obj x139886474650407 = PRIM_CDR(x139886474650375);
+Obj x139886474650471 = PRIM_CAR(x139886474650407);
+Obj body = x139886474650471;
+Obj x139886474650823 = PRIM_CDR(x139886475383815);
+Obj x139886474650855 = PRIM_CDR(x139886474650823);
+Obj x139886474650887 = PRIM_CDR(x139886474650855);
+Obj x139886474650919 = PRIM_EQ(Nil, x139886474650887);
+if (True == x139886474650919) {
+pushCont(co, 6, clofun7, 1, args);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9094,7 +9547,167 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080647335;
+__arg0 = x139886475330055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475330055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475330055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475330055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475330055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label6:
+{
+Obj x139886474651079 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35diff);
+__arg1 = x139886474651079;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj x139886475333127 = makeNative(9, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475184071 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475184071) {
+Obj x139886475184327 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475184359 = PRIM_EQ(symif, x139886475184327);
+if (True == x139886475184359) {
+Obj x139886475184615 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475184647 = PRIM_ISCONS(x139886475184615);
+if (True == x139886475184647) {
+Obj x139886475184935 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475184967 = PRIM_CAR(x139886475184935);
+Obj x = x139886475184967;
+Obj x139886475185351 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475185383 = PRIM_CDR(x139886475185351);
+Obj x139886475185415 = PRIM_ISCONS(x139886475185383);
+if (True == x139886475185415) {
+Obj x139886475185831 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475185863 = PRIM_CDR(x139886475185831);
+Obj x139886475185895 = PRIM_CAR(x139886475185863);
+Obj y = x139886475185895;
+Obj x139886475124967 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475124999 = PRIM_CDR(x139886475124967);
+Obj x139886475125031 = PRIM_CDR(x139886475124999);
+Obj x139886475125063 = PRIM_ISCONS(x139886475125031);
+if (True == x139886475125063) {
+Obj x139886475125575 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475125671 = PRIM_CDR(x139886475125575);
+Obj x139886475125703 = PRIM_CDR(x139886475125671);
+Obj x139886475125735 = PRIM_CAR(x139886475125703);
+Obj z = x139886475125735;
+Obj x139886475126343 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475126375 = PRIM_CDR(x139886475126343);
+Obj x139886475126407 = PRIM_CDR(x139886475126375);
+Obj x139886475126439 = PRIM_CDR(x139886475126407);
+Obj x139886475126471 = PRIM_EQ(Nil, x139886475126439);
+if (True == x139886475126471) {
+Obj x139886475126855 = makeCons(z, Nil);
+Obj x139886475126951 = makeCons(y, x139886475126855);
+Obj x139886475126983 = makeCons(x, x139886475126951);
+PUSH_CONT_0(co, 8, clofun7);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg2 = x139886475126983;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475333127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9105,13 +9718,12 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj hd1 = __arg1;
-Obj x139749080448423 = makeCons(hd1, closureRef(co, 1));
+Obj x139886475127015 = __arg1;
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = closureRef(co, 0);
-__arg2 = x139749080448423;
-__arg3 = closureRef(co, 2);
+__arg0 = globalRef(symcora_47lib_47toc_35foldl);
+__arg1 = globalRef(symcora_47lib_47toc_35union);
+__arg2 = Nil;
+__arg3 = x139886475127015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9121,67 +9733,147 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Obj x139886476186663 = makeNative(11, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475192839 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475192839) {
+Obj x139886475193159 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475193191 = PRIM_EQ(symdo, x139886475193159);
+if (True == x139886475193191) {
+Obj x139886475193479 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475193511 = PRIM_ISCONS(x139886475193479);
+if (True == x139886475193511) {
+Obj x139886475193831 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475193863 = PRIM_CAR(x139886475193831);
+Obj x = x139886475193863;
+Obj x139886475194247 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475194279 = PRIM_CDR(x139886475194247);
+Obj x139886475194311 = PRIM_ISCONS(x139886475194279);
+if (True == x139886475194311) {
+Obj x139886475182439 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475182471 = PRIM_CDR(x139886475182439);
+Obj x139886475182503 = PRIM_CAR(x139886475182471);
+Obj y = x139886475182503;
+Obj x139886475182951 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475182983 = PRIM_CDR(x139886475182951);
+Obj x139886475183015 = PRIM_CDR(x139886475182983);
+Obj x139886475183079 = PRIM_EQ(Nil, x139886475183015);
+if (True == x139886475183079) {
+Obj x139886475183399 = makeCons(y, Nil);
+Obj x139886475183431 = makeCons(x, x139886475183399);
+PUSH_CONT_0(co, 10, clofun7);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg2 = x139886475183431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476186663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476186663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label10:
 {
-Obj x139749080391335 = __arg1;
-Obj x139749080391367 = __arg2;
-Obj x139749080363079 = makeNative(12, clofun7, 0, 2, x139749080391335, x139749080391367);
-Obj x = x139749080391335;
-Obj next = x139749080391367;
-Obj x139749080463527 = primIsSymbol(x);
-if (True == x139749080463527) {
-if (True == True) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
+Obj x139886475183463 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35foldl);
+__arg1 = globalRef(symcora_47lib_47toc_35union);
+__arg2 = Nil;
+__arg3 = x139886475183463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080363079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 11, clofun7, 3, next, x, x139749080363079);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label11:
 {
-Obj x139749080464327 = __arg1;
-Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080363079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139749080464327) {
-if (True == True) {
+Obj x139886476146535 = makeNative(15, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475243847 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475243847) {
+Obj x139886475244199 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475244231 = PRIM_EQ(symlet, x139886475244199);
+if (True == x139886475244231) {
+Obj x139886475244583 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475244615 = PRIM_ISCONS(x139886475244583);
+if (True == x139886475244615) {
+Obj x139886475245031 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475245063 = PRIM_CAR(x139886475245031);
+Obj a = x139886475245063;
+Obj x139886475245575 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475245607 = PRIM_CDR(x139886475245575);
+Obj x139886475245639 = PRIM_ISCONS(x139886475245607);
+if (True == x139886475245639) {
+Obj x139886475246055 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475246087 = PRIM_CDR(x139886475246055);
+Obj x139886475246119 = PRIM_CAR(x139886475246087);
+Obj b = x139886475246119;
+Obj x139886475246695 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475246727 = PRIM_CDR(x139886475246695);
+Obj x139886475246759 = PRIM_CDR(x139886475246727);
+Obj x139886475246791 = PRIM_ISCONS(x139886475246759);
+if (True == x139886475246791) {
+Obj x139886475247367 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475247399 = PRIM_CDR(x139886475247367);
+Obj x139886475247431 = PRIM_CDR(x139886475247399);
+Obj x139886475247463 = PRIM_CAR(x139886475247431);
+Obj c = x139886475247463;
+Obj x139886475190759 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475190791 = PRIM_CDR(x139886475190759);
+Obj x139886475190823 = PRIM_CDR(x139886475190791);
+Obj x139886475190855 = PRIM_CDR(x139886475190823);
+Obj x139886475190887 = PRIM_EQ(Nil, x139886475190855);
+if (True == x139886475190887) {
+pushCont(co, 12, clofun7, 2, c, a);
 __nargs = 2;
-__arg0 = next;
-__arg1 = x;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9189,44 +9881,69 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080363079;
+__arg0 = x139886476146535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-if (True == False) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080363079;
+__arg0 = x139886476146535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x139886476146535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476146535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476146535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476146535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj x139749080363623 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-pushCont(co, 13, clofun7, 2, x, x139749080363623);
+Obj x139886475191143 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 13, clofun7, 2, a, x139886475191143);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9236,281 +9953,313 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139749080462695 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080363623= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080462695) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080363623;
+Obj x139886475191975 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475191143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475192071 = makeCons(a, Nil);
+pushCont(co, 14, clofun7, 1, x139886475191143);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35diff);
+__arg1 = x139886475191975;
+__arg2 = x139886475192071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label14:
 {
-Obj x139749080364167 = makeNative(18, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749080646119 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080646119) {
-Obj x139749080646919 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080646951 = PRIM_EQ(symif, x139749080646919);
-if (True == x139749080646951) {
-Obj x139749080647751 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080647783 = PRIM_ISCONS(x139749080647751);
-if (True == x139749080647783) {
-Obj x139749080648327 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080648359 = PRIM_CAR(x139749080648327);
-Obj a = x139749080648359;
-Obj x139749080649639 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080649671 = PRIM_CDR(x139749080649639);
-Obj x139749080522759 = PRIM_ISCONS(x139749080649671);
-if (True == x139749080522759) {
-Obj x139749080523559 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080523591 = PRIM_CDR(x139749080523559);
-Obj x139749080523623 = PRIM_CAR(x139749080523591);
-Obj b = x139749080523623;
-Obj x139749080524807 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080524839 = PRIM_CDR(x139749080524807);
-Obj x139749080524871 = PRIM_CDR(x139749080524839);
-Obj x139749080524903 = PRIM_ISCONS(x139749080524871);
-if (True == x139749080524903) {
-Obj x139749080525927 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080525991 = PRIM_CDR(x139749080525927);
-Obj x139749080526023 = PRIM_CDR(x139749080525991);
-Obj x139749080526055 = PRIM_CAR(x139749080526023);
-Obj c = x139749080526055;
-Obj x139749080474375 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080474407 = PRIM_CDR(x139749080474375);
-Obj x139749080474567 = PRIM_CDR(x139749080474407);
-Obj x139749080474599 = PRIM_CDR(x139749080474567);
-Obj x139749080474631 = PRIM_EQ(Nil, x139749080474599);
-if (True == x139749080474631) {
-Obj next = closureRef(co, 1);
+Obj x139886475192103 = __arg1;
+Obj x139886475191143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = a;
-__arg2 = makeNative(15, clofun7, 1, 3, b, c, next);
+__arg0 = globalRef(symcora_47lib_47toc_35union);
+__arg1 = x139886475191143;
+__arg2 = x139886475192103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080364167;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label15:
 {
-Obj ra = __arg1;
-pushCont(co, 16, clofun7, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 2);
+Obj x139886476079623 = makeNative(16, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475270343 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475270343) {
+Obj x139886475270663 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475270695 = PRIM_EQ(sym_37closure, x139886475270663);
+if (True == x139886475270695) {
+Obj x139886475270983 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475271079 = PRIM_ISCONS(x139886475270983);
+if (True == x139886475271079) {
+Obj x139886475271367 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475271399 = PRIM_CAR(x139886475271367);
+Obj lam = x139886475271399;
+Obj x139886475271751 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475271783 = PRIM_CDR(x139886475271751);
+Obj more = x139886475271783;
+Obj x139886475271943 = makeCons(lam, more);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = x139886475271943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476079623;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079623;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476079623;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label16:
 {
-Obj x139749080476487 = __arg1;
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 17, clofun7, 2, x139749080476487, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
+Obj x139886475981351 = makeNative(17, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475268263 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475268263) {
+Obj x139886475268551 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475268615 = PRIM_EQ(symreturn, x139886475268551);
+if (True == x139886475268615) {
+Obj x139886475268903 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475268935 = PRIM_ISCONS(x139886475268903);
+if (True == x139886475268935) {
+Obj x139886475269255 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475269287 = PRIM_CAR(x139886475269255);
+Obj x = x139886475269287;
+Obj x139886475269703 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475269735 = PRIM_CDR(x139886475269703);
+Obj x139886475269767 = PRIM_EQ(Nil, x139886475269735);
+if (True == x139886475269767) {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475981351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475981351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label17:
 {
-Obj x139749080476935 = __arg1;
-Obj x139749080476487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080477191 = makeCons(x139749080476935, Nil);
-Obj x139749080477223 = makeCons(x139749080476487, x139749080477191);
-Obj x139749080477255 = makeCons(ra, x139749080477223);
-Obj x139749080477287 = makeCons(symif, x139749080477255);
-__nargs = 2;
-__arg1 = x139749080477287;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475983719 = makeNative(19, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475330087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475330087) {
+Obj x139886475330407 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475330439 = PRIM_EQ(symcall, x139886475330407);
+if (True == x139886475330439) {
+Obj x139886475330791 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475330823 = PRIM_ISCONS(x139886475330791);
+if (True == x139886475330823) {
+Obj x139886475331175 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475331207 = PRIM_CAR(x139886475331175);
+Obj exp = x139886475331207;
+Obj x139886475331655 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475331687 = PRIM_CDR(x139886475331655);
+Obj x139886475331751 = PRIM_ISCONS(x139886475331687);
+if (True == x139886475331751) {
+Obj x139886475332103 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475332135 = PRIM_CDR(x139886475332103);
+Obj x139886475332167 = PRIM_CAR(x139886475332135);
+Obj cont = x139886475332167;
+Obj x139886475332647 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475332679 = PRIM_CDR(x139886475332647);
+Obj x139886475332711 = PRIM_CDR(x139886475332679);
+Obj x139886475332743 = PRIM_EQ(Nil, x139886475332711);
+if (True == x139886475332743) {
+Obj x139886475333159 = makeCons(cont, Nil);
+Obj x139886475333191 = makeCons(exp, x139886475333159);
+PUSH_CONT_0(co, 18, clofun7);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg2 = x139886475333191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475983719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475983719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label18:
 {
-Obj x139749080365575 = makeNative(21, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749078808391 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078808391) {
-Obj x139749078808839 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078808871 = PRIM_EQ(symdo, x139749078808839);
-if (True == x139749078808871) {
-Obj x139749078809287 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078809319 = PRIM_ISCONS(x139749078809287);
-if (True == x139749078809319) {
-Obj x139749078809735 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078809767 = PRIM_CAR(x139749078809735);
-Obj a = x139749078809767;
-Obj x139749078810343 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078810375 = PRIM_CDR(x139749078810343);
-Obj x139749078810407 = PRIM_ISCONS(x139749078810375);
-if (True == x139749078810407) {
-Obj x139749078774119 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078774151 = PRIM_CDR(x139749078774119);
-Obj x139749078774183 = PRIM_CAR(x139749078774151);
-Obj b = x139749078774183;
-Obj x139749078774951 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078774983 = PRIM_CDR(x139749078774951);
-Obj x139749078775015 = PRIM_CDR(x139749078774983);
-Obj x139749078775047 = PRIM_EQ(Nil, x139749078775015);
-if (True == x139749078775047) {
-Obj next = closureRef(co, 1);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = a;
-__arg2 = makeNative(19, clofun7, 1, 2, b, next);
+Obj x139886475333223 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35foldl);
+__arg1 = globalRef(symcora_47lib_47toc_35union);
+__arg2 = Nil;
+__arg3 = x139886475333223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080365575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080365575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080365575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080365575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080365575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label19:
 {
-Obj ra = __arg1;
-Obj x139749078775623 = primIsSymbol(ra);
-if (True == x139749078775623) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
+Obj x139886475568679 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475385383 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475385383) {
+Obj x139886475385639 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475385671 = PRIM_EQ(symtailcall, x139886475385639);
+if (True == x139886475385671) {
+Obj x139886475385959 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475385991 = PRIM_ISCONS(x139886475385959);
+if (True == x139886475385991) {
+Obj x139886475386311 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475386343 = PRIM_CAR(x139886475386311);
+Obj exp = x139886475386343;
+Obj x139886475386727 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475386791 = PRIM_CDR(x139886475386727);
+Obj x139886475386823 = PRIM_EQ(Nil, x139886475386791);
+if (True == x139886475386823) {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 20, clofun7, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
+__nargs = 1;
+__arg0 = x139886475568679;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475568679;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475568679;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475568679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9521,218 +10270,174 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139749078776583 = __arg1;
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749078776647 = makeCons(x139749078776583, Nil);
-Obj x139749078776679 = makeCons(ra, x139749078776647);
-Obj x139749078776711 = makeCons(symdo, x139749078776679);
+Obj x139886475508967 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475464423 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475464423) {
+Obj x139886475464679 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475382791 = PRIM_EQ(symcontinuation, x139886475464679);
+if (True == x139886475382791) {
+Obj x139886475383047 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475383079 = PRIM_ISCONS(x139886475383047);
+if (True == x139886475383079) {
+Obj x139886475383367 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475383399 = PRIM_CAR(x139886475383367);
+Obj arg = x139886475383399;
+Obj x139886475383719 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475383751 = PRIM_CDR(x139886475383719);
+Obj x139886475383783 = PRIM_ISCONS(x139886475383751);
+if (True == x139886475383783) {
+Obj x139886475384167 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475384199 = PRIM_CDR(x139886475384167);
+Obj x139886475384231 = PRIM_CAR(x139886475384199);
+Obj body = x139886475384231;
+Obj x139886475384615 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475384647 = PRIM_CDR(x139886475384615);
+Obj x139886475384679 = PRIM_CDR(x139886475384647);
+Obj x139886475384711 = PRIM_EQ(Nil, x139886475384679);
+if (True == x139886475384711) {
+pushCont(co, 21, clofun7, 1, arg);
 __nargs = 2;
-__arg1 = x139749078776711;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475508967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475508967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475508967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475508967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475508967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label21:
 {
-Obj x139749080366759 = makeNative(24, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749078841511 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078841511) {
-Obj x139749078841959 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078841991 = PRIM_EQ(symlet, x139749078841959);
-if (True == x139749078841991) {
-Obj x139749078842407 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078842439 = PRIM_ISCONS(x139749078842407);
-if (True == x139749078842439) {
-Obj x139749078842855 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078842887 = PRIM_CAR(x139749078842855);
-Obj a = x139749078842887;
-Obj x139749078822983 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078823015 = PRIM_CDR(x139749078822983);
-Obj x139749078823047 = PRIM_ISCONS(x139749078823015);
-if (True == x139749078823047) {
-Obj x139749078823623 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078823655 = PRIM_CDR(x139749078823623);
-Obj x139749078823687 = PRIM_CAR(x139749078823655);
-Obj b = x139749078823687;
-Obj x139749078824423 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078824455 = PRIM_CDR(x139749078824423);
-Obj x139749078824487 = PRIM_CDR(x139749078824455);
-Obj x139749078824519 = PRIM_ISCONS(x139749078824487);
-if (True == x139749078824519) {
-Obj x139749078825255 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078825287 = PRIM_CDR(x139749078825255);
-Obj x139749078825319 = PRIM_CDR(x139749078825287);
-Obj x139749078825351 = PRIM_CAR(x139749078825319);
-Obj c = x139749078825351;
-Obj x139749078826279 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078826311 = PRIM_CDR(x139749078826279);
-Obj x139749078826343 = PRIM_CDR(x139749078826311);
-Obj x139749078826375 = PRIM_CDR(x139749078826343);
-Obj x139749078826407 = PRIM_EQ(Nil, x139749078826375);
-if (True == x139749078826407) {
-Obj next = closureRef(co, 1);
+Obj x139886475384871 = __arg1;
+Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = b;
-__arg2 = makeNative(22, clofun7, 1, 3, a, c, next);
+__arg0 = globalRef(symcora_47lib_47toc_35diff);
+__arg1 = x139886475384871;
+__arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080366759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label22:
 {
-Obj rb = __arg1;
-pushCont(co, 23, clofun7, 1, rb);
+Obj x139886475463367 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475463367) {
+Obj x139886475463623 = PRIM_CAR(closureRef(co, 0));
+Obj f = x139886475463623;
+Obj x139886475463815 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886475463815;
+Obj x139886475464135 = makeCons(f, args);
+PUSH_CONT_0(co, 23, clofun7);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
+__arg2 = x139886475464135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label23:
 {
-Obj x139749078807207 = __arg1;
-Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749078807271 = makeCons(x139749078807207, Nil);
-Obj x139749078807303 = makeCons(rb, x139749078807271);
-Obj x139749078807335 = makeCons(closureRef(co, 0), x139749078807303);
-Obj x139749078807367 = makeCons(symlet, x139749078807335);
-__nargs = 2;
-__arg1 = x139749078807367;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475464167 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35foldl);
+__arg1 = globalRef(symcora_47lib_47toc_35union);
+__arg2 = Nil;
+__arg3 = x139886475464167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label24:
 {
-Obj x139749080351783 = makeNative(26, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079069351 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079069351) {
-Obj x139749079070023 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079070055 = PRIM_EQ(sym_37closure, x139749079070023);
-if (True == x139749079070055) {
-Obj x139749079070471 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079070503 = PRIM_ISCONS(x139749079070471);
-if (True == x139749079070503) {
-Obj x139749079071175 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079071303 = PRIM_CAR(x139749079071175);
-Obj x139749079071335 = PRIM_ISCONS(x139749079071303);
-if (True == x139749079071335) {
-Obj x139749079072263 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079072295 = PRIM_CAR(x139749079072263);
-Obj x139749079072327 = PRIM_CAR(x139749079072295);
-Obj x139749079072423 = PRIM_EQ(symlambda, x139749079072327);
-if (True == x139749079072423) {
-Obj x139749079044711 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079044807 = PRIM_CAR(x139749079044711);
-Obj x139749079044839 = PRIM_CDR(x139749079044807);
-Obj x139749079044871 = PRIM_ISCONS(x139749079044839);
-if (True == x139749079044871) {
-Obj x139749079045703 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079045735 = PRIM_CAR(x139749079045703);
-Obj x139749079045767 = PRIM_CDR(x139749079045735);
-Obj x139749079045799 = PRIM_CAR(x139749079045767);
-Obj args = x139749079045799;
-Obj x139749079046823 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079046919 = PRIM_CAR(x139749079046823);
-Obj x139749079046951 = PRIM_CDR(x139749079046919);
-Obj x139749079046983 = PRIM_CDR(x139749079046951);
-Obj x139749079047015 = PRIM_ISCONS(x139749079046983);
-if (True == x139749079047015) {
-Obj x139749079048039 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079048071 = PRIM_CAR(x139749079048039);
-Obj x139749079048103 = PRIM_CDR(x139749079048071);
-Obj x139749079048135 = PRIM_CDR(x139749079048103);
-Obj x139749079048167 = PRIM_CAR(x139749079048135);
-Obj body = x139749079048167;
-Obj x139749078979815 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078979847 = PRIM_CAR(x139749078979815);
-Obj x139749078979879 = PRIM_CDR(x139749078979847);
-Obj x139749078979911 = PRIM_CDR(x139749078979879);
-Obj x139749078979943 = PRIM_CDR(x139749078979911);
-Obj x139749078979975 = PRIM_EQ(Nil, x139749078979943);
-if (True == x139749078979975) {
-Obj x139749078980519 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078980551 = PRIM_CDR(x139749078980519);
-Obj frees = x139749078980551;
-Obj next = closureRef(co, 1);
-pushCont(co, 25, clofun7, 3, args, frees, next);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = body;
-__arg2 = globalRef(symcora_47lib_47toc_35id);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475982567 = __arg1;
+Obj x139886475983975 = makeNative(25, clofun7, 0, 1, x139886475982567);
+Obj x139886475472199 = PRIM_ISCONS(x139886475982567);
+if (True == x139886475472199) {
+Obj x139886475472423 = PRIM_CAR(x139886475982567);
+Obj x139886475472455 = PRIM_EQ(sym_37const, x139886475472423);
+if (True == x139886475472455) {
+Obj x139886475472679 = PRIM_CDR(x139886475982567);
+Obj x139886475472711 = PRIM_ISCONS(x139886475472679);
+if (True == x139886475472711) {
+Obj x139886475460647 = PRIM_CDR(x139886475982567);
+Obj x139886475460711 = PRIM_CAR(x139886475460647);
+Obj x139886475460999 = PRIM_CDR(x139886475982567);
+Obj x139886475461031 = PRIM_CDR(x139886475460999);
+Obj x139886475461063 = PRIM_EQ(Nil, x139886475461031);
+if (True == x139886475461063) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080351783;
+__arg0 = x139886475983975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9741,7 +10446,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080351783;
+__arg0 = x139886475983975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9750,7 +10455,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080351783;
+__arg0 = x139886475983975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9759,43 +10464,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080351783;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080351783;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080351783;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080351783;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080351783;
+__arg0 = x139886475983975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9806,49 +10475,116 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139749078981991 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749078982055 = makeCons(x139749078981991, Nil);
-Obj x139749078982119 = makeCons(args, x139749078982055);
-Obj x139749078982151 = makeCons(symlambda, x139749078982119);
-Obj x139749078982215 = makeCons(x139749078982151, frees);
-Obj x139749078982247 = makeCons(sym_37closure, x139749078982215);
+Obj x139886475567495 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475470535 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475470535) {
+Obj x139886475470791 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475470823 = PRIM_EQ(sym_37global, x139886475470791);
+if (True == x139886475470823) {
+Obj x139886475471079 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475471111 = PRIM_ISCONS(x139886475471079);
+if (True == x139886475471111) {
+Obj x139886475471367 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475471399 = PRIM_CAR(x139886475471367);
+Obj x139886475471719 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475471751 = PRIM_CDR(x139886475471719);
+Obj x139886475471783 = PRIM_EQ(Nil, x139886475471751);
+if (True == x139886475471783) {
 __nargs = 2;
-__arg0 = next;
-__arg1 = x139749078982247;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475567495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label26:
-{
-Obj x139749080353383 = makeNative(27, clofun7, 0, 0);
-Obj x139749079145319 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079145319) {
-Obj x139749079145735 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139749079145735;
-Obj x139749079145991 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139749079145991;
-Obj next = closureRef(co, 1);
-Obj x139749079068775 = makeCons(f, args);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = x139749079068775;
-__arg2 = Nil;
-__arg3 = next;
+} else {
+__nargs = 1;
+__arg0 = x139886475567495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 } else {
 __nargs = 1;
-__arg0 = x139749080353383;
+__arg0 = x139886475567495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475567495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label26:
+{
+Obj x139886475570343 = makeNative(27, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475509703 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475509703) {
+Obj x139886475468999 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475469031 = PRIM_EQ(sym_37builtin, x139886475468999);
+if (True == x139886475469031) {
+Obj x139886475469351 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475469383 = PRIM_ISCONS(x139886475469351);
+if (True == x139886475469383) {
+Obj x139886475469639 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475469671 = PRIM_CAR(x139886475469639);
+Obj x139886475470023 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475470055 = PRIM_CDR(x139886475470023);
+Obj x139886475470087 = PRIM_EQ(Nil, x139886475470055);
+if (True == x139886475470087) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475570343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475570343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475570343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475570343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9859,80 +10595,185 @@ goto *jumpTable[ps.label];
 
 label27:
 {
+Obj x139886475469799 = makeNative(28, clofun7, 0, 1, closureRef(co, 0));
+Obj x139886475507975 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475507975) {
+Obj x139886475508231 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475508263 = PRIM_EQ(symquote, x139886475508231);
+if (True == x139886475508263) {
+Obj x139886475508519 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475508551 = PRIM_ISCONS(x139886475508519);
+if (True == x139886475508551) {
+Obj x139886475508807 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475508839 = PRIM_CAR(x139886475508807);
+Obj x139886475509191 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475509223 = PRIM_CDR(x139886475509191);
+Obj x139886475509255 = PRIM_EQ(Nil, x139886475509223);
+if (True == x139886475509255) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label28:
-{
-Obj x = __arg1;
-Obj x139749079143207 = makeCons(x, Nil);
-Obj x139749079143239 = makeCons(symreturn, x139749079143207);
-__nargs = 2;
-__arg1 = x139749079143239;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label29:
-{
-Obj x139749080447431 = __arg1;
-Obj x139749080447463 = __arg2;
-Obj x139749080447847 = makeNative(31, clofun7, 0, 2, x139749080447431, x139749080447463);
-Obj __ = x139749080447431;
-Obj x = x139749080447463;
-pushCont(co, 30, clofun7, 2, x, x139749080447847);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj x139749079158599 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080447847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749079158599) {
-__nargs = 2;
-__arg1 = x;
+__arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080447847;
+__arg0 = x139886475469799;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469799;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label28:
+{
+Obj x139886475461511 = makeNative(29, clofun7, 0, 0);
+Obj x139886475570919 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475570919) {
+Obj x139886475506119 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475506215 = PRIM_EQ(sym_37closure_45ref, x139886475506119);
+if (True == x139886475506215) {
+Obj x139886475506535 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475506631 = PRIM_ISCONS(x139886475506535);
+if (True == x139886475506631) {
+Obj x139886475507015 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475507047 = PRIM_CAR(x139886475507015);
+Obj x139886475507463 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475507495 = PRIM_CDR(x139886475507463);
+Obj x139886475507527 = PRIM_EQ(Nil, x139886475507495);
+if (True == x139886475507527) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475461511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475461511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475461511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475461511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label29:
+{
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label30:
+{
+Obj x139886476186983 = __arg1;
+Obj x139886476187207 = __arg2;
+Obj x139886475567719 = PRIM_EQ(Nil, x139886476186983);
+if (True == x139886475567719) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476147719 = makeNative(32, clofun7, 0, 2, x139886476186983, x139886476187207);
+Obj x139886475568935 = PRIM_ISCONS(x139886476186983);
+if (True == x139886475568935) {
+Obj x139886475569095 = PRIM_CAR(x139886476186983);
+Obj x = x139886475569095;
+Obj x139886475569255 = PRIM_CDR(x139886476186983);
+Obj y = x139886475569255;
+pushCont(co, 31, clofun7, 3, y, x139886476187207, x139886476147719);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35elem_63);
+__arg1 = x;
+__arg2 = x139886476187207;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476147719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label31:
 {
-Obj x139749080448391 = makeNative(33, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj x139749079156839 = primIsSymbol(var);
-if (True == x139749079156839) {
-pushCont(co, 32, clofun7, 1, var);
+Obj x139886475569415 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476187207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476147719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139886475569415) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35index);
-__arg1 = var;
-__arg2 = fvs;
+__arg0 = globalRef(symcora_47lib_47toc_35diff);
+__arg1 = y;
+__arg2 = x139886476187207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9940,7 +10781,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080448391;
+__arg0 = x139886476147719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9951,178 +10792,151 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139749079157159 = __arg1;
-Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pos = x139749079157159;
-Obj x139749079157511 = PRIM_EQ(MAKE_NUMBER(-1), pos);
-if (True == x139749079157511) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475568039 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475568039) {
+Obj x139886475568263 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886475568263;
+Obj x139886475568455 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475568455;
+pushCont(co, 33, clofun7, 1, x);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35diff);
+__arg1 = y;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 } else {
-Obj x139749079157991 = makeCons(pos, Nil);
-Obj x139749079158023 = makeCons(sym_37closure_45ref, x139749079157991);
 __nargs = 2;
-__arg1 = x139749079158023;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label33:
 {
-Obj x139749080448935 = makeNative(38, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj x139749079208391 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079208391) {
-Obj x139749079209031 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079209063 = PRIM_EQ(symlambda, x139749079209031);
-if (True == x139749079209063) {
-Obj x139749079209607 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079209735 = PRIM_ISCONS(x139749079209607);
-if (True == x139749079209735) {
-Obj x139749079210151 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079210215 = PRIM_CAR(x139749079210151);
-Obj args = x139749079210215;
-Obj x139749079210951 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079211015 = PRIM_CDR(x139749079210951);
-Obj x139749079211047 = PRIM_ISCONS(x139749079211015);
-if (True == x139749079211047) {
-Obj x139749079211847 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079211879 = PRIM_CDR(x139749079211847);
-Obj x139749079211911 = PRIM_CAR(x139749079211879);
-Obj body = x139749079211911;
-Obj x139749079171943 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079171975 = PRIM_CDR(x139749079171943);
-Obj x139749079172007 = PRIM_CDR(x139749079171975);
-Obj x139749079172039 = PRIM_EQ(Nil, x139749079172007);
-if (True == x139749079172039) {
-Obj x139749079173671 = makeCons(body, Nil);
-Obj x139749079173703 = makeCons(args, x139749079173671);
-Obj x139749079173735 = makeCons(symlambda, x139749079173703);
-pushCont(co, 34, clofun7, 3, body, args, fvs);
+Obj x139886475568647 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475568711 = makeCons(x, x139886475568647);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139749079173735;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080448935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080448935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080448935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080448935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080448935;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x139886475568711;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label34:
 {
-Obj x139749079173895 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = x139749079173895;
-pushCont(co, 35, clofun7, 3, args, fvs, fvs1);
+Obj x139886476186855 = __arg1;
+Obj x139886476186951 = __arg2;
+Obj x139886475598215 = PRIM_EQ(Nil, x139886476186855);
+if (True == x139886475598215) {
+__nargs = 2;
+__arg1 = x139886476186951;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476147463 = makeNative(36, clofun7, 0, 2, x139886476186855, x139886476186951);
+Obj x139886475599367 = PRIM_ISCONS(x139886476186855);
+if (True == x139886475599367) {
+Obj x139886475599527 = PRIM_CAR(x139886476186855);
+Obj x = x139886475599527;
+Obj x139886475599687 = PRIM_CDR(x139886476186855);
+Obj y = x139886475599687;
+pushCont(co, 35, clofun7, 3, y, x139886476186951, x139886476147463);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs1;
-__arg2 = body;
+__arg0 = globalRef(symcora_47init_35elem_63);
+__arg1 = x;
+__arg2 = x139886476186951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476147463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label35:
 {
-Obj x139749079154823 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749079154983 = makeCons(x139749079154823, Nil);
-Obj x139749079155015 = makeCons(args, x139749079154983);
-Obj x139749079155047 = makeCons(symlambda, x139749079155015);
-pushCont(co, 36, clofun7, 2, fvs1, x139749079155047);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs;
+Obj x139886475599847 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476186951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476147463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139886475599847) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35union);
+__arg1 = y;
+__arg2 = x139886476186951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476147463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label36:
 {
-Obj x139749079155495 = __arg1;
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079155047= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 37, clofun7, 1, x139749079155047);
+Obj x139886475598535 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475598535) {
+Obj x139886475598727 = PRIM_CAR(closureRef(co, 0));
+Obj x = x139886475598727;
+Obj x139886475598919 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475598919;
+pushCont(co, 37, clofun7, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079155495;
-__arg2 = fvs1;
+__arg0 = globalRef(symcora_47lib_47toc_35union);
+__arg1 = y;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label37:
 {
-Obj x139749079155687 = __arg1;
-Obj x139749079155047= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079155719 = makeCons(x139749079155047, x139749079155687);
-Obj x139749079155751 = makeCons(sym_37closure, x139749079155719);
+Obj x139886475599111 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475599143 = makeCons(x, x139886475599111);
 __nargs = 2;
-__arg1 = x139749079155751;
+__arg1 = x139886475599143;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -10130,165 +10944,104 @@ goto *jumpTable[co->ctx.pc.label];
 
 label38:
 {
-Obj x139749080388679 = makeNative(41, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj x139749079759207 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079759207) {
-Obj x139749079759783 = PRIM_CAR(closureRef(co, 1));
-Obj x139749079759911 = PRIM_EQ(symlet, x139749079759783);
-if (True == x139749079759911) {
-Obj x139749079760359 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079760391 = PRIM_ISCONS(x139749079760359);
-if (True == x139749079760391) {
-Obj x139749079244807 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079244839 = PRIM_CAR(x139749079244807);
-Obj a = x139749079244839;
-Obj x139749079245511 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079245639 = PRIM_CDR(x139749079245511);
-Obj x139749079245671 = PRIM_ISCONS(x139749079245639);
-if (True == x139749079245671) {
-Obj x139749079246407 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079246535 = PRIM_CDR(x139749079246407);
-Obj x139749079246567 = PRIM_CAR(x139749079246535);
-Obj b = x139749079246567;
-Obj x139749079247559 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079247591 = PRIM_CDR(x139749079247559);
-Obj x139749079247719 = PRIM_CDR(x139749079247591);
-Obj x139749079247751 = PRIM_ISCONS(x139749079247719);
-if (True == x139749079247751) {
-Obj x139749079248647 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079248679 = PRIM_CDR(x139749079248647);
-Obj x139749079248711 = PRIM_CDR(x139749079248679);
-Obj x139749079248743 = PRIM_CAR(x139749079248711);
-Obj c = x139749079248743;
-Obj x139749079229543 = PRIM_CDR(closureRef(co, 1));
-Obj x139749079229575 = PRIM_CDR(x139749079229543);
-Obj x139749079229607 = PRIM_CDR(x139749079229575);
-Obj x139749079229639 = PRIM_CDR(x139749079229607);
-Obj x139749079229831 = PRIM_EQ(Nil, x139749079229639);
-if (True == x139749079229831) {
-pushCont(co, 39, clofun7, 3, fvs, c, a);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs;
-__arg2 = b;
+Obj x139886476080007 = __arg1;
+Obj x139886476080039 = __arg2;
+Obj x139886476080327 = __arg3;
+Obj x139886476103783 = makeNative(42, clofun7, 1, 3, x139886476080007, x139886476080327, x139886476080039);
+pushCont(co, 39, clofun7, 2, x139886476080327, x139886476103783);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35number_63);
+__arg1 = x139886476080327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080388679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label39:
 {
-Obj x139749079230791 = __arg1;
-Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 40, clofun7, 2, x139749079230791, a);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs;
-__arg2 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label40:
-{
-Obj x139749079231303 = __arg1;
-Obj x139749079230791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079231367 = makeCons(x139749079231303, Nil);
-Obj x139749079231399 = makeCons(x139749079230791, x139749079231367);
-Obj x139749079231495 = makeCons(a, x139749079231399);
-Obj x139749079231623 = makeCons(symlet, x139749079231495);
+Obj x139886475597351 = __arg1;
+Obj x139886476080327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475597351) {
 __nargs = 2;
-__arg1 = x139749079231623;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label41:
-{
-Obj x139749080390087 = makeNative(43, clofun7, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj x139749079757255 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079757255) {
-Obj x139749079757607 = PRIM_CAR(closureRef(co, 1));
-Obj f = x139749079757607;
-Obj x139749079757991 = PRIM_CDR(closureRef(co, 1));
-Obj args = x139749079757991;
-pushCont(co, 42, clofun7, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs;
+__arg0 = x139886476103783;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749080390087;
+Obj x139886475597511 = primIsString(x139886476080327);
+if (True == x139886475597511) {
+__nargs = 2;
+__arg0 = x139886476103783;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 40, clofun7, 2, x139886476080327, x139886476103783);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35boolean_63);
+__arg1 = x139886476080327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label40:
+{
+Obj x139886475597671 = __arg1;
+Obj x139886476080327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x139886475597671) {
+__nargs = 2;
+__arg0 = x139886476103783;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 41, clofun7, 1, x139886476103783);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35null_63);
+__arg1 = x139886476080327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label41:
+{
+Obj x139886475597831 = __arg1;
+Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x139886475597831) {
+__nargs = 2;
+__arg0 = x139886476103783;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x139886476103783;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10299,124 +11052,273 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139749079758407 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079758727 = makeCons(f, args);
+Obj x139886476103815 = __arg1;
+if (True == x139886476103815) {
+Obj x139886475182695 = makeCons(closureRef(co, 1), Nil);
+Obj x139886475182727 = makeCons(sym_37const, x139886475182695);
+__nargs = 2;
+__arg1 = x139886475182727;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475567239 = makeNative(44, clofun7, 0, 3, closureRef(co, 1), closureRef(co, 0), closureRef(co, 2));
+Obj x139886475984263 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x139886475984263) {
+Obj x139886475984519 = PRIM_CAR(closureRef(co, 1));
+Obj x139886475984583 = PRIM_EQ(symquote, x139886475984519);
+if (True == x139886475984583) {
+Obj x139886475984839 = PRIM_CDR(closureRef(co, 1));
+Obj x139886475984871 = PRIM_ISCONS(x139886475984839);
+if (True == x139886475984871) {
+Obj x139886475596007 = PRIM_CDR(closureRef(co, 1));
+Obj x139886475596039 = PRIM_CAR(x139886475596007);
+Obj x = x139886475596039;
+Obj x139886475596391 = PRIM_CDR(closureRef(co, 1));
+Obj x139886475596423 = PRIM_CDR(x139886475596391);
+Obj x139886475596455 = PRIM_EQ(Nil, x139886475596423);
+if (True == x139886475596455) {
+pushCont(co, 43, clofun7, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079758407;
-__arg2 = x139749079758727;
+__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
+__arg1 = x;
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475567239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475567239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475567239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475567239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label43:
 {
+Obj x139886475596679 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475596839 = makeCons(x, Nil);
+Obj x139886475596871 = makeCons(sym_37const, x139886475596839);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x139886475596871;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label44:
 {
-Obj x139749080474119 = __arg1;
-Obj x139749080474343 = makeNative(46, clofun7, 0, 1, x139749080474119);
-Obj x = x139749080474119;
-pushCont(co, 45, clofun7, 1, x139749080474343);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x;
+Obj x139886475183047 = primIsSymbol(closureRef(co, 0));
+if (True == x139886475183047) {
+PUSH_CONT_0(co, 18, clofun8);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35elem_63);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj x139886475463303 = makeNative(47, clofun7, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886476083015 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476083015) {
+Obj x139886475980871 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475980903 = PRIM_EQ(symlambda, x139886475980871);
+if (True == x139886475980903) {
+Obj x139886475981191 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475981223 = PRIM_ISCONS(x139886475981191);
+if (True == x139886475981223) {
+Obj x139886475981543 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475981575 = PRIM_CAR(x139886475981543);
+Obj args = x139886475981575;
+Obj x139886475981895 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475981927 = PRIM_CDR(x139886475981895);
+Obj x139886475981959 = PRIM_ISCONS(x139886475981927);
+if (True == x139886475981959) {
+Obj x139886475982279 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475982311 = PRIM_CDR(x139886475982279);
+Obj x139886475982343 = PRIM_CAR(x139886475982311);
+Obj body = x139886475982343;
+Obj x139886475982759 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475982855 = PRIM_CDR(x139886475982759);
+Obj x139886475982919 = PRIM_CDR(x139886475982855);
+Obj x139886475982983 = PRIM_EQ(Nil, x139886475982919);
+if (True == x139886475982983) {
+pushCont(co, 45, clofun7, 2, body, args);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35append);
+__arg1 = args;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475463303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475463303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475463303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475463303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475463303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label45:
 {
-Obj x139749079783943 = __arg1;
-Obj x139749080474343= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139749079783943) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080474343;
+Obj x139886475983431 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun7, 1, args);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = x139886475983431;
+__arg2 = closureRef(co, 2);
+__arg3 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label46:
 {
-Obj x139749080474663 = makeNative(47, clofun7, 0, 1, closureRef(co, 0));
-Obj x = closureRef(co, 0);
-Obj x139749079783175 = primIsSymbol(x);
-if (True == x139749079783175) {
-Obj x139749079783399 = makeCons(x, Nil);
+Obj x139886475983495 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475983527 = makeCons(x139886475983495, Nil);
+Obj x139886475983559 = makeCons(args, x139886475983527);
+Obj x139886475983591 = makeCons(symlambda, x139886475983559);
 __nargs = 2;
-__arg1 = x139749079783399;
+__arg1 = x139886475983591;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080474663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label47:
 {
-Obj x139749080474983 = makeNative(49, clofun7, 0, 1, closureRef(co, 0));
-Obj x139749080354087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080354087) {
-Obj x139749080354663 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080354695 = PRIM_EQ(symlambda, x139749080354663);
-if (True == x139749080354695) {
-Obj x139749079970919 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079970951 = PRIM_ISCONS(x139749079970919);
-if (True == x139749079970951) {
-Obj x139749079971399 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079971431 = PRIM_CAR(x139749079971399);
-Obj args = x139749079971431;
-Obj x139749079972103 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079972135 = PRIM_CDR(x139749079972103);
-Obj x139749079972167 = PRIM_ISCONS(x139749079972135);
-if (True == x139749079972167) {
-Obj x139749079972807 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079972839 = PRIM_CDR(x139749079972807);
-Obj x139749079972871 = PRIM_CAR(x139749079972839);
-Obj body = x139749079972871;
-Obj x139749079781383 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079781415 = PRIM_CDR(x139749079781383);
-Obj x139749079781447 = PRIM_CDR(x139749079781415);
-Obj x139749079781479 = PRIM_EQ(Nil, x139749079781447);
-if (True == x139749079781479) {
-pushCont(co, 48, clofun7, 1, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = body;
+Obj x139886475386631 = makeNative(48, clofun7, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886476106919 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476106919) {
+Obj x139886476107175 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476107207 = PRIM_EQ(symif, x139886476107175);
+if (True == x139886476107207) {
+Obj x139886476107463 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476107495 = PRIM_ISCONS(x139886476107463);
+if (True == x139886476107495) {
+Obj x139886476079143 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476079175 = PRIM_CAR(x139886476079143);
+Obj x139886476079207 = PRIM_ISCONS(x139886476079175);
+if (True == x139886476079207) {
+Obj x139886476079591 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476079655 = PRIM_CAR(x139886476079591);
+Obj x139886476079687 = PRIM_CAR(x139886476079655);
+Obj x139886476079719 = PRIM_EQ(symif, x139886476079687);
+if (True == x139886476079719) {
+Obj x139886476080135 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476080167 = PRIM_CAR(x139886476080135);
+Obj x139886476080199 = PRIM_CDR(x139886476080167);
+Obj exp1 = x139886476080199;
+Obj x139886476080487 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476080519 = PRIM_CDR(x139886476080487);
+Obj exp2 = x139886476080519;
+Obj x139886476080679 = primGenSym();
+Obj f = x139886476080679;
+Obj x139886476080839 = primGenSym();
+Obj v = x139886476080839;
+Obj x139886476081511 = makeCons(v, Nil);
+Obj x139886476081831 = makeCons(v, exp2);
+Obj x139886476081863 = makeCons(symif, x139886476081831);
+Obj x139886476081895 = makeCons(x139886476081863, Nil);
+Obj x139886476081927 = makeCons(x139886476081511, x139886476081895);
+Obj x139886476081991 = makeCons(symlambda, x139886476081927);
+Obj x139886476082279 = makeCons(symif, exp1);
+Obj x139886476082311 = makeCons(x139886476082279, Nil);
+Obj x139886476082343 = makeCons(f, x139886476082311);
+Obj x139886476082375 = makeCons(x139886476082343, Nil);
+Obj x139886476082407 = makeCons(x139886476081991, x139886476082375);
+Obj x139886476082439 = makeCons(f, x139886476082407);
+Obj x139886476082471 = makeCons(symlet, x139886476082439);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x139886476082471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10424,34 +11326,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080474983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080474983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080474983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080474983;
+__arg0 = x139886475386631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10460,7 +11335,34 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080474983;
+__arg0 = x139886475386631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475386631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475386631;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475386631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10471,124 +11373,58 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139749079781863 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476145895 = makeNative(1, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886476105543 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476105543) {
+Obj x139886476105799 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476105831 = PRIM_EQ(symif, x139886476105799);
+if (True == x139886476105831) {
+Obj x139886476106023 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886476106023;
+pushCont(co, 49, clofun7, 1, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139749079781863;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886476145895;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476145895;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label49:
+{
+Obj x139886476106311 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 0, clofun8);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886476106311;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label49:
-{
-Obj x139749080475943 = makeNative(1, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749080389511 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080389511) {
-Obj x139749080390055 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080390119 = PRIM_EQ(symif, x139749080390055);
-if (True == x139749080390119) {
-Obj x139749080390631 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080390663 = PRIM_ISCONS(x139749080390631);
-if (True == x139749080390663) {
-Obj x139749080391175 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080391207 = PRIM_CAR(x139749080391175);
-Obj x = x139749080391207;
-Obj x139749080363335 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080363367 = PRIM_CDR(x139749080363335);
-Obj x139749080363399 = PRIM_ISCONS(x139749080363367);
-if (True == x139749080363399) {
-Obj x139749080364295 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080364327 = PRIM_CDR(x139749080364295);
-Obj x139749080364359 = PRIM_CAR(x139749080364327);
-Obj y = x139749080364359;
-Obj x139749080365191 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080365223 = PRIM_CDR(x139749080365191);
-Obj x139749080365255 = PRIM_CDR(x139749080365223);
-Obj x139749080365287 = PRIM_ISCONS(x139749080365255);
-if (True == x139749080365287) {
-Obj x139749080366343 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080366375 = PRIM_CDR(x139749080366343);
-Obj x139749080366407 = PRIM_CDR(x139749080366375);
-Obj x139749080366439 = PRIM_CAR(x139749080366407);
-Obj z = x139749080366439;
-Obj x139749080351207 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080351239 = PRIM_CDR(x139749080351207);
-Obj x139749080351271 = PRIM_CDR(x139749080351239);
-Obj x139749080351303 = PRIM_CDR(x139749080351271);
-Obj x139749080351335 = PRIM_EQ(Nil, x139749080351303);
-if (True == x139749080351335) {
-Obj x139749080352711 = makeCons(z, Nil);
-Obj x139749080352743 = makeCons(y, x139749080352711);
-Obj x139749080352775 = makeCons(x, x139749080352743);
-PUSH_CONT_0(co, 0, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139749080352775;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080475943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 fail:
@@ -10607,59 +11443,54 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43, &&label44, &&label45, &&label46, &&label47, &&label48, &&label49};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139749080352807 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139749080352807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476106343 = __arg1;
+Obj x139886476106375 = makeCons(symif, x139886476106343);
+__nargs = 2;
+__arg1 = x139886476106375;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj x139749080477127 = makeNative(3, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749080464167 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080464167) {
-Obj x139749080464711 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080464743 = PRIM_EQ(symdo, x139749080464711);
-if (True == x139749080464743) {
-Obj x139749080465351 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080465383 = PRIM_ISCONS(x139749080465351);
-if (True == x139749080465383) {
-Obj x139749080445543 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080445607 = PRIM_CAR(x139749080445543);
-Obj x = x139749080445607;
-Obj x139749080446375 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080446407 = PRIM_CDR(x139749080446375);
-Obj x139749080446439 = PRIM_ISCONS(x139749080446407);
-if (True == x139749080446439) {
-Obj x139749080447335 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080447367 = PRIM_CDR(x139749080447335);
-Obj x139749080447399 = PRIM_CAR(x139749080447367);
-Obj y = x139749080447399;
-Obj x139749080448455 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080448487 = PRIM_CDR(x139749080448455);
-Obj x139749080448519 = PRIM_CDR(x139749080448487);
-Obj x139749080448551 = PRIM_EQ(Nil, x139749080448519);
-if (True == x139749080448551) {
-Obj x139749080388263 = makeCons(y, Nil);
-Obj x139749080388295 = makeCons(x, x139749080388263);
-PUSH_CONT_0(co, 2, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139749080388295;
+Obj x139886476106823 = makeNative(4, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886476146087 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886476146087) {
+Obj x139886476146375 = PRIM_CAR(closureRef(co, 0));
+Obj x139886476146407 = PRIM_EQ(symdo, x139886476146375);
+if (True == x139886476146407) {
+Obj x139886476146695 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476146727 = PRIM_ISCONS(x139886476146695);
+if (True == x139886476146727) {
+Obj x139886476146983 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476147047 = PRIM_CAR(x139886476146983);
+Obj x = x139886476147047;
+Obj x139886476147431 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476147495 = PRIM_CDR(x139886476147431);
+Obj x139886476147559 = PRIM_ISCONS(x139886476147495);
+if (True == x139886476147559) {
+Obj x139886476147911 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476147943 = PRIM_CDR(x139886476147911);
+Obj x139886476147975 = PRIM_CAR(x139886476147943);
+Obj y = x139886476147975;
+Obj x139886476148519 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476148551 = PRIM_CDR(x139886476148519);
+Obj x139886476148583 = PRIM_CDR(x139886476148551);
+Obj x139886476148615 = PRIM_EQ(Nil, x139886476148583);
+if (True == x139886476148615) {
+pushCont(co, 2, clofun8, 1, y);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10667,16 +11498,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080477127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080477127;
+__arg0 = x139886476106823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10685,7 +11507,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477127;
+__arg0 = x139886476106823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10694,7 +11516,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477127;
+__arg0 = x139886476106823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10703,7 +11525,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080477127;
+__arg0 = x139886476106823;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476106823;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10714,12 +11545,14 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139749080388327 = __arg1;
+Obj x139886476103943 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun8, 1, x139886476103943);
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139749080388327;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10729,134 +11562,135 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139749080461703 = makeNative(7, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749080523815 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080523815) {
-Obj x139749080524455 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080524487 = PRIM_EQ(symlet, x139749080524455);
-if (True == x139749080524487) {
-Obj x139749080524999 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080525031 = PRIM_ISCONS(x139749080524999);
-if (True == x139749080525031) {
-Obj x139749080525511 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080525543 = PRIM_CAR(x139749080525511);
-Obj a = x139749080525543;
-Obj x139749080526279 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080526311 = PRIM_CDR(x139749080526279);
-Obj x139749080526407 = PRIM_ISCONS(x139749080526311);
-if (True == x139749080526407) {
-Obj x139749080473991 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080474023 = PRIM_CDR(x139749080473991);
-Obj x139749080474055 = PRIM_CAR(x139749080474023);
-Obj b = x139749080474055;
-Obj x139749080475143 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080475175 = PRIM_CDR(x139749080475143);
-Obj x139749080475207 = PRIM_CDR(x139749080475175);
-Obj x139749080475335 = PRIM_ISCONS(x139749080475207);
-if (True == x139749080475335) {
-Obj x139749080476295 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080476391 = PRIM_CDR(x139749080476295);
-Obj x139749080476423 = PRIM_CDR(x139749080476391);
-Obj x139749080476455 = PRIM_CAR(x139749080476423);
-Obj c = x139749080476455;
-Obj x139749080461415 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080461447 = PRIM_CDR(x139749080461415);
-Obj x139749080461479 = PRIM_CDR(x139749080461447);
-Obj x139749080461511 = PRIM_CDR(x139749080461479);
-Obj x139749080461575 = PRIM_EQ(Nil, x139749080461511);
-if (True == x139749080461575) {
-pushCont(co, 4, clofun8, 2, c, a);
+Obj x139886476104487 = __arg1;
+Obj x139886476103943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886476104839 = makeCons(x139886476104487, Nil);
+Obj x139886476104871 = makeCons(x139886476103943, x139886476104839);
+Obj x139886476104903 = makeCons(symdo, x139886476104871);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080461703;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x139886476104903;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj x139749080461959 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 5, clofun8, 2, a, x139749080461959);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = c;
+Obj x139886475982951 = makeNative(7, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886474652551 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886474652551) {
+Obj x139886474652807 = PRIM_CAR(closureRef(co, 0));
+Obj x139886474652839 = PRIM_EQ(symlet, x139886474652807);
+if (True == x139886474652839) {
+Obj x139886474653095 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474653127 = PRIM_ISCONS(x139886474653095);
+if (True == x139886474653127) {
+Obj x139886476186247 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476186279 = PRIM_CAR(x139886476186247);
+Obj a = x139886476186279;
+Obj x139886476186631 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476186695 = PRIM_CDR(x139886476186631);
+Obj x139886476186791 = PRIM_ISCONS(x139886476186695);
+if (True == x139886476186791) {
+Obj x139886476187463 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476187495 = PRIM_CDR(x139886476187463);
+Obj x139886476187655 = PRIM_CAR(x139886476187495);
+Obj b = x139886476187655;
+Obj x139886476188231 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188263 = PRIM_CDR(x139886476188231);
+Obj x139886476188295 = PRIM_CDR(x139886476188263);
+Obj x139886476188327 = PRIM_ISCONS(x139886476188295);
+if (True == x139886476188327) {
+Obj x139886476188903 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476188935 = PRIM_CDR(x139886476188903);
+Obj x139886476188967 = PRIM_CDR(x139886476188935);
+Obj x139886476189031 = PRIM_CAR(x139886476188967);
+Obj c = x139886476189031;
+Obj x139886476189511 = PRIM_CDR(closureRef(co, 0));
+Obj x139886476189543 = PRIM_CDR(x139886476189511);
+Obj x139886476189575 = PRIM_CDR(x139886476189543);
+Obj x139886476189607 = PRIM_CDR(x139886476189575);
+Obj x139886476189639 = PRIM_EQ(Nil, x139886476189607);
+if (True == x139886476189639) {
+pushCont(co, 5, clofun8, 2, c, a);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475982951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label5:
 {
-Obj x139749080462471 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080461959= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080462759 = makeCons(a, Nil);
-pushCont(co, 6, clofun8, 1, x139749080461959);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139749080462471;
-__arg2 = x139749080462759;
+Obj x139886476144935 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476145255 = makeCons(a, closureRef(co, 1));
+pushCont(co, 6, clofun8, 2, x139886476144935, a);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = x139886476145255;
+__arg2 = closureRef(co, 2);
+__arg3 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10866,40 +11700,70 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139749080462791 = __arg1;
-Obj x139749080461959= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = x139749080461959;
-__arg2 = x139749080462791;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476145319 = __arg1;
+Obj x139886476144935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886476145351 = makeCons(x139886476145319, Nil);
+Obj x139886476145383 = makeCons(x139886476144935, x139886476145351);
+Obj x139886476145415 = makeCons(a, x139886476145383);
+Obj x139886476145447 = makeCons(symlet, x139886476145415);
+__nargs = 2;
+__arg1 = x139886476145447;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label7:
 {
-Obj x139749080462887 = makeNative(8, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749080646695 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749080646695) {
-Obj x139749080647271 = PRIM_CAR(closureRef(co, 0));
-Obj x139749080647303 = PRIM_EQ(sym_37closure, x139749080647271);
-if (True == x139749080647303) {
-Obj x139749080647911 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080647975 = PRIM_ISCONS(x139749080647911);
-if (True == x139749080647975) {
-Obj x139749080648423 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080648455 = PRIM_CAR(x139749080648423);
-Obj lam = x139749080648455;
-Obj x139749080649319 = PRIM_CDR(closureRef(co, 0));
-Obj x139749080649351 = PRIM_CDR(x139749080649319);
-Obj more = x139749080649351;
-Obj x139749080522983 = makeCons(lam, more);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139749080522983;
+Obj x139886475469191 = makeNative(8, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x139886475126631 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475126631) {
+Obj x139886475126887 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475126919 = PRIM_ISCONS(x139886475126887);
+if (True == x139886475126919) {
+Obj x139886475127239 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475127271 = PRIM_CAR(x139886475127239);
+Obj x139886475127303 = PRIM_EQ(symlambda, x139886475127271);
+if (True == x139886475127303) {
+Obj x139886475127559 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475127591 = PRIM_CDR(x139886475127559);
+Obj exp1 = x139886475127591;
+Obj x139886475127847 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475127879 = PRIM_ISCONS(x139886475127847);
+if (True == x139886475127879) {
+Obj x139886475128199 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475128231 = PRIM_CAR(x139886475128199);
+Obj x139886475128263 = PRIM_ISCONS(x139886475128231);
+if (True == x139886475128263) {
+Obj x139886475128647 = PRIM_CDR(closureRef(co, 0));
+Obj x139886475128679 = PRIM_CAR(x139886475128647);
+Obj x139886475128711 = PRIM_CAR(x139886475128679);
+Obj x139886475128743 = PRIM_EQ(symif, x139886475128711);
+if (True == x139886475128743) {
+Obj x139886474649831 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474649863 = PRIM_CAR(x139886474649831);
+Obj x139886474649895 = PRIM_CDR(x139886474649863);
+Obj exp2 = x139886474649895;
+Obj x139886474650215 = PRIM_CDR(closureRef(co, 0));
+Obj x139886474650247 = PRIM_CDR(x139886474650215);
+Obj x139886474650279 = PRIM_EQ(Nil, x139886474650247);
+if (True == x139886474650279) {
+Obj x139886474650439 = primGenSym();
+Obj f = x139886474650439;
+Obj x139886474651431 = makeCons(symlambda, exp1);
+Obj x139886474651719 = makeCons(symif, exp2);
+Obj x139886474651751 = makeCons(x139886474651719, Nil);
+Obj x139886474651783 = makeCons(f, x139886474651751);
+Obj x139886474651815 = makeCons(x139886474651783, Nil);
+Obj x139886474651847 = makeCons(x139886474651431, x139886474651815);
+Obj x139886474651879 = makeCons(f, x139886474651847);
+Obj x139886474651911 = makeCons(symlet, x139886474651879);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x139886474651911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10907,7 +11771,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080462887;
+__arg0 = x139886475469191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10916,7 +11780,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080462887;
+__arg0 = x139886475469191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10925,7 +11789,43 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139749080462887;
+__arg0 = x139886475469191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475469191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10936,25 +11836,17 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139749080463623 = makeNative(9, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749078982087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749078982087) {
-Obj x139749078982535 = PRIM_CAR(closureRef(co, 0));
-Obj x139749078982567 = PRIM_EQ(symreturn, x139749078982535);
-if (True == x139749078982567) {
-Obj x139749078839623 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078839655 = PRIM_ISCONS(x139749078839623);
-if (True == x139749078839655) {
-Obj x139749078840071 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078840103 = PRIM_CAR(x139749078840071);
-Obj x = x139749078840103;
-Obj x139749078840711 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078840743 = PRIM_CDR(x139749078840711);
-Obj x139749078840775 = PRIM_EQ(Nil, x139749078840743);
-if (True == x139749078840775) {
+Obj x139886475383335 = makeNative(16, clofun8, 0, 3, closureRef(co, 1), closureRef(co, 2), closureRef(co, 0));
+Obj x139886475185095 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475185095) {
+Obj x139886475185287 = PRIM_CAR(closureRef(co, 0));
+Obj op = x139886475185287;
+Obj x139886475185479 = PRIM_CDR(closureRef(co, 0));
+Obj args = x139886475185479;
+pushCont(co, 9, clofun8, 3, op, args, x139886475383335);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x;
+__arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
+__arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10962,34 +11854,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080463623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080463623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080463623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080463623;
+__arg0 = x139886475383335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11000,38 +11865,15 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139749080464359 = makeNative(11, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079046407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079046407) {
-Obj x139749079046855 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079046887 = PRIM_EQ(symcall, x139749079046855);
-if (True == x139749079046887) {
-Obj x139749079047303 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079047335 = PRIM_ISCONS(x139749079047303);
-if (True == x139749079047335) {
-Obj x139749079047751 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079047783 = PRIM_CAR(x139749079047751);
-Obj exp = x139749079047783;
-Obj x139749078978727 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078978759 = PRIM_CDR(x139749078978727);
-Obj x139749078978791 = PRIM_ISCONS(x139749078978759);
-if (True == x139749078978791) {
-Obj x139749078979367 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078979399 = PRIM_CDR(x139749078979367);
-Obj x139749078979431 = PRIM_CAR(x139749078979399);
-Obj cont = x139749078979431;
-Obj x139749078980199 = PRIM_CDR(closureRef(co, 0));
-Obj x139749078980231 = PRIM_CDR(x139749078980199);
-Obj x139749078980263 = PRIM_CDR(x139749078980231);
-Obj x139749078980295 = PRIM_EQ(Nil, x139749078980263);
-if (True == x139749078980295) {
-Obj x139749078981127 = makeCons(cont, Nil);
-Obj x139749078981159 = makeCons(exp, x139749078981127);
-PUSH_CONT_0(co, 10, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139749078981159;
+Obj x139886475185639 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475383335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x139886475185639) {
+pushCont(co, 10, clofun8, 2, op, args);
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
+__arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11039,43 +11881,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139749080464359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080464359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080464359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080464359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080464359;
+__arg0 = x139886475383335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11086,12 +11892,14 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139749078981191 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139749078981191;
+Obj x139886475185799 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj required = x139886475185799;
+pushCont(co, 11, clofun8, 3, required, op, args);
+__nargs = 2;
+__arg0 = globalRef(symcora_47init_35length);
+__arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11101,1719 +11909,38 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139749080465319 = makeNative(12, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079070823 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079070823) {
-Obj x139749079071431 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079071463 = PRIM_EQ(symtailcall, x139749079071431);
-if (True == x139749079071463) {
-Obj x139749079071879 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079071911 = PRIM_ISCONS(x139749079071879);
-if (True == x139749079071911) {
-Obj x139749079072359 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079072391 = PRIM_CAR(x139749079072359);
-Obj exp = x139749079072391;
-Obj x139749079044455 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079044487 = PRIM_CDR(x139749079044455);
-Obj x139749079044519 = PRIM_EQ(Nil, x139749079044487);
-if (True == x139749079044519) {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080465319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080465319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080465319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080465319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj x139749080445575 = makeNative(14, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079143335 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079143335) {
-Obj x139749079143815 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079143847 = PRIM_EQ(symcontinuation, x139749079143815);
-if (True == x139749079143847) {
-Obj x139749079144295 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079144327 = PRIM_ISCONS(x139749079144295);
-if (True == x139749079144327) {
-Obj x139749079144807 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079144839 = PRIM_CAR(x139749079144807);
-Obj arg = x139749079144839;
-Obj x139749079145511 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079145543 = PRIM_CDR(x139749079145511);
-Obj x139749079145575 = PRIM_ISCONS(x139749079145543);
-if (True == x139749079145575) {
-Obj x139749079146183 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079146215 = PRIM_CDR(x139749079146183);
-Obj x139749079146311 = PRIM_CAR(x139749079146215);
-Obj body = x139749079146311;
-Obj x139749079069383 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079069415 = PRIM_CDR(x139749079069383);
-Obj x139749079069447 = PRIM_CDR(x139749079069415);
-Obj x139749079069479 = PRIM_EQ(Nil, x139749079069447);
-if (True == x139749079069479) {
-pushCont(co, 13, clofun8, 1, arg);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080445575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080445575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj x139749079069895 = __arg1;
-Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139749079069895;
-__arg2 = arg;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x139749080446535 = makeNative(16, clofun8, 0, 0);
-Obj x139749079158151 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079158151) {
-Obj x139749079158407 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139749079158407;
-Obj x139749079158663 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139749079158663;
-Obj x139749079142919 = makeCons(f, args);
-PUSH_CONT_0(co, 15, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139749079142919;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080446535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139749079142951 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139749079142951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj x139749080649703 = __arg1;
-Obj x139749080522951 = makeNative(18, clofun8, 0, 1, x139749080649703);
-Obj x139749079173095 = PRIM_ISCONS(x139749080649703);
-if (True == x139749079173095) {
-Obj x139749079173543 = PRIM_CAR(x139749080649703);
-Obj x139749079173575 = PRIM_EQ(sym_37const, x139749079173543);
-if (True == x139749079173575) {
-Obj x139749079174151 = PRIM_CDR(x139749080649703);
-Obj x139749079174183 = PRIM_ISCONS(x139749079174151);
-if (True == x139749079174183) {
-Obj x139749079174631 = PRIM_CDR(x139749080649703);
-Obj x139749079174663 = PRIM_CAR(x139749079174631);
-Obj x = x139749079174663;
-Obj x139749079154887 = PRIM_CDR(x139749080649703);
-Obj x139749079154919 = PRIM_CDR(x139749079154887);
-Obj x139749079154951 = PRIM_EQ(Nil, x139749079154919);
-if (True == x139749079154951) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080522951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080522951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080522951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080522951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label18:
-{
-Obj x139749080523687 = makeNative(19, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079210183 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079210183) {
-Obj x139749079210727 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079210759 = PRIM_EQ(sym_37global, x139749079210727);
-if (True == x139749079210759) {
-Obj x139749079211207 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079211239 = PRIM_ISCONS(x139749079211207);
-if (True == x139749079211239) {
-Obj x139749079211751 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079211783 = PRIM_CAR(x139749079211751);
-Obj x = x139749079211783;
-Obj x139749079171559 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079171591 = PRIM_CDR(x139749079171559);
-Obj x139749079171623 = PRIM_EQ(Nil, x139749079171591);
-if (True == x139749079171623) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080523687;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080523687;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080523687;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080523687;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj x139749080524423 = makeNative(20, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079231463 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079231463) {
-Obj x139749079232007 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079232039 = PRIM_EQ(sym_37builtin, x139749079232007);
-if (True == x139749079232039) {
-Obj x139749079208007 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079208039 = PRIM_ISCONS(x139749079208007);
-if (True == x139749079208039) {
-Obj x139749079208455 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079208487 = PRIM_CAR(x139749079208455);
-Obj op = x139749079208487;
-Obj x139749079209223 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079209255 = PRIM_CDR(x139749079209223);
-Obj x139749079209287 = PRIM_EQ(Nil, x139749079209255);
-if (True == x139749079209287) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080524423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080524423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080524423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080524423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj x139749080525159 = makeNative(21, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079248583 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079248583) {
-Obj x139749079228615 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079228647 = PRIM_EQ(symquote, x139749079228615);
-if (True == x139749079228647) {
-Obj x139749079229191 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079229223 = PRIM_ISCONS(x139749079229191);
-if (True == x139749079229223) {
-Obj x139749079229767 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079229799 = PRIM_CAR(x139749079229767);
-Obj x = x139749079229799;
-Obj x139749079230407 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079230439 = PRIM_CDR(x139749079230407);
-Obj x139749079230471 = PRIM_EQ(Nil, x139749079230439);
-if (True == x139749079230471) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080525159;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525159;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525159;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525159;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label21:
-{
-Obj x139749080525895 = makeNative(22, clofun8, 0, 1, closureRef(co, 0));
-Obj x139749079245223 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079245223) {
-Obj x139749079245767 = PRIM_CAR(closureRef(co, 0));
-Obj x139749079245799 = PRIM_EQ(sym_37closure_45ref, x139749079245767);
-if (True == x139749079245799) {
-Obj x139749079246247 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079246279 = PRIM_ISCONS(x139749079246247);
-if (True == x139749079246279) {
-Obj x139749079246791 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079246823 = PRIM_CAR(x139749079246791);
-Obj __ = x139749079246823;
-Obj x139749079247623 = PRIM_CDR(closureRef(co, 0));
-Obj x139749079247655 = PRIM_CDR(x139749079247623);
-Obj x139749079247687 = PRIM_EQ(Nil, x139749079247655);
-if (True == x139749079247687) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080525895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749080525895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label22:
-{
-Obj x139749080526631 = makeNative(23, clofun8, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label23:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label24:
-{
-Obj x139749080646983 = __arg1;
-Obj x139749080647015 = __arg2;
-Obj x139749080647399 = makeNative(25, clofun8, 0, 2, x139749080646983, x139749080647015);
-Obj x139749079759143 = PRIM_EQ(Nil, x139749080646983);
-if (True == x139749079759143) {
-Obj __ = x139749080647015;
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080647399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label25:
-{
-Obj x139749080647943 = makeNative(27, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079757351 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079757351) {
-Obj x139749079757639 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139749079757639;
-Obj x139749079757959 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139749079757959;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 26, clofun8, 3, y, s2, x139749080647943);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080647943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label26:
-{
-Obj x139749079758343 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080647943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139749079758343) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080647943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label27:
-{
-Obj x139749080648711 = makeNative(29, clofun8, 0, 0);
-Obj x139749079784391 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079784391) {
-Obj x139749079784679 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139749079784679;
-Obj x139749079784935 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139749079784935;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 28, clofun8, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080648711;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label28:
-{
-Obj x139749079785447 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079756807 = makeCons(x, x139749079785447);
-__nargs = 2;
-__arg1 = x139749079756807;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label29:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj x139749079155559 = __arg1;
-Obj x139749079155591 = __arg2;
-Obj x139749079155975 = makeNative(31, clofun8, 0, 2, x139749079155559, x139749079155591);
-Obj x139749079782887 = PRIM_EQ(Nil, x139749079155559);
-if (True == x139749079782887) {
-Obj s2 = x139749079155591;
-__nargs = 2;
-__arg1 = s2;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079155975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label31:
-{
-Obj x139749079156519 = makeNative(33, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139749079973575 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079973575) {
-Obj x139749079973831 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139749079973831;
-Obj x139749079781607 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139749079781607;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 32, clofun8, 3, y, s2, x139749079156519);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079156519;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label32:
-{
-Obj x139749079781991 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079156519= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139749079781991) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079156519;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label33:
-{
-Obj x139749080645991 = makeNative(35, clofun8, 0, 0);
-Obj x139749079972071 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139749079972071) {
-Obj x139749079972327 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139749079972327;
-Obj x139749079972583 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139749079972583;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 34, clofun8, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749080645991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj x139749079973095 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079973127 = makeCons(x, x139749079973095);
-__nargs = 2;
-__arg1 = x139749079973127;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label35:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label36:
-{
-Obj x139749079230823 = __arg1;
-Obj x139749079230855 = __arg2;
-Obj x139749079230887 = __arg3;
-Obj x139749079231431 = makeNative(40, clofun8, 0, 3, x139749079230823, x139749079230855, x139749079230887);
-Obj __ = x139749079230823;
-Obj globals = x139749079230855;
-Obj x = x139749079230887;
-pushCont(co, 37, clofun8, 2, x, x139749079231431);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35number_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label37:
-{
-Obj x139749080351079 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079231431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080351079) {
-if (True == True) {
-Obj x139749080351559 = makeCons(x, Nil);
-Obj x139749080351591 = makeCons(sym_37const, x139749080351559);
-__nargs = 2;
-__arg1 = x139749080351591;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079231431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-Obj x139749080352039 = primIsString(x);
-if (True == x139749080352039) {
-if (True == True) {
-Obj x139749080352519 = makeCons(x, Nil);
-Obj x139749080352551 = makeCons(sym_37const, x139749080352519);
-__nargs = 2;
-__arg1 = x139749080352551;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079231431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 38, clofun8, 2, x, x139749079231431);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35boolean_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label38:
-{
-Obj x139749080352935 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079231431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080352935) {
-if (True == True) {
-Obj x139749080353447 = makeCons(x, Nil);
-Obj x139749080353479 = makeCons(sym_37const, x139749080353447);
-__nargs = 2;
-__arg1 = x139749080353479;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079231431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 39, clofun8, 2, x, x139749079231431);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label39:
-{
-Obj x139749080353863 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079231431= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080353863) {
-if (True == True) {
-Obj x139749080354311 = makeCons(x, Nil);
-Obj x139749080354343 = makeCons(sym_37const, x139749080354311);
-__nargs = 2;
-__arg1 = x139749080354343;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079231431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj x139749079969959 = makeCons(x, Nil);
-Obj x139749079969991 = makeCons(sym_37const, x139749079969959);
-__nargs = 2;
-__arg1 = x139749079969991;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079231431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label40:
-{
-Obj x139749079232199 = makeNative(42, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj __ = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749080391655 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080391655) {
-Obj x139749080363655 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080363687 = PRIM_EQ(symquote, x139749080363655);
-if (True == x139749080363687) {
-Obj x139749080364199 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080364231 = PRIM_ISCONS(x139749080364199);
-if (True == x139749080364231) {
-Obj x139749080364679 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080364711 = PRIM_CAR(x139749080364679);
-Obj x = x139749080364711;
-Obj x139749080365351 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080365383 = PRIM_CDR(x139749080365351);
-Obj x139749080365415 = PRIM_EQ(Nil, x139749080365383);
-if (True == x139749080365415) {
-pushCont(co, 41, clofun8, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = x;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079232199;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079232199;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079232199;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079232199;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label41:
-{
-Obj x139749080365767 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080366215 = makeCons(x, Nil);
-Obj x139749080366247 = makeCons(sym_37const, x139749080366215);
-__nargs = 2;
-__arg1 = x139749080366247;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label42:
-{
-Obj x139749079208807 = makeNative(45, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x = closureRef(co, 2);
-Obj x139749080389895 = primIsSymbol(x);
-if (True == x139749080389895) {
-pushCont(co, 43, clofun8, 2, globals, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = x;
-__arg2 = env;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079208807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label43:
-{
-Obj x139749080390279 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139749080390279) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 44, clofun8, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = x;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label44:
-{
-Obj x139749080390599 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080391015 = makeCons(x, Nil);
-Obj x139749080391079 = makeCons(sym_37global, x139749080391015);
-__nargs = 2;
-__arg1 = x139749080391079;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label45:
-{
-Obj x139749079209575 = makeNative(48, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749080464999 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080464999) {
-Obj x139749080445063 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080445095 = PRIM_EQ(symlambda, x139749080445063);
-if (True == x139749080445095) {
-Obj x139749080445671 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080445703 = PRIM_ISCONS(x139749080445671);
-if (True == x139749080445703) {
-Obj x139749080446183 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080446215 = PRIM_CAR(x139749080446183);
-Obj args = x139749080446215;
-Obj x139749080446951 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080446983 = PRIM_CDR(x139749080446951);
-Obj x139749080447015 = PRIM_ISCONS(x139749080446983);
-if (True == x139749080447015) {
-Obj x139749080447751 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080447783 = PRIM_CDR(x139749080447751);
-Obj x139749080447815 = PRIM_CAR(x139749080447783);
-Obj body = x139749080447815;
-Obj x139749080448679 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080448711 = PRIM_CDR(x139749080448679);
-Obj x139749080448743 = PRIM_CDR(x139749080448711);
-Obj x139749080448775 = PRIM_EQ(Nil, x139749080448743);
-if (True == x139749080448775) {
-pushCont(co, 46, clofun8, 3, globals, body, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35append);
-__arg1 = args;
-__arg2 = env;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079209575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079209575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079209575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079209575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079209575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label46:
-{
-Obj x139749080388455 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 47, clofun8, 1, args);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139749080388455;
-__arg2 = globals;
-__arg3 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
-Obj x139749080388583 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080388647 = makeCons(x139749080388583, Nil);
-Obj x139749080388711 = makeCons(args, x139749080388647);
-Obj x139749080388743 = makeCons(symlambda, x139749080388711);
-__nargs = 2;
-__arg1 = x139749080388743;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label48:
-{
-Obj x139749079210983 = makeNative(1, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749080462599 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080462599) {
-Obj x139749080463143 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080463175 = PRIM_EQ(symif, x139749080463143);
-if (True == x139749080463175) {
-Obj x139749080463431 = PRIM_CDR(closureRef(co, 2));
-Obj args = x139749080463431;
-pushCont(co, 49, clofun8, 1, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079210983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079210983;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label49:
-{
-Obj x139749080464135 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 0, clofun9);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749080464135;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-static void clofun9(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43, &&label44, &&label45, &&label46};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj x139749080464199 = __arg1;
-Obj x139749080464231 = makeCons(symif, x139749080464199);
-__nargs = 2;
-__arg1 = x139749080464231;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label1:
-{
-Obj x139749079211943 = makeNative(4, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749080525351 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080525351) {
-Obj x139749080525799 = PRIM_CAR(closureRef(co, 2));
-Obj x139749080525831 = PRIM_EQ(symdo, x139749080525799);
-if (True == x139749080525831) {
-Obj x139749080526343 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080526375 = PRIM_ISCONS(x139749080526343);
-if (True == x139749080526375) {
-Obj x139749080473703 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080473735 = PRIM_CAR(x139749080473703);
-Obj x = x139749080473735;
-Obj x139749080474439 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080474471 = PRIM_CDR(x139749080474439);
-Obj x139749080474503 = PRIM_ISCONS(x139749080474471);
-if (True == x139749080474503) {
-Obj x139749080475239 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080475271 = PRIM_CDR(x139749080475239);
-Obj x139749080475303 = PRIM_CAR(x139749080475271);
-Obj y = x139749080475303;
-Obj x139749080476167 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080476199 = PRIM_CDR(x139749080476167);
-Obj x139749080476231 = PRIM_CDR(x139749080476199);
-Obj x139749080476263 = PRIM_EQ(Nil, x139749080476231);
-if (True == x139749080476263) {
-pushCont(co, 2, clofun9, 3, env, globals, y);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-__arg3 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079211943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079211943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079211943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079211943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079211943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj x139749080477063 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 3, clofun9, 1, x139749080477063);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-__arg3 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139749080477575 = __arg1;
-Obj x139749080477063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749080477671 = makeCons(x139749080477575, Nil);
-Obj x139749080461351 = makeCons(x139749080477063, x139749080477671);
-Obj x139749080461383 = makeCons(symdo, x139749080461351);
-__nargs = 2;
-__arg1 = x139749080461383;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-Obj x139749079172391 = makeNative(7, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749079072071 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749079072071) {
-Obj x139749079072519 = PRIM_CAR(closureRef(co, 2));
-Obj x139749079072551 = PRIM_EQ(symlet, x139749079072519);
-if (True == x139749079072551) {
-Obj x139749079044295 = PRIM_CDR(closureRef(co, 2));
-Obj x139749079044327 = PRIM_ISCONS(x139749079044295);
-if (True == x139749079044327) {
-Obj x139749079044743 = PRIM_CDR(closureRef(co, 2));
-Obj x139749079044775 = PRIM_CAR(x139749079044743);
-Obj a = x139749079044775;
-Obj x139749079045351 = PRIM_CDR(closureRef(co, 2));
-Obj x139749079045383 = PRIM_CDR(x139749079045351);
-Obj x139749079045415 = PRIM_ISCONS(x139749079045383);
-if (True == x139749079045415) {
-Obj x139749079045991 = PRIM_CDR(closureRef(co, 2));
-Obj x139749079046023 = PRIM_CDR(x139749079045991);
-Obj x139749079046055 = PRIM_CAR(x139749079046023);
-Obj b = x139749079046055;
-Obj x139749080646375 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080646407 = PRIM_CDR(x139749080646375);
-Obj x139749080646567 = PRIM_CDR(x139749080646407);
-Obj x139749080646599 = PRIM_ISCONS(x139749080646567);
-if (True == x139749080646599) {
-Obj x139749080647527 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080647559 = PRIM_CDR(x139749080647527);
-Obj x139749080647591 = PRIM_CDR(x139749080647559);
-Obj x139749080647623 = PRIM_CAR(x139749080647591);
-Obj c = x139749080647623;
-Obj x139749080648615 = PRIM_CDR(closureRef(co, 2));
-Obj x139749080648647 = PRIM_CDR(x139749080648615);
-Obj x139749080648679 = PRIM_CDR(x139749080648647);
-Obj x139749080648743 = PRIM_CDR(x139749080648679);
-Obj x139749080648775 = PRIM_EQ(Nil, x139749080648743);
-if (True == x139749080648775) {
-pushCont(co, 5, clofun9, 4, env, globals, c, a);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-__arg3 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079172391;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label5:
-{
-Obj x139749080523079 = __arg1;
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749080523783 = makeCons(a, env);
-pushCont(co, 6, clofun9, 2, x139749080523079, a);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139749080523783;
-__arg2 = globals;
-__arg3 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x139749080523879 = __arg1;
-Obj x139749080523079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749080523943 = makeCons(x139749080523879, Nil);
-Obj x139749080523975 = makeCons(x139749080523079, x139749080523943);
-Obj x139749080524007 = makeCons(a, x139749080523975);
-Obj x139749080524039 = makeCons(symlet, x139749080524007);
-__nargs = 2;
-__arg1 = x139749080524039;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label7:
-{
-Obj x139749079174023 = makeNative(15, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj x139749079144103 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749079144103) {
-Obj x139749079144359 = PRIM_CAR(closureRef(co, 2));
-Obj op = x139749079144359;
-Obj x139749079144615 = PRIM_CDR(closureRef(co, 2));
-Obj args = x139749079144615;
-pushCont(co, 8, clofun9, 5, op, args, env, globals, x139749079174023);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
-__arg1 = op;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079174023;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj x139749079144871 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139749079174023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-if (True == x139749079144871) {
-pushCont(co, 9, clofun9, 4, op, args, env, globals);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
-__arg1 = op;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079174023;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj x139749079145127 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj required = x139749079145127;
-pushCont(co, 10, clofun9, 5, required, op, args, env, globals);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x139749079145383 = __arg1;
+Obj x139886475185959 = __arg1;
 Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj provided = x139749079145383;
-Obj x139749079145671 = PRIM_EQ(required, provided);
-if (True == x139749079145671) {
-Obj x139749079146247 = makeCons(op, Nil);
-Obj x139749079146279 = makeCons(sym_37builtin, x139749079146247);
-pushCont(co, 13, clofun9, 2, args, x139749079146279);
+Obj provided = x139886475185959;
+Obj x139886475186119 = PRIM_EQ(required, provided);
+if (True == x139886475186119) {
+Obj x139886475124903 = makeCons(op, Nil);
+Obj x139886475124935 = makeCons(sym_37builtin, x139886475124903);
+pushCont(co, 14, clofun8, 2, args, x139886475124935);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139749079069255 = PRIM_GT(required, provided);
-if (True == x139749079069255) {
-Obj x139749079069703 = PRIM_SUB(required, provided);
-pushCont(co, 11, clofun9, 4, op, args, env, globals);
+Obj x139886475125383 = PRIM_GT(required, provided);
+if (True == x139886475125383) {
+Obj x139886475125607 = PRIM_SUB(required, provided);
+pushCont(co, 12, clofun8, 2, op, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139749079069703;
+__arg1 = x139886475125607;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -12822,187 +11949,173 @@ __arg1 = makeCString("primitive call mismatch");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
-}
-
-label11:
-{
-Obj x139749079069767 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj tmp = x139749079069767;
-Obj x139749079071079 = makeCons(op, args);
-pushCont(co, 12, clofun9, 3, tmp, env, globals);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35append);
-__arg1 = x139749079071079;
-__arg2 = tmp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj x139749079071143 = __arg1;
-Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139749079071207 = makeCons(x139749079071143, Nil);
-Obj x139749079071239 = makeCons(tmp, x139749079071207);
-Obj x139749079071271 = makeCons(symlambda, x139749079071239);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-__arg3 = x139749079071271;
+Obj x139886475125639 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj tmp = x139886475125639;
+Obj x139886475126119 = makeCons(op, args);
+pushCont(co, 13, clofun8, 1, tmp);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35append);
+__arg1 = x139886475126119;
+__arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj x139749079068871 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079146279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 14, clofun9, 1, x139749079146279);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079068871;
-__arg2 = args;
+Obj x139886475126151 = __arg1;
+Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475126183 = makeCons(x139886475126151, Nil);
+Obj x139886475126215 = makeCons(tmp, x139886475126183);
+Obj x139886475126247 = makeCons(symlambda, x139886475126215);
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x139886475126247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj x139749079068935 = __arg1;
-Obj x139749079146279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139749079068967 = makeCons(x139749079146279, x139749079068935);
-__nargs = 2;
-__arg1 = x139749079068967;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x139886475125159 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475124935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 15, clofun8, 1, x139886475124935);
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886475125159;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj x139749079175015 = makeNative(17, clofun9, 0, 0);
-Obj env = closureRef(co, 0);
-Obj globals = closureRef(co, 1);
-Obj ls = closureRef(co, 2);
-pushCont(co, 16, clofun9, 1, ls);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = env;
-__arg2 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475125191 = __arg1;
+Obj x139886475124935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x139886475125223 = makeCons(x139886475124935, x139886475125191);
+__nargs = 2;
+__arg1 = x139886475125223;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj x139749079143687 = __arg1;
-Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 17, clofun8);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139749079143687;
-__arg2 = ls;
+__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Obj x139886475184871 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(symcora_47init_35map);
+__arg1 = x139886475184871;
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj x139749079228423 = __arg1;
-Obj x139749079228455 = __arg2;
-Obj x139749079228839 = makeNative(19, clofun9, 0, 2, x139749079228423, x139749079228455);
-Obj x139749079157639 = PRIM_EQ(MAKE_NUMBER(0), x139749079228423);
-if (True == x139749079157639) {
-Obj res = x139749079228455;
+Obj x139886475183271 = __arg1;
+if (True == x139886475183271) {
 __nargs = 2;
-__arg1 = res;
+__arg1 = closureRef(co, 0);
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749079228839;
+PUSH_CONT_0(co, 19, clofun8);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj x139749079229383 = makeNative(20, clofun9, 0, 0);
-Obj n = closureRef(co, 0);
-Obj res = closureRef(co, 1);
-Obj x139749079156935 = PRIM_SUB(n, MAKE_NUMBER(1));
-Obj x139749079157287 = primGenSym();
-Obj x139749079157351 = makeCons(x139749079157287, res);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139749079156935;
-__arg2 = x139749079157351;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886475183527 = __arg1;
+Obj x139886475183719 = makeCons(closureRef(co, 0), Nil);
+Obj x139886475183751 = makeCons(sym_37global, x139886475183719);
+__nargs = 2;
+__arg1 = x139886475183751;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
+Obj x139886476187591 = __arg1;
+Obj x139886476187623 = __arg2;
+Obj x139886475194023 = PRIM_EQ(MAKE_NUMBER(0), x139886476187591);
+if (True == x139886475194023) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg1 = x139886476187623;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475194183 = PRIM_SUB(x139886476187591, MAKE_NUMBER(1));
+Obj x139886475194343 = primGenSym();
+Obj x139886475182087 = makeCons(x139886475194343, x139886476187623);
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
+__arg1 = x139886475194183;
+__arg2 = x139886475182087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 label21:
 {
 Obj x = __arg1;
-PUSH_CONT_0(co, 22, clofun9);
+PUSH_CONT_0(co, 22, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = x;
@@ -13010,34 +12123,34 @@ __arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label22:
 {
-Obj x139749079155111 = __arg1;
-Obj find = x139749079155111;
-pushCont(co, 23, clofun9, 1, find);
+Obj x139886475193415 = __arg1;
+Obj find = x139886475193415;
+pushCont(co, 23, clofun8, 1, find);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label23:
 {
-Obj x139749079155367 = __arg1;
+Obj x139886475193575 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139749079155367) {
+if (True == x139886475193575) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13046,7 +12159,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13054,7 +12167,7 @@ goto *jumpTable[ps.label];
 label24:
 {
 Obj x = __arg1;
-PUSH_CONT_0(co, 25, clofun9);
+PUSH_CONT_0(co, 25, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = x;
@@ -13062,34 +12175,34 @@ __arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label25:
 {
-Obj x139749079174503 = __arg1;
-Obj find = x139749079174503;
-pushCont(co, 26, clofun9, 1, find);
+Obj x139886475192807 = __arg1;
+Obj find = x139886475192807;
+pushCont(co, 26, clofun8, 1, find);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label26:
 {
-Obj x139749079174759 = __arg1;
+Obj x139886475192967 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139749079174759) {
+if (True == x139886475192967) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13098,7 +12211,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13106,7 +12219,7 @@ goto *jumpTable[ps.label];
 label27:
 {
 Obj x = __arg1;
-PUSH_CONT_0(co, 28, clofun9);
+PUSH_CONT_0(co, 28, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = x;
@@ -13114,128 +12227,102 @@ __arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label28:
 {
-Obj x139749079173767 = __arg1;
-PUSH_CONT_0(co, 29, clofun9);
+Obj x139886475192359 = __arg1;
+PUSH_CONT_0(co, 29, clofun8);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x139749079173767;
+__arg1 = x139886475192359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label29:
 {
-Obj x139749079173799 = __arg1;
-Obj x139749079173831 = primNot(x139749079173799);
+Obj x139886475192391 = __arg1;
+Obj x139886475192423 = primNot(x139886475192391);
 __nargs = 2;
-__arg1 = x139749079173831;
+__arg1 = x139886475192423;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label30:
 {
-Obj x139749079247015 = __arg1;
-Obj x139749079247047 = __arg2;
-Obj x139749079247431 = makeNative(31, clofun9, 0, 2, x139749079247015, x139749079247047);
-Obj x = x139749079247015;
-Obj x139749079758535 = PRIM_EQ(Nil, x139749079247047);
-if (True == x139749079758535) {
+Obj x139886475244711 = __arg1;
+Obj x139886475244743 = __arg2;
+Obj x139886475270311 = PRIM_EQ(Nil, x139886475244743);
+if (True == x139886475270311) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749079247431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label31:
-{
-Obj x139749079247975 = makeNative(33, clofun9, 0, 0);
-Obj x = closureRef(co, 0);
-Obj x139749079785351 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749079785351) {
-Obj x139749079757031 = PRIM_CAR(closureRef(co, 1));
-Obj hd = x139749079757031;
-Obj x139749079757287 = PRIM_CDR(closureRef(co, 1));
-Obj tl = x139749079757287;
-pushCont(co, 32, clofun9, 2, x, tl);
+Obj x139886475270471 = PRIM_ISCONS(x139886475244743);
+if (True == x139886475270471) {
+Obj x139886475270631 = PRIM_CAR(x139886475244743);
+Obj hd = x139886475270631;
+Obj x139886475270791 = PRIM_CDR(x139886475244743);
+Obj tl = x139886475270791;
+pushCont(co, 31, clofun8, 2, x139886475244711, tl);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
-__arg1 = x;
+__arg1 = x139886475244711;
 __arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749079247975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label32:
-{
-Obj x139749079757767 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139749079757831 = PRIM_LT(x139749079757767, MAKE_NUMBER(0));
-if (True == x139749079757831) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
-__arg1 = x;
-__arg2 = tl;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label33:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
-label34:
+label31:
+{
+Obj x139886475271015 = __arg1;
+Obj x139886475244711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x139886475271047 = PRIM_LT(x139886475271015, MAKE_NUMBER(0));
+if (True == x139886475271047) {
+__nargs = 3;
+__arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
+__arg1 = x139886475244711;
+__arg2 = tl;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label32:
 {
 Obj x = __arg1;
 Obj l = __arg2;
@@ -13247,324 +12334,235 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label33:
+{
+Obj x139886475463879 = __arg1;
+Obj x139886475463911 = __arg2;
+Obj x139886475463975 = __arg3;
+Obj x139886475333415 = PRIM_EQ(Nil, x139886475463975);
+if (True == x139886475333415) {
+__nargs = 2;
+__arg1 = MAKE_NUMBER(-1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886475330311 = makeNative(34, clofun8, 0, 3, x139886475463975, x139886475463879, x139886475463911);
+Obj x139886475269031 = PRIM_ISCONS(x139886475463975);
+if (True == x139886475269031) {
+Obj x139886475269191 = PRIM_CAR(x139886475463975);
+Obj a = x139886475269191;
+Obj x139886475269351 = PRIM_CDR(x139886475463975);
+Obj x139886475269511 = PRIM_EQ(x139886475463911, a);
+if (True == x139886475269511) {
+__nargs = 2;
+__arg1 = x139886475463879;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x139886475330311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886475330311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label34:
+{
+Obj x139886475268199 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475268199) {
+Obj x139886475268391 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475268583 = PRIM_CDR(closureRef(co, 0));
+Obj b = x139886475268583;
+Obj x139886475268775 = PRIM_ADD(closureRef(co, 1), MAKE_NUMBER(1));
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
+__arg1 = x139886475268775;
+__arg2 = closureRef(co, 2);
+__arg3 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label35:
 {
-Obj x139749079759591 = __arg1;
-Obj x139749079759623 = __arg2;
-Obj x139749079759655 = __arg3;
-Obj x139749079760199 = makeNative(36, clofun9, 0, 3, x139749079759591, x139749079759623, x139749079759655);
-Obj __ = x139749079759591;
-Obj x = x139749079759623;
-Obj x139749079783495 = PRIM_EQ(Nil, x139749079759655);
-if (True == x139749079783495) {
+Obj x139886475982791 = __arg1;
+Obj x139886475982823 = __arg2;
+Obj x139886475982887 = __arg3;
+Obj x139886475332295 = PRIM_EQ(Nil, x139886475982887);
+if (True == x139886475332295) {
 __nargs = 2;
-__arg1 = MAKE_NUMBER(-1);
+__arg1 = x139886475982823;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
+if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139749079760199;
+Obj x139886475332455 = PRIM_ISCONS(x139886475982887);
+if (True == x139886475332455) {
+Obj x139886475332615 = PRIM_CAR(x139886475982887);
+Obj x = x139886475332615;
+Obj x139886475332775 = PRIM_CDR(x139886475982887);
+Obj y = x139886475332775;
+pushCont(co, 36, clofun8, 2, x139886475982791, y);
+__nargs = 3;
+__arg0 = x139886475982791;
+__arg1 = x139886475982823;
+__arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label36:
 {
-Obj x139749079244871 = makeNative(37, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj pos = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj x139749079781927 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749079781927) {
-Obj x139749079782183 = PRIM_CAR(closureRef(co, 2));
-Obj a = x139749079782183;
-Obj x139749079782439 = PRIM_CDR(closureRef(co, 2));
-Obj b = x139749079782439;
-Obj x139749079782791 = PRIM_EQ(x, a);
-if (True == x139749079782791) {
-__nargs = 2;
-__arg1 = pos;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079244871;
+Obj x139886475332935 = __arg1;
+Obj x139886475982791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 4;
+__arg0 = globalRef(symcora_47lib_47toc_35foldl);
+__arg1 = x139886475982791;
+__arg2 = x139886475332935;
+__arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079244871;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label37:
 {
-Obj x139749079245863 = makeNative(38, clofun9, 0, 0);
-Obj pos = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj x139749079972967 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749079972967) {
-Obj x139749079973223 = PRIM_CAR(closureRef(co, 2));
-Obj a = x139749079973223;
-Obj x139749079973479 = PRIM_CDR(closureRef(co, 2));
-Obj b = x139749079973479;
-Obj x139749079973863 = PRIM_ADD(pos, MAKE_NUMBER(1));
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = x139749079973863;
-__arg2 = x;
-__arg3 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x139886476186887 = __arg1;
+Obj x139886476186919 = __arg2;
+Obj x139886475386759 = PRIM_EQ(Nil, x139886476186919);
+if (True == x139886475386759) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x139886476147015 = makeNative(38, clofun8, 0, 2, x139886476186919, x139886476186887);
+Obj x139886475330503 = PRIM_ISCONS(x139886476186919);
+if (True == x139886475330503) {
+Obj x139886475330727 = PRIM_CAR(x139886476186919);
+Obj x139886475330759 = PRIM_ISCONS(x139886475330727);
+if (True == x139886475330759) {
+Obj x139886475330983 = PRIM_CAR(x139886476186919);
+Obj x139886475331015 = PRIM_CAR(x139886475330983);
+Obj x = x139886475331015;
+Obj x139886475331271 = PRIM_CAR(x139886476186919);
+Obj x139886475331303 = PRIM_CDR(x139886475331271);
+Obj y = x139886475331303;
+Obj x139886475331463 = PRIM_CDR(x139886476186919);
+Obj x139886475331623 = PRIM_EQ(x139886476186887, x);
+if (True == x139886475331623) {
+Obj x139886475331719 = makeCons(x, y);
+__nargs = 2;
+__arg1 = x139886475331719;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139749079245863;
+__arg0 = x139886476147015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476147015;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x139886476147015;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label38:
 {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label39:
-{
-Obj x139749079756903 = __arg1;
-Obj x139749079756935 = __arg2;
-Obj x139749079756967 = __arg3;
-Obj x139749079757511 = makeNative(40, clofun9, 0, 3, x139749079756903, x139749079756935, x139749079756967);
-Obj f = x139749079756903;
-Obj acc = x139749079756935;
-Obj x139749079971559 = PRIM_EQ(Nil, x139749079756967);
-if (True == x139749079971559) {
-__nargs = 2;
-__arg1 = acc;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079757511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label40:
-{
-Obj x139749079758279 = makeNative(42, clofun9, 0, 0);
-Obj f = closureRef(co, 0);
-Obj acc = closureRef(co, 1);
-Obj x139749080354375 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139749080354375) {
-Obj x139749080354631 = PRIM_CAR(closureRef(co, 2));
-Obj x = x139749080354631;
-Obj x139749079969863 = PRIM_CDR(closureRef(co, 2));
-Obj y = x139749079969863;
-pushCont(co, 41, clofun9, 2, f, y);
-__nargs = 3;
-__arg0 = f;
-__arg1 = acc;
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079758279;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label41:
-{
-Obj x139749079970983 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = f;
-__arg2 = x139749079970983;
-__arg3 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label42:
-{
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label43:
-{
-Obj x139749079782631 = __arg1;
-Obj x139749079782663 = __arg2;
-Obj x139749079783047 = makeNative(44, clofun9, 0, 2, x139749079782631, x139749079782663);
-Obj var = x139749079782631;
-Obj x139749080353031 = PRIM_EQ(Nil, x139749079782663);
-if (True == x139749080353031) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079783047;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label44:
-{
-Obj x139749079783591 = makeNative(45, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj var = closureRef(co, 0);
-Obj x139749080366503 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749080366503) {
-Obj x139749080366951 = PRIM_CAR(closureRef(co, 1));
-Obj x139749080366983 = PRIM_ISCONS(x139749080366951);
-if (True == x139749080366983) {
-Obj x139749080351015 = PRIM_CAR(closureRef(co, 1));
-Obj x139749080351047 = PRIM_CAR(x139749080351015);
-Obj x = x139749080351047;
-Obj x139749080351463 = PRIM_CAR(closureRef(co, 1));
-Obj x139749080351495 = PRIM_CDR(x139749080351463);
-Obj y = x139749080351495;
-Obj x139749080351751 = PRIM_CDR(closureRef(co, 1));
-Obj __ = x139749080351751;
-Obj x139749080352071 = PRIM_EQ(var, x);
-if (True == x139749080352071) {
-Obj x139749080352295 = makeCons(x, y);
-__nargs = 2;
-__arg1 = x139749080352295;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun9) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139749079783591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079783591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139749079783591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label45:
-{
-Obj x139749079784583 = makeNative(46, clofun9, 0, 0);
-Obj var = closureRef(co, 0);
-Obj x139749080365319 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139749080365319) {
-Obj x139749080365607 = PRIM_CAR(closureRef(co, 1));
-Obj __ = x139749080365607;
-Obj x139749080365863 = PRIM_CDR(closureRef(co, 1));
-Obj y = x139749080365863;
+Obj x139886475329735 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x139886475329735) {
+Obj x139886475329927 = PRIM_CAR(closureRef(co, 0));
+Obj x139886475330151 = PRIM_CDR(closureRef(co, 0));
+Obj y = x139886475330151;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = var;
+__arg1 = closureRef(co, 1);
 __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139749079784583;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label46:
-{
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35error);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 
 fail:

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -56,24 +56,33 @@
 	_ globals ['quote x] => (begin (add-symbol-to-list x globals) ['%const x])
 	env globals x => (if (elem? x env) x
 			     (begin
-			       (add-symbol-to-list x globals)
-			       ['%global x])) where (symbol? x)
-			       env globals ['lambda args body] => ['lambda args (parse (append args env) globals body)]
-			       env globals ['if . args] => ['if . (map (parse env globals) args)]
-			       env globals ['do x y] => ['do (parse env globals x) (parse env globals y)]
-			       env globals ['let a b c] => ['let a (parse env globals b) (parse (cons a env) globals c)]
-			       env globals [op . args] => (let required (builtin->args op)
-							    provided (length args)
-							    (cond
-							     ((= required provided)  [['%builtin op] . (map (parse env globals) args)])
-							     ((> required provided)
-							      ;; rewrite partial apply of primitives
-							      ;; (+ x) => (lambda (tmp) (+ x tmp))
-							      (let tmp (temp-list (- required provided) ())
-								(parse env globals ['lambda tmp (append [op . args] tmp)])))
-							     (true (error "primitive call mismatch"))))
-			       where (builtin? op)
-			       env globals ls => (map (parse env globals) ls))
+			      (add-symbol-to-list x globals)
+			      ['%global x])) where (symbol? x)
+	env globals ['lambda args body] => ['lambda args (parse (append args env) globals body)]
+	;; macro rewrite to avoid code explosion during tailify-pass
+	env globals ['if ['if . exp1] . exp2] => (let f (gensym)
+						      v (gensym)
+						      (parse env globals ['let f ['lambda [v] ['if v . exp2]]
+							     [f ['if . exp1]]]))
+	env globals ['if . args] => ['if . (map (parse env globals) args)]
+	env globals ['do x y] => ['do (parse env globals x) (parse env globals y)]
+	env globals ['let a b c] => ['let a (parse env globals b) (parse (cons a env) globals c)]
+	;; macro rewrite to avoid code explosion during tailify-pass
+	env globals [['lambda . exp1] ['if . exp2]] => (let f (gensym)
+							    (parse env globals ['let f ['lambda . exp1]
+								   [f ['if . exp2]]]))
+	env globals [op . args] => (let required (builtin->args op)
+					provided (length args)
+					(cond
+					  ((= required provided)  [['%builtin op] . (map (parse env globals) args)])
+					  ((> required provided)
+					   ;; rewrite partial apply of primitives
+					   ;; (+ x) => (lambda (tmp) (+ x tmp))
+					   (let tmp (temp-list (- required provided) ())
+						(parse env globals ['lambda tmp (append [op . args] tmp)])))
+					  (true (error "primitive call mismatch"))))
+	where (builtin? op)
+	env globals ls => (map (parse env globals) ls))
 
   (func union
 	[] s2 => s2

--- a/test/benchmark/ack.cora
+++ b/test/benchmark/ack.cora
@@ -1,13 +1,13 @@
-;; (func ack
-;; 		0 y => (+ 1 y)
-;; 		x 0 => (ack (- x 1) 1)
-;; 		x y => (ack (- x 1) (ack x (- y 1))))
+(func ack
+      0 y => (+ 1 y)
+      x 0 => (ack (- x 1) 1)
+      x y => (ack (- x 1) (ack x (- y 1))))
 
-(defun ack (x y)
-  (cond
-    ((= x 0) (+ 1 y))
-    ((= y 0) (ack (- x 1) 1))
-    (true (ack (- x 1) (ack x (- y 1))))))
+;; (defun ack (x y)
+;;   (cond
+;;     ((= x 0) (+ 1 y))
+;;     ((= y 0) (ack (- x 1) 1))
+;;     (true (ack (- x 1) (ack x (- y 1))))))
 
 (let n 13
-		(ack 3 n))
+     (ack 3 n))


### PR DESCRIPTION
add a source to source translate pass in the last step of macroexpand
`peval` works like cp0 in chez scheme but much less optimized