### PR TITLE
*: use thread local variable to make symbol table thread-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,17 @@ ifeq ("${ENABLE_ASAN}", "1")
 	CFLAGS += -fsanitize=address
 endif
 
+ifeq ("${ENABLE_TSAN}", "1")
+	CFLAGS += -fsanitize=thread
+endif
+
 LD_FLAG	:=  -lcora -ldl
 ifeq ("${ENABLE_ASAN}", "1")
 	LD_FLAG = -lasan -lcora -ldl
+endif
+
+ifeq ("${ENABLE_TSAN}", "1")
+	LD_FLAG = -ltsan -lcora -ldl
 endif
 
 all: cora.bin lib

--- a/init.c
+++ b/init.c
@@ -8,333 +8,175 @@ static void clofun3(struct Cora* co);
 static void clofun4(struct Cora* co);
 
 
-static Obj symcora_47init_35assq;
-static Obj symcora_47init_35append;
-static Obj symcora_47init_35filter;
-static Obj symcora_47init_35length;
-static Obj symcora_47init_35elem_63;
-static Obj symcora_47init_35macroexpand;
-static Obj symcora_47init_35map;
-static Obj symcora_47init_35reverse;
-static Obj symcora_47init_35throw;
-static Obj symcora_47init_35try;
-static Obj symcora_47init_35import;
-static Obj symcora_47init_35load_45so;
-static Obj symcora_47init_35load;
-static Obj symcora_47init_35apply;
-static Obj symcora_47init_35read_45file_45as_45sexp;
-static Obj symcora_47init_35value_45or;
-static Obj symcora_47init_35value;
-static Obj symcora_47init_35bytes_45length;
-static Obj symcora_47init_35bytes;
-static Obj symcora_47init_35vector_45length;
-static Obj symcora_47init_35vector_45ref;
-static Obj symcora_47init_35vector_45set_33;
-static Obj symcora_47init_35vector_63;
-static Obj symcora_47init_35vector;
-static Obj symcora_47init_35symbol_45_62string;
-static Obj symcora_47init_35intern;
-static Obj symcora_47init_35string_45append;
-static Obj symcora_47init_35number_63;
-static Obj symcora_47init_35null_63;
-static Obj symcora_47init_35boolean_63;
-static Obj symcora_47init_35atom_63;
-static Obj symcora_47init_35pair_63;
-static Obj symcora_47init_35cdddr;
-static Obj symcora_47init_35cadddr;
-static Obj symcora_47init_35caddr;
-static Obj symcora_47init_35cddr;
-static Obj symcora_47init_35cdar;
-static Obj symcora_47init_35caar;
-static Obj symcora_47init_35cadr;
-static Obj symthrow;
-static Obj symtry;
-static Obj symload;
-static Obj symload_45so;
-static Obj symapply;
-static Obj symvalue;
-static Obj symread_45file_45as_45sexp;
-static Obj symbytes_45length;
-static Obj symbytes;
-static Obj symvector_45length;
-static Obj symvector_45ref;
-static Obj symvector_45set_33;
-static Obj symvector_63;
-static Obj symvector;
-static Obj symcora_47init_35_42ns_45export_42;
-static Obj symnumber_63;
-static Obj symcora_47init_35builtin_63;
-static Obj symassq;
-static Obj symstring_63;
-static Obj syminteger_63;
-static Obj symnot;
-static Obj symsymbol_63;
-static Obj symgensym;
-static Obj sym_60;
-static Obj sym_62;
-static Obj sym_47;
-static Obj sym_42;
-static Obj sym_45;
-static Obj sym_43;
-static Obj symset;
-static Obj symcora_47init_35_42builtin_45prims_42;
-static Obj symvalue_45or;
-static Obj symcora_47init_35lookup_45var;
-static Obj symsymbol_45_62string;
-static Obj symstring_45append;
-static Obj symintern;
-static Obj symsymbol_45cooked_63;
-static Obj symcora_47init_35var_45with_45ns;
-static Obj sym_42ns_45export_42;
-static Obj symns;
-static Obj sympackage;
-static Obj symcora_47init_35parse_45package;
-static Obj symimport;
-static Obj symexport;
-static Obj symcora_47init_35parse_45package_45h;
-static Obj symfold_45apply;
-static Obj symcora_47init_35rewrite_45fold_45apply;
-static Obj symbackquote;
-static Obj symunquote;
-static Obj symcora_47init_35rewrite_45backquote;
-static Obj symbegin;
-static Obj symdo;
-static Obj symcora_47init_35rewrite_45begin;
-static Obj symcora_47init_35peval;
-static Obj symcora_47init_35parse;
-static Obj symcora_47init_35rewrite_45namespace;
-static Obj symfunc;
-static Obj symcora_47init_35gen_45paramenters;
-static Obj symcora_47init_35rules_45arg_45count;
-static Obj symappend;
-static Obj symfilter;
-static Obj symcora_47init_35filter_45h;
-static Obj symlength;
-static Obj symcora_47init_35length_45h;
-static Obj symcora_47init_35rules_45patterns;
-static Obj symcora_47init_35extract_45rules;
-static Obj sym_61_62;
-static Obj symcora_47init_35extract_45rules1;
-static Obj symmatch;
-static Obj symcora_47init_35rewrite_45match;
-static Obj symcora_47init_35match_45helper;
-static Obj symwhere;
-static Obj symcora_47init_35extract_45rule_45action;
-static Obj symstr;
-static Obj sym_61;
-static Obj symcdr;
-static Obj symcar;
-static Obj symcons_63;
-static Obj symcora_47init_35match1;
-static Obj symcora_47init_35match_45cons_45expander;
-static Obj symlist_45rest;
-static Obj symcora_47init_35rcons1;
-static Obj symboolean_63;
-static Obj symand;
-static Obj symcora_47init_35rewrite_45and;
-static Obj symor;
-static Obj symcora_47init_35rewrite_45or;
-static Obj symif;
-static Obj symerror;
-static Obj symcond;
-static Obj symlet;
-static Obj symcora_47init_35rewrite_45let;
-static Obj symatom_63;
-static Obj symelem_63;
-static Obj symdef;
-static Obj symdefun;
-static Obj symlist;
-static Obj symdefmacro;
-static Obj symdefmacro_45macro;
-static Obj symmacroexpand;
-static Obj symquote;
-static Obj symlambda;
-static Obj symcora_47init_35macroexpand_45boot;
-static Obj symcora_47init_35macroexpand1;
-static Obj symcora_47init_35macroexpand1_45h;
-static Obj symcora_47init_35add_45to_45_42macros_42;
-static Obj sym_42protect_45symbol_42;
-static Obj sym_42macros_42;
-static Obj symmap;
-static Obj symmap_45h;
-static Obj symreverse;
-static Obj symcora_47init_35reverse_45h;
-static Obj sympair_63;
-static Obj symcons;
-static Obj symrcons;
-static Obj symcdddr;
-static Obj symcadddr;
-static Obj symcaddr;
-static Obj symcddr;
-static Obj symcdar;
-static Obj symcaar;
-static Obj symcadr;
-static Obj symnull_63;
+static __thread Obj* __symbolTable;
+
 void entry(struct Cora *co) {
-symcora_47init_35assq = intern("cora/init#assq");
-symcora_47init_35append = intern("cora/init#append");
-symcora_47init_35filter = intern("cora/init#filter");
-symcora_47init_35length = intern("cora/init#length");
-symcora_47init_35elem_63 = intern("cora/init#elem?");
-symcora_47init_35macroexpand = intern("cora/init#macroexpand");
-symcora_47init_35map = intern("cora/init#map");
-symcora_47init_35reverse = intern("cora/init#reverse");
-symcora_47init_35throw = intern("cora/init#throw");
-symcora_47init_35try = intern("cora/init#try");
-symcora_47init_35import = intern("cora/init#import");
-symcora_47init_35load_45so = intern("cora/init#load-so");
-symcora_47init_35load = intern("cora/init#load");
-symcora_47init_35apply = intern("cora/init#apply");
-symcora_47init_35read_45file_45as_45sexp = intern("cora/init#read-file-as-sexp");
-symcora_47init_35value_45or = intern("cora/init#value-or");
-symcora_47init_35value = intern("cora/init#value");
-symcora_47init_35bytes_45length = intern("cora/init#bytes-length");
-symcora_47init_35bytes = intern("cora/init#bytes");
-symcora_47init_35vector_45length = intern("cora/init#vector-length");
-symcora_47init_35vector_45ref = intern("cora/init#vector-ref");
-symcora_47init_35vector_45set_33 = intern("cora/init#vector-set!");
-symcora_47init_35vector_63 = intern("cora/init#vector?");
-symcora_47init_35vector = intern("cora/init#vector");
-symcora_47init_35symbol_45_62string = intern("cora/init#symbol->string");
-symcora_47init_35intern = intern("cora/init#intern");
-symcora_47init_35string_45append = intern("cora/init#string-append");
-symcora_47init_35number_63 = intern("cora/init#number?");
-symcora_47init_35null_63 = intern("cora/init#null?");
-symcora_47init_35boolean_63 = intern("cora/init#boolean?");
-symcora_47init_35atom_63 = intern("cora/init#atom?");
-symcora_47init_35pair_63 = intern("cora/init#pair?");
-symcora_47init_35cdddr = intern("cora/init#cdddr");
-symcora_47init_35cadddr = intern("cora/init#cadddr");
-symcora_47init_35caddr = intern("cora/init#caddr");
-symcora_47init_35cddr = intern("cora/init#cddr");
-symcora_47init_35cdar = intern("cora/init#cdar");
-symcora_47init_35caar = intern("cora/init#caar");
-symcora_47init_35cadr = intern("cora/init#cadr");
-symthrow = intern("throw");
-symtry = intern("try");
-symload = intern("load");
-symload_45so = intern("load-so");
-symapply = intern("apply");
-symvalue = intern("value");
-symread_45file_45as_45sexp = intern("read-file-as-sexp");
-symbytes_45length = intern("bytes-length");
-symbytes = intern("bytes");
-symvector_45length = intern("vector-length");
-symvector_45ref = intern("vector-ref");
-symvector_45set_33 = intern("vector-set!");
-symvector_63 = intern("vector?");
-symvector = intern("vector");
-symcora_47init_35_42ns_45export_42 = intern("cora/init#*ns-export*");
-symnumber_63 = intern("number?");
-symcora_47init_35builtin_63 = intern("cora/init#builtin?");
-symassq = intern("assq");
-symstring_63 = intern("string?");
-syminteger_63 = intern("integer?");
-symnot = intern("not");
-symsymbol_63 = intern("symbol?");
-symgensym = intern("gensym");
-sym_60 = intern("<");
-sym_62 = intern(">");
-sym_47 = intern("/");
-sym_42 = intern("*");
-sym_45 = intern("-");
-sym_43 = intern("+");
-symset = intern("set");
-symcora_47init_35_42builtin_45prims_42 = intern("cora/init#*builtin-prims*");
-symvalue_45or = intern("value-or");
-symcora_47init_35lookup_45var = intern("cora/init#lookup-var");
-symsymbol_45_62string = intern("symbol->string");
-symstring_45append = intern("string-append");
-symintern = intern("intern");
-symsymbol_45cooked_63 = intern("symbol-cooked?");
-symcora_47init_35var_45with_45ns = intern("cora/init#var-with-ns");
-sym_42ns_45export_42 = intern("*ns-export*");
-symns = intern("ns");
-sympackage = intern("package");
-symcora_47init_35parse_45package = intern("cora/init#parse-package");
-symimport = intern("import");
-symexport = intern("export");
-symcora_47init_35parse_45package_45h = intern("cora/init#parse-package-h");
-symfold_45apply = intern("fold-apply");
-symcora_47init_35rewrite_45fold_45apply = intern("cora/init#rewrite-fold-apply");
-symbackquote = intern("backquote");
-symunquote = intern("unquote");
-symcora_47init_35rewrite_45backquote = intern("cora/init#rewrite-backquote");
-symbegin = intern("begin");
-symdo = intern("do");
-symcora_47init_35rewrite_45begin = intern("cora/init#rewrite-begin");
-symcora_47init_35peval = intern("cora/init#peval");
-symcora_47init_35parse = intern("cora/init#parse");
-symcora_47init_35rewrite_45namespace = intern("cora/init#rewrite-namespace");
-symfunc = intern("func");
-symcora_47init_35gen_45paramenters = intern("cora/init#gen-paramenters");
-symcora_47init_35rules_45arg_45count = intern("cora/init#rules-arg-count");
-symappend = intern("append");
-symfilter = intern("filter");
-symcora_47init_35filter_45h = intern("cora/init#filter-h");
-symlength = intern("length");
-symcora_47init_35length_45h = intern("cora/init#length-h");
-symcora_47init_35rules_45patterns = intern("cora/init#rules-patterns");
-symcora_47init_35extract_45rules = intern("cora/init#extract-rules");
-sym_61_62 = intern("=>");
-symcora_47init_35extract_45rules1 = intern("cora/init#extract-rules1");
-symmatch = intern("match");
-symcora_47init_35rewrite_45match = intern("cora/init#rewrite-match");
-symcora_47init_35match_45helper = intern("cora/init#match-helper");
-symwhere = intern("where");
-symcora_47init_35extract_45rule_45action = intern("cora/init#extract-rule-action");
-symstr = intern("str");
-sym_61 = intern("=");
-symcdr = intern("cdr");
-symcar = intern("car");
-symcons_63 = intern("cons?");
-symcora_47init_35match1 = intern("cora/init#match1");
-symcora_47init_35match_45cons_45expander = intern("cora/init#match-cons-expander");
-symlist_45rest = intern("list-rest");
-symcora_47init_35rcons1 = intern("cora/init#rcons1");
-symboolean_63 = intern("boolean?");
-symand = intern("and");
-symcora_47init_35rewrite_45and = intern("cora/init#rewrite-and");
-symor = intern("or");
-symcora_47init_35rewrite_45or = intern("cora/init#rewrite-or");
-symif = intern("if");
-symerror = intern("error");
-symcond = intern("cond");
-symlet = intern("let");
-symcora_47init_35rewrite_45let = intern("cora/init#rewrite-let");
-symatom_63 = intern("atom?");
-symelem_63 = intern("elem?");
-symdef = intern("def");
-symdefun = intern("defun");
-symlist = intern("list");
-symdefmacro = intern("defmacro");
-symdefmacro_45macro = intern("defmacro-macro");
-symmacroexpand = intern("macroexpand");
-symquote = intern("quote");
-symlambda = intern("lambda");
-symcora_47init_35macroexpand_45boot = intern("cora/init#macroexpand-boot");
-symcora_47init_35macroexpand1 = intern("cora/init#macroexpand1");
-symcora_47init_35macroexpand1_45h = intern("cora/init#macroexpand1-h");
-symcora_47init_35add_45to_45_42macros_42 = intern("cora/init#add-to-*macros*");
-sym_42protect_45symbol_42 = intern("*protect-symbol*");
-sym_42macros_42 = intern("*macros*");
-symmap = intern("map");
-symmap_45h = intern("map-h");
-symreverse = intern("reverse");
-symcora_47init_35reverse_45h = intern("cora/init#reverse-h");
-sympair_63 = intern("pair?");
-symcons = intern("cons");
-symrcons = intern("rcons");
-symcdddr = intern("cdddr");
-symcadddr = intern("cadddr");
-symcaddr = intern("caddr");
-symcddr = intern("cddr");
-symcdar = intern("cdar");
-symcaar = intern("caar");
-symcadr = intern("cadr");
-symnull_63 = intern("null?");
+__symbolTable = (Obj*)malloc(sizeof(Obj) * 162);
+__symbolTable[0] = intern("cora/init#assq");
+__symbolTable[1] = intern("cora/init#append");
+__symbolTable[2] = intern("cora/init#filter");
+__symbolTable[3] = intern("cora/init#length");
+__symbolTable[4] = intern("cora/init#elem?");
+__symbolTable[5] = intern("cora/init#macroexpand");
+__symbolTable[6] = intern("cora/init#map");
+__symbolTable[7] = intern("cora/init#reverse");
+__symbolTable[8] = intern("cora/init#throw");
+__symbolTable[9] = intern("cora/init#try");
+__symbolTable[10] = intern("cora/init#import");
+__symbolTable[11] = intern("cora/init#load-so");
+__symbolTable[12] = intern("cora/init#load");
+__symbolTable[13] = intern("cora/init#apply");
+__symbolTable[14] = intern("cora/init#read-file-as-sexp");
+__symbolTable[15] = intern("cora/init#value-or");
+__symbolTable[16] = intern("cora/init#value");
+__symbolTable[17] = intern("cora/init#bytes-length");
+__symbolTable[18] = intern("cora/init#bytes");
+__symbolTable[19] = intern("cora/init#vector-length");
+__symbolTable[20] = intern("cora/init#vector-ref");
+__symbolTable[21] = intern("cora/init#vector-set!");
+__symbolTable[22] = intern("cora/init#vector?");
+__symbolTable[23] = intern("cora/init#vector");
+__symbolTable[24] = intern("cora/init#symbol->string");
+__symbolTable[25] = intern("cora/init#intern");
+__symbolTable[26] = intern("cora/init#string-append");
+__symbolTable[27] = intern("cora/init#number?");
+__symbolTable[28] = intern("cora/init#null?");
+__symbolTable[29] = intern("cora/init#boolean?");
+__symbolTable[30] = intern("cora/init#atom?");
+__symbolTable[31] = intern("cora/init#pair?");
+__symbolTable[32] = intern("cora/init#cdddr");
+__symbolTable[33] = intern("cora/init#cadddr");
+__symbolTable[34] = intern("cora/init#caddr");
+__symbolTable[35] = intern("cora/init#cddr");
+__symbolTable[36] = intern("cora/init#cdar");
+__symbolTable[37] = intern("cora/init#caar");
+__symbolTable[38] = intern("cora/init#cadr");
+__symbolTable[39] = intern("throw");
+__symbolTable[40] = intern("try");
+__symbolTable[41] = intern("load");
+__symbolTable[42] = intern("load-so");
+__symbolTable[43] = intern("apply");
+__symbolTable[44] = intern("value");
+__symbolTable[45] = intern("read-file-as-sexp");
+__symbolTable[46] = intern("bytes-length");
+__symbolTable[47] = intern("bytes");
+__symbolTable[48] = intern("vector-length");
+__symbolTable[49] = intern("vector-ref");
+__symbolTable[50] = intern("vector-set!");
+__symbolTable[51] = intern("vector?");
+__symbolTable[52] = intern("vector");
+__symbolTable[53] = intern("cora/init#*ns-export*");
+__symbolTable[54] = intern("number?");
+__symbolTable[55] = intern("cora/init#builtin?");
+__symbolTable[56] = intern("assq");
+__symbolTable[57] = intern("string?");
+__symbolTable[58] = intern("integer?");
+__symbolTable[59] = intern("not");
+__symbolTable[60] = intern("symbol?");
+__symbolTable[61] = intern("gensym");
+__symbolTable[62] = intern("<");
+__symbolTable[63] = intern(">");
+__symbolTable[64] = intern("/");
+__symbolTable[65] = intern("*");
+__symbolTable[66] = intern("-");
+__symbolTable[67] = intern("+");
+__symbolTable[68] = intern("set");
+__symbolTable[69] = intern("cora/init#*builtin-prims*");
+__symbolTable[70] = intern("value-or");
+__symbolTable[71] = intern("cora/init#lookup-var");
+__symbolTable[72] = intern("symbol->string");
+__symbolTable[73] = intern("string-append");
+__symbolTable[74] = intern("intern");
+__symbolTable[75] = intern("symbol-cooked?");
+__symbolTable[76] = intern("cora/init#var-with-ns");
+__symbolTable[77] = intern("*ns-export*");
+__symbolTable[78] = intern("ns");
+__symbolTable[79] = intern("package");
+__symbolTable[80] = intern("cora/init#parse-package");
+__symbolTable[81] = intern("import");
+__symbolTable[82] = intern("export");
+__symbolTable[83] = intern("cora/init#parse-package-h");
+__symbolTable[84] = intern("fold-apply");
+__symbolTable[85] = intern("cora/init#rewrite-fold-apply");
+__symbolTable[86] = intern("backquote");
+__symbolTable[87] = intern("unquote");
+__symbolTable[88] = intern("cora/init#rewrite-backquote");
+__symbolTable[89] = intern("begin");
+__symbolTable[90] = intern("do");
+__symbolTable[91] = intern("cora/init#rewrite-begin");
+__symbolTable[92] = intern("cora/init#peval");
+__symbolTable[93] = intern("cora/init#parse");
+__symbolTable[94] = intern("cora/init#rewrite-namespace");
+__symbolTable[95] = intern("func");
+__symbolTable[96] = intern("cora/init#gen-paramenters");
+__symbolTable[97] = intern("cora/init#rules-arg-count");
+__symbolTable[98] = intern("append");
+__symbolTable[99] = intern("filter");
+__symbolTable[100] = intern("cora/init#filter-h");
+__symbolTable[101] = intern("length");
+__symbolTable[102] = intern("cora/init#length-h");
+__symbolTable[103] = intern("cora/init#rules-patterns");
+__symbolTable[104] = intern("cora/init#extract-rules");
+__symbolTable[105] = intern("=>");
+__symbolTable[106] = intern("cora/init#extract-rules1");
+__symbolTable[107] = intern("match");
+__symbolTable[108] = intern("cora/init#rewrite-match");
+__symbolTable[109] = intern("cora/init#match-helper");
+__symbolTable[110] = intern("where");
+__symbolTable[111] = intern("cora/init#extract-rule-action");
+__symbolTable[112] = intern("str");
+__symbolTable[113] = intern("=");
+__symbolTable[114] = intern("cdr");
+__symbolTable[115] = intern("car");
+__symbolTable[116] = intern("cons?");
+__symbolTable[117] = intern("cora/init#match1");
+__symbolTable[118] = intern("cora/init#match-cons-expander");
+__symbolTable[119] = intern("list-rest");
+__symbolTable[120] = intern("cora/init#rcons1");
+__symbolTable[121] = intern("boolean?");
+__symbolTable[122] = intern("and");
+__symbolTable[123] = intern("cora/init#rewrite-and");
+__symbolTable[124] = intern("or");
+__symbolTable[125] = intern("cora/init#rewrite-or");
+__symbolTable[126] = intern("if");
+__symbolTable[127] = intern("error");
+__symbolTable[128] = intern("cond");
+__symbolTable[129] = intern("let");
+__symbolTable[130] = intern("cora/init#rewrite-let");
+__symbolTable[131] = intern("atom?");
+__symbolTable[132] = intern("elem?");
+__symbolTable[133] = intern("def");
+__symbolTable[134] = intern("defun");
+__symbolTable[135] = intern("list");
+__symbolTable[136] = intern("defmacro");
+__symbolTable[137] = intern("defmacro-macro");
+__symbolTable[138] = intern("macroexpand");
+__symbolTable[139] = intern("quote");
+__symbolTable[140] = intern("lambda");
+__symbolTable[141] = intern("cora/init#macroexpand-boot");
+__symbolTable[142] = intern("cora/init#macroexpand1");
+__symbolTable[143] = intern("cora/init#macroexpand1-h");
+__symbolTable[144] = intern("cora/init#add-to-*macros*");
+__symbolTable[145] = intern("*protect-symbol*");
+__symbolTable[146] = intern("*macros*");
+__symbolTable[147] = intern("map");
+__symbolTable[148] = intern("map-h");
+__symbolTable[149] = intern("reverse");
+__symbolTable[150] = intern("cora/init#reverse-h");
+__symbolTable[151] = intern("pair?");
+__symbolTable[152] = intern("cons");
+__symbolTable[153] = intern("rcons");
+__symbolTable[154] = intern("cdddr");
+__symbolTable[155] = intern("cadddr");
+__symbolTable[156] = intern("caddr");
+__symbolTable[157] = intern("cddr");
+__symbolTable[158] = intern("cdar");
+__symbolTable[159] = intern("caar");
+__symbolTable[160] = intern("cadr");
+__symbolTable[161] = intern("null?");
 clofun0(co);
 }
+
 static void clofun0(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
@@ -348,20 +190,20 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139709265112647 = primSet(co, symnull_63, makeNative(20, clofun4, 1, 0));
-Obj x139709265113063 = primSet(co, symcadr, makeNative(19, clofun4, 1, 0));
-Obj x139709265470791 = primSet(co, symcaar, makeNative(18, clofun4, 1, 0));
-Obj x139709265471527 = primSet(co, symcdar, makeNative(17, clofun4, 1, 0));
-Obj x139709265472551 = primSet(co, symcddr, makeNative(16, clofun4, 1, 0));
-Obj x139709265428487 = primSet(co, symcaddr, makeNative(15, clofun4, 1, 0));
-Obj x139709265429351 = primSet(co, symcadddr, makeNative(14, clofun4, 1, 0));
-Obj x139709265429895 = primSet(co, symcdddr, makeNative(13, clofun4, 1, 0));
-Obj x139709265430887 = primSet(co, symrcons, makeNative(11, clofun4, 1, 0));
-Obj x139709265431239 = primSet(co, sympair_63, makeNative(10, clofun4, 1, 0));
-Obj x139709265431975 = primSet(co, symcora_47init_35reverse_45h, makeNative(9, clofun4, 2, 0));
+Obj x140421013469671 = primSet(co, __symbolTable[161], makeNative(20, clofun4, 1, 0));
+Obj x140421013470087 = primSet(co, __symbolTable[160], makeNative(19, clofun4, 1, 0));
+Obj x140421013470567 = primSet(co, __symbolTable[159], makeNative(18, clofun4, 1, 0));
+Obj x140421013470983 = primSet(co, __symbolTable[158], makeNative(17, clofun4, 1, 0));
+Obj x140421013389479 = primSet(co, __symbolTable[157], makeNative(16, clofun4, 1, 0));
+Obj x140421013389991 = primSet(co, __symbolTable[156], makeNative(15, clofun4, 1, 0));
+Obj x140421013390599 = primSet(co, __symbolTable[155], makeNative(14, clofun4, 1, 0));
+Obj x140421013391111 = primSet(co, __symbolTable[154], makeNative(13, clofun4, 1, 0));
+Obj x140421013392071 = primSet(co, __symbolTable[153], makeNative(11, clofun4, 1, 0));
+Obj x140421013392391 = primSet(co, __symbolTable[151], makeNative(10, clofun4, 1, 0));
+Obj x140421013393127 = primSet(co, __symbolTable[150], makeNative(9, clofun4, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse_45h);
+__arg0 = globalRef(__symbolTable[150]);
 __arg1 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -372,24 +214,24 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139709265432199 = __arg1;
-Obj x139709265432231 = primSet(co, symreverse, x139709265432199);
-Obj x139709265367591 = primSet(co, symmap_45h, makeNative(7, clofun4, 3, 0));
-Obj x139709265367879 = primSet(co, symmap, makeNative(6, clofun4, 2, 0));
-Obj x139709265368039 = primSet(co, sym_42macros_42, Nil);
-Obj x139709265368263 = primGenSym();
-Obj x139709265368295 = primSet(co, sym_42protect_45symbol_42, x139709265368263);
-Obj x139709265368807 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(5, clofun4, 2, 0));
-Obj x139709265370695 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(2, clofun4, 2, 0));
-Obj x139709265370983 = primSet(co, symcora_47init_35macroexpand1, makeNative(1, clofun4, 1, 0));
-Obj x139709265340583 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(45, clofun3, 1, 0));
-Obj x139709265340743 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj x139709265341927 = primSet(co, symdefmacro_45macro, makeNative(41, clofun3, 1, 0));
+Obj x140421013393351 = __arg1;
+Obj x140421013393383 = primSet(co, __symbolTable[149], x140421013393351);
+Obj x140421013271399 = primSet(co, __symbolTable[148], makeNative(7, clofun4, 3, 0));
+Obj x140421013271687 = primSet(co, __symbolTable[147], makeNative(6, clofun4, 2, 0));
+Obj x140421013271847 = primSet(co, __symbolTable[146], Nil);
+Obj x140421013272071 = primGenSym();
+Obj x140421013272103 = primSet(co, __symbolTable[145], x140421013272071);
+Obj x140421013272615 = primSet(co, __symbolTable[144], makeNative(5, clofun4, 2, 0));
+Obj x140421015385639 = primSet(co, __symbolTable[143], makeNative(2, clofun4, 2, 0));
+Obj x140421015385927 = primSet(co, __symbolTable[142], makeNative(1, clofun4, 1, 0));
+Obj x140421015343239 = primSet(co, __symbolTable[141], makeNative(45, clofun3, 1, 0));
+Obj x140421015343399 = primSet(co, __symbolTable[138], globalRef(__symbolTable[141]));
+Obj x140421015344583 = primSet(co, __symbolTable[137], makeNative(41, clofun3, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symdefmacro;
-__arg2 = globalRef(symdefmacro_45macro);
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[136];
+__arg2 = globalRef(__symbolTable[137]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -399,11 +241,11 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139709265342087 = __arg1;
+Obj x140421015344743 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symlist;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[135];
 __arg2 = makeNative(40, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -414,11 +256,11 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139709265264647 = __arg1;
+Obj x140421015345127 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symdefun;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[134];
 __arg2 = makeNative(36, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -429,14 +271,14 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139709265265735 = __arg1;
-Obj x139709265266535 = primSet(co, symelem_63, makeNative(35, clofun3, 2, 0));
-Obj x139709265266951 = primSet(co, symatom_63, makeNative(34, clofun3, 1, 0));
-Obj x139709265268295 = primSet(co, symcora_47init_35rewrite_45let, makeNative(29, clofun3, 1, 0));
+Obj x140421015346215 = __arg1;
+Obj x140421015347015 = primSet(co, __symbolTable[132], makeNative(35, clofun3, 2, 0));
+Obj x140421015032423 = primSet(co, __symbolTable[131], makeNative(34, clofun3, 1, 0));
+Obj x140421015033959 = primSet(co, __symbolTable[130], makeNative(29, clofun3, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symlet;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[129];
 __arg2 = makeNative(28, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -447,11 +289,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139709265268679 = __arg1;
+Obj x140421015034407 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symcond;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[128];
 __arg2 = makeNative(24, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -462,12 +304,12 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139709265229319 = __arg1;
-Obj x139709265230855 = primSet(co, symcora_47init_35rewrite_45or, makeNative(22, clofun3, 1, 0));
+Obj x140421013680455 = __arg1;
+Obj x140421013682023 = primSet(co, __symbolTable[125], makeNative(22, clofun3, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symor;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[124];
 __arg2 = makeNative(21, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -478,12 +320,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139709265231239 = __arg1;
-Obj x139709265142663 = primSet(co, symcora_47init_35rewrite_45and, makeNative(19, clofun3, 1, 0));
+Obj x140421013682407 = __arg1;
+Obj x140421013683975 = primSet(co, __symbolTable[123], makeNative(19, clofun3, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symand;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[122];
 __arg2 = makeNative(18, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -494,13 +336,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139709265143047 = __arg1;
-Obj x139709265143591 = primSet(co, symboolean_63, makeNative(17, clofun3, 1, 0));
-Obj x139709265144743 = primSet(co, symcora_47init_35rcons1, makeNative(14, clofun3, 1, 0));
+Obj x140421013622919 = __arg1;
+Obj x140421013623463 = primSet(co, __symbolTable[121], makeNative(17, clofun3, 1, 0));
+Obj x140421013624647 = primSet(co, __symbolTable[120], makeNative(14, clofun3, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symlist_45rest;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[119];
 __arg2 = makeNative(13, clofun3, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -511,16 +353,16 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139709265145127 = __arg1;
-Obj x139709265111719 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(4, clofun3, 4, 0));
-Obj x139709265046503 = primSet(co, symcora_47init_35match1, makeNative(48, clofun2, 4, 0));
-Obj x139709264982919 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(43, clofun2, 2, 0));
-Obj x139709264961575 = primSet(co, symcora_47init_35match_45helper, makeNative(34, clofun2, 2, 0));
-Obj x139709264963815 = primSet(co, symcora_47init_35rewrite_45match, makeNative(28, clofun2, 1, 0));
+Obj x140421013625031 = __arg1;
+Obj x140421013562983 = primSet(co, __symbolTable[118], makeNative(4, clofun3, 4, 0));
+Obj x140421013468775 = primSet(co, __symbolTable[117], makeNative(48, clofun2, 4, 0));
+Obj x140421013471079 = primSet(co, __symbolTable[111], makeNative(43, clofun2, 2, 0));
+Obj x140421013270567 = primSet(co, __symbolTable[109], makeNative(34, clofun2, 2, 0));
+Obj x140421013273703 = primSet(co, __symbolTable[108], makeNative(28, clofun2, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symmatch;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[107];
 __arg2 = makeNative(27, clofun2, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -531,21 +373,21 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139709264964103 = __arg1;
-Obj x139709265370823 = primSet(co, symcora_47init_35extract_45rules1, makeNative(22, clofun2, 3, 0));
-Obj x139709265338375 = primSet(co, symcora_47init_35extract_45rules, makeNative(21, clofun2, 1, 0));
-Obj x139709265339367 = primSet(co, symcora_47init_35rules_45patterns, makeNative(18, clofun2, 2, 0));
-Obj x139709265340263 = primSet(co, symcora_47init_35length_45h, makeNative(17, clofun2, 2, 0));
-Obj x139709265340647 = primSet(co, symlength, makeNative(16, clofun2, 1, 0));
-Obj x139709265342279 = primSet(co, symcora_47init_35filter_45h, makeNative(14, clofun2, 3, 0));
-Obj x139709265264807 = primSet(co, symfilter, makeNative(13, clofun2, 2, 0));
-Obj x139709265265895 = primSet(co, symappend, makeNative(11, clofun2, 2, 0));
-Obj x139709265268039 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(4, clofun2, 1, 0));
-Obj x139709265228199 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(2, clofun2, 1, 0));
+Obj x140421013273991 = __arg1;
+Obj x140421012992999 = primSet(co, __symbolTable[106], makeNative(22, clofun2, 3, 0));
+Obj x140421012993287 = primSet(co, __symbolTable[104], makeNative(21, clofun2, 1, 0));
+Obj x140421015384839 = primSet(co, __symbolTable[103], makeNative(18, clofun2, 2, 0));
+Obj x140421015385863 = primSet(co, __symbolTable[102], makeNative(17, clofun2, 2, 0));
+Obj x140421015386183 = primSet(co, __symbolTable[101], makeNative(16, clofun2, 1, 0));
+Obj x140421015387847 = primSet(co, __symbolTable[100], makeNative(14, clofun2, 3, 0));
+Obj x140421015343111 = primSet(co, __symbolTable[99], makeNative(13, clofun2, 2, 0));
+Obj x140421015344071 = primSet(co, __symbolTable[98], makeNative(11, clofun2, 2, 0));
+Obj x140421015346471 = primSet(co, __symbolTable[97], makeNative(4, clofun2, 1, 0));
+Obj x140421015032519 = primSet(co, __symbolTable[96], makeNative(2, clofun2, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symfunc;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[95];
 __arg2 = makeNative(46, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -556,15 +398,15 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139709265230311 = __arg1;
-Obj x139709265230663 = primSet(co, symcora_47init_35rewrite_45namespace, makeNative(45, clofun1, 1, 0));
-Obj x139709265231047 = primSet(co, symcora_47init_35peval, makeNative(44, clofun1, 1, 0));
-Obj x139709265231623 = primSet(co, symmacroexpand, makeNative(41, clofun1, 1, 0));
-Obj x139709265109735 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(37, clofun1, 1, 0));
+Obj x140421015034887 = __arg1;
+Obj x140421015035303 = primSet(co, __symbolTable[94], makeNative(45, clofun1, 1, 0));
+Obj x140421015035623 = primSet(co, __symbolTable[92], makeNative(44, clofun1, 1, 0));
+Obj x140421013680647 = primSet(co, __symbolTable[138], makeNative(41, clofun1, 1, 0));
+Obj x140421013624455 = primSet(co, __symbolTable[91], makeNative(37, clofun1, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symbegin;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[89];
 __arg2 = makeNative(36, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -575,12 +417,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139709265110183 = __arg1;
-Obj x139709265044935 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(33, clofun1, 1, 0));
+Obj x140421013625095 = __arg1;
+Obj x140421013563463 = primSet(co, __symbolTable[88], makeNative(33, clofun1, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symbackquote;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[86];
 __arg2 = makeNative(31, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -591,12 +433,12 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139709265045383 = __arg1;
-Obj x139709265047367 = primSet(co, symcora_47init_35rewrite_45fold_45apply, makeNative(26, clofun1, 2, 0));
+Obj x140421013563975 = __arg1;
+Obj x140421013467751 = primSet(co, __symbolTable[85], makeNative(26, clofun1, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = symfold_45apply;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[84];
 __arg2 = makeNative(23, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -607,13 +449,13 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139709264982535 = __arg1;
-Obj x139709264904391 = primSet(co, symcora_47init_35parse_45package_45h, makeNative(19, clofun1, 4, 0));
-Obj x139709264904679 = primSet(co, symcora_47init_35parse_45package, makeNative(18, clofun1, 2, 0));
+Obj x140421013468551 = __arg1;
+Obj x140421013271623 = primSet(co, __symbolTable[83], makeNative(19, clofun1, 4, 0));
+Obj x140421013272007 = primSet(co, __symbolTable[80], makeNative(18, clofun1, 2, 0));
 PUSH_CONT_0(co, 15, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = sympackage;
+__arg0 = globalRef(__symbolTable[144]);
+__arg1 = __symbolTable[79];
 __arg2 = makeNative(10, clofun1, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -624,161 +466,161 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139709264907015 = __arg1;
-Obj x139709264907911 = primSet(co, symcora_47init_35var_45with_45ns, makeNative(5, clofun1, 2, 0));
-Obj x139709264901639 = primSet(co, symcora_47init_35lookup_45var, makeNative(47, clofun0, 3, 0));
-Obj x139709264902055 = makeCons(makeCString("primSet"), Nil);
-Obj x139709264902087 = makeCons(MAKE_NUMBER(2), x139709264902055);
-Obj x139709264902119 = makeCons(symset, x139709264902087);
-Obj x139709264902407 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x139709264902439 = makeCons(MAKE_NUMBER(1), x139709264902407);
-Obj x139709264902471 = makeCons(symcar, x139709264902439);
-Obj x139709264902759 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x139709264902791 = makeCons(MAKE_NUMBER(1), x139709264902759);
-Obj x139709264902823 = makeCons(symcdr, x139709264902791);
-Obj x139709264903111 = makeCons(makeCString("makeCons"), Nil);
-Obj x139709264903143 = makeCons(MAKE_NUMBER(2), x139709264903111);
-Obj x139709264903175 = makeCons(symcons, x139709264903143);
-Obj x139709264903463 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x139709264903495 = makeCons(MAKE_NUMBER(1), x139709264903463);
-Obj x139709264903527 = makeCons(symcons_63, x139709264903495);
-Obj x139709264903815 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x139709264903847 = makeCons(MAKE_NUMBER(2), x139709264903815);
-Obj x139709264903879 = makeCons(sym_43, x139709264903847);
-Obj x139709264904167 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x139709264891911 = makeCons(MAKE_NUMBER(2), x139709264904167);
-Obj x139709264891943 = makeCons(sym_45, x139709264891911);
-Obj x139709264892231 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x139709264892263 = makeCons(MAKE_NUMBER(2), x139709264892231);
-Obj x139709264892295 = makeCons(sym_42, x139709264892263);
-Obj x139709264892583 = makeCons(makeCString("primDiv"), Nil);
-Obj x139709264892615 = makeCons(MAKE_NUMBER(2), x139709264892583);
-Obj x139709264892647 = makeCons(sym_47, x139709264892615);
-Obj x139709264892935 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x139709264892967 = makeCons(MAKE_NUMBER(2), x139709264892935);
-Obj x139709264892999 = makeCons(sym_61, x139709264892967);
-Obj x139709264893287 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x139709264893319 = makeCons(MAKE_NUMBER(2), x139709264893287);
-Obj x139709264893351 = makeCons(sym_62, x139709264893319);
-Obj x139709264893639 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x139709264893671 = makeCons(MAKE_NUMBER(2), x139709264893639);
-Obj x139709264893703 = makeCons(sym_60, x139709264893671);
-Obj x139709264893991 = makeCons(makeCString("primGenSym"), Nil);
-Obj x139709264894023 = makeCons(MAKE_NUMBER(0), x139709264893991);
-Obj x139709264894055 = makeCons(symgensym, x139709264894023);
-Obj x139709265470183 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x139709265470343 = makeCons(MAKE_NUMBER(1), x139709265470183);
-Obj x139709265470535 = makeCons(symsymbol_63, x139709265470343);
-Obj x139709265471367 = makeCons(makeCString("primNot"), Nil);
-Obj x139709265471591 = makeCons(MAKE_NUMBER(1), x139709265471367);
-Obj x139709265471655 = makeCons(symnot, x139709265471591);
-Obj x139709265472615 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x139709265472647 = makeCons(MAKE_NUMBER(1), x139709265472615);
-Obj x139709265472711 = makeCons(syminteger_63, x139709265472647);
-Obj x139709265428871 = makeCons(makeCString("primIsString"), Nil);
-Obj x139709265428903 = makeCons(MAKE_NUMBER(1), x139709265428871);
-Obj x139709265428935 = makeCons(symstring_63, x139709265428903);
-Obj x139709265428967 = makeCons(x139709265428935, Nil);
-Obj x139709265428999 = makeCons(x139709265472711, x139709265428967);
-Obj x139709265429095 = makeCons(x139709265471655, x139709265428999);
-Obj x139709265429127 = makeCons(x139709265470535, x139709265429095);
-Obj x139709265429159 = makeCons(x139709264894055, x139709265429127);
-Obj x139709265429191 = makeCons(x139709264893703, x139709265429159);
-Obj x139709265429383 = makeCons(x139709264893351, x139709265429191);
-Obj x139709265429415 = makeCons(x139709264892999, x139709265429383);
-Obj x139709265429447 = makeCons(x139709264892647, x139709265429415);
-Obj x139709265429575 = makeCons(x139709264892295, x139709265429447);
-Obj x139709265429607 = makeCons(x139709264891943, x139709265429575);
-Obj x139709265429639 = makeCons(x139709264903879, x139709265429607);
-Obj x139709265429671 = makeCons(x139709264903527, x139709265429639);
-Obj x139709265429703 = makeCons(x139709264903175, x139709265429671);
-Obj x139709265429735 = makeCons(x139709264902823, x139709265429703);
-Obj x139709265429767 = makeCons(x139709264902471, x139709265429735);
-Obj x139709265429991 = makeCons(x139709264902119, x139709265429767);
-Obj x139709265430023 = primSet(co, symcora_47init_35_42builtin_45prims_42, x139709265429991);
-Obj x139709265369191 = primSet(co, symassq, makeNative(45, clofun0, 2, 0));
-Obj x139709265369959 = primSet(co, symcora_47init_35builtin_63, makeNative(42, clofun0, 1, 0));
-Obj x139709264894503 = primSet(co, symcora_47init_35parse, makeNative(16, clofun0, 4, 0));
-Obj x139709264868423 = makeCons(symappend, Nil);
-Obj x139709264868455 = makeCons(symfilter, x139709264868423);
-Obj x139709264868487 = makeCons(symlength, x139709264868455);
-Obj x139709264868519 = makeCons(symelem_63, x139709264868487);
-Obj x139709264868551 = makeCons(symmacroexpand, x139709264868519);
-Obj x139709264868583 = makeCons(symmap, x139709264868551);
-Obj x139709264868615 = makeCons(symreverse, x139709264868583);
-Obj x139709264868647 = makeCons(symthrow, x139709264868615);
-Obj x139709264868679 = makeCons(symtry, x139709264868647);
-Obj x139709264868711 = makeCons(symload, x139709264868679);
-Obj x139709264868743 = makeCons(symimport, x139709264868711);
-Obj x139709264868775 = makeCons(symload_45so, x139709264868743);
-Obj x139709264868807 = makeCons(symapply, x139709264868775);
-Obj x139709264868839 = makeCons(symvalue_45or, x139709264868807);
-Obj x139709264868871 = makeCons(symvalue, x139709264868839);
-Obj x139709264868903 = makeCons(symread_45file_45as_45sexp, x139709264868871);
-Obj x139709264868935 = makeCons(symbytes_45length, x139709264868903);
-Obj x139709264868967 = makeCons(symbytes, x139709264868935);
-Obj x139709264868999 = makeCons(symvector_45length, x139709264868967);
-Obj x139709264869031 = makeCons(symvector_45ref, x139709264868999);
-Obj x139709264869063 = makeCons(symvector_45set_33, x139709264869031);
-Obj x139709264869095 = makeCons(symvector_63, x139709264869063);
-Obj x139709264869127 = makeCons(symvector, x139709264869095);
-Obj x139709264869159 = makeCons(symsymbol_45_62string, x139709264869127);
-Obj x139709264869191 = makeCons(symintern, x139709264869159);
-Obj x139709264869223 = makeCons(symstring_45append, x139709264869191);
-Obj x139709264869255 = makeCons(symnull_63, x139709264869223);
-Obj x139709264869287 = makeCons(symnumber_63, x139709264869255);
-Obj x139709264869319 = makeCons(symboolean_63, x139709264869287);
-Obj x139709264869351 = makeCons(symatom_63, x139709264869319);
-Obj x139709264869383 = makeCons(sympair_63, x139709264869351);
-Obj x139709264869415 = makeCons(symcdddr, x139709264869383);
-Obj x139709264869447 = makeCons(symcadddr, x139709264869415);
-Obj x139709264869479 = makeCons(symcaddr, x139709264869447);
-Obj x139709264869511 = makeCons(symcddr, x139709264869479);
-Obj x139709264869543 = makeCons(symcdar, x139709264869511);
-Obj x139709264869575 = makeCons(symcaar, x139709264869543);
-Obj x139709264869607 = makeCons(symcadr, x139709264869575);
-Obj x139709264869639 = primSet(co, symcora_47init_35_42ns_45export_42, x139709264869607);
-Obj x139709264869799 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj x139709264869959 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj x139709264870119 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj x139709264870279 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj x139709264870439 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj x139709264870599 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj x139709264870759 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj x139709264870919 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj x139709264871079 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj x139709264871239 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj x139709264871399 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj x139709264818311 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj x139709264818471 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj x139709264818631 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj x139709264818791 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj x139709264818951 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj x139709264819111 = primSet(co, symcora_47init_35vector_63, globalRef(symvector_63));
-Obj x139709264819271 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj x139709264819431 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj x139709264819591 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj x139709264819751 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj x139709264819911 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj x139709264820071 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj x139709264820231 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj x139709264820391 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj x139709264820551 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj x139709264820711 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj x139709264820871 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj x139709264821031 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj x139709264821191 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj x139709264821351 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj x139709264821511 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj x139709264821671 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj x139709264821831 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj x139709264821991 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj x139709264822151 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj x139709264789543 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj x139709264789703 = primSet(co, symcora_47init_35append, globalRef(symappend));
-Obj x139709264789799 = primSet(co, symcora_47init_35assq, globalRef(symassq));
+Obj x140421013108935 = __arg1;
+Obj x140421013110023 = primSet(co, __symbolTable[76], makeNative(5, clofun1, 2, 0));
+Obj x140421013091943 = primSet(co, __symbolTable[71], makeNative(47, clofun0, 3, 0));
+Obj x140421013092519 = makeCons(makeCString("primSet"), Nil);
+Obj x140421013092551 = makeCons(MAKE_NUMBER(2), x140421013092519);
+Obj x140421013092583 = makeCons(__symbolTable[68], x140421013092551);
+Obj x140421013092999 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x140421013093031 = makeCons(MAKE_NUMBER(1), x140421013092999);
+Obj x140421013093063 = makeCons(__symbolTable[115], x140421013093031);
+Obj x140421013093479 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x140421013093511 = makeCons(MAKE_NUMBER(1), x140421013093479);
+Obj x140421013093543 = makeCons(__symbolTable[114], x140421013093511);
+Obj x140421013093959 = makeCons(makeCString("makeCons"), Nil);
+Obj x140421013093991 = makeCons(MAKE_NUMBER(2), x140421013093959);
+Obj x140421013094023 = makeCons(__symbolTable[152], x140421013093991);
+Obj x140421012992103 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x140421012992135 = makeCons(MAKE_NUMBER(1), x140421012992103);
+Obj x140421012992167 = makeCons(__symbolTable[116], x140421012992135);
+Obj x140421012992615 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x140421012992647 = makeCons(MAKE_NUMBER(2), x140421012992615);
+Obj x140421012992679 = makeCons(__symbolTable[67], x140421012992647);
+Obj x140421012993703 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x140421012993735 = makeCons(MAKE_NUMBER(2), x140421012993703);
+Obj x140421012993767 = makeCons(__symbolTable[66], x140421012993735);
+Obj x140421012994055 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x140421012994087 = makeCons(MAKE_NUMBER(2), x140421012994055);
+Obj x140421012994119 = makeCons(__symbolTable[65], x140421012994087);
+Obj x140421012994407 = makeCons(makeCString("primDiv"), Nil);
+Obj x140421012994439 = makeCons(MAKE_NUMBER(2), x140421012994407);
+Obj x140421012994471 = makeCons(__symbolTable[64], x140421012994439);
+Obj x140421012994759 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x140421012994791 = makeCons(MAKE_NUMBER(2), x140421012994759);
+Obj x140421012994823 = makeCons(__symbolTable[113], x140421012994791);
+Obj x140421012995111 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x140421012995143 = makeCons(MAKE_NUMBER(2), x140421012995111);
+Obj x140421012995207 = makeCons(__symbolTable[63], x140421012995143);
+Obj x140421012995655 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x140421012995687 = makeCons(MAKE_NUMBER(2), x140421012995655);
+Obj x140421012995719 = makeCons(__symbolTable[62], x140421012995687);
+Obj x140421012996007 = makeCons(makeCString("primGenSym"), Nil);
+Obj x140421012996039 = makeCons(MAKE_NUMBER(0), x140421012996007);
+Obj x140421012996071 = makeCons(__symbolTable[61], x140421012996039);
+Obj x140421012513031 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x140421012513063 = makeCons(MAKE_NUMBER(1), x140421012513031);
+Obj x140421012513095 = makeCons(__symbolTable[60], x140421012513063);
+Obj x140421012513383 = makeCons(makeCString("primNot"), Nil);
+Obj x140421012513415 = makeCons(MAKE_NUMBER(1), x140421012513383);
+Obj x140421012513447 = makeCons(__symbolTable[59], x140421012513415);
+Obj x140421012513735 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x140421012513767 = makeCons(MAKE_NUMBER(1), x140421012513735);
+Obj x140421012513799 = makeCons(__symbolTable[58], x140421012513767);
+Obj x140421012514087 = makeCons(makeCString("primIsString"), Nil);
+Obj x140421012514119 = makeCons(MAKE_NUMBER(1), x140421012514087);
+Obj x140421012514151 = makeCons(__symbolTable[57], x140421012514119);
+Obj x140421012514183 = makeCons(x140421012514151, Nil);
+Obj x140421012514215 = makeCons(x140421012513799, x140421012514183);
+Obj x140421012514247 = makeCons(x140421012513447, x140421012514215);
+Obj x140421012514279 = makeCons(x140421012513095, x140421012514247);
+Obj x140421012514311 = makeCons(x140421012996071, x140421012514279);
+Obj x140421012514343 = makeCons(x140421012995719, x140421012514311);
+Obj x140421012514375 = makeCons(x140421012995207, x140421012514343);
+Obj x140421012514407 = makeCons(x140421012994823, x140421012514375);
+Obj x140421012514439 = makeCons(x140421012994471, x140421012514407);
+Obj x140421012514471 = makeCons(x140421012994119, x140421012514439);
+Obj x140421012514503 = makeCons(x140421012993767, x140421012514471);
+Obj x140421012514535 = makeCons(x140421012992679, x140421012514503);
+Obj x140421012514567 = makeCons(x140421012992167, x140421012514535);
+Obj x140421012514599 = makeCons(x140421013094023, x140421012514567);
+Obj x140421012514631 = makeCons(x140421013093543, x140421012514599);
+Obj x140421012514663 = makeCons(x140421013093063, x140421012514631);
+Obj x140421012514695 = makeCons(x140421013092583, x140421012514663);
+Obj x140421012514727 = primSet(co, __symbolTable[69], x140421012514695);
+Obj x140421012390535 = primSet(co, __symbolTable[56], makeNative(45, clofun0, 2, 0));
+Obj x140421012391047 = primSet(co, __symbolTable[55], makeNative(42, clofun0, 1, 0));
+Obj x140421012993575 = primSet(co, __symbolTable[93], makeNative(16, clofun0, 4, 0));
+Obj x140421012513991 = makeCons(__symbolTable[98], Nil);
+Obj x140421012514023 = makeCons(__symbolTable[99], x140421012513991);
+Obj x140421012514055 = makeCons(__symbolTable[101], x140421012514023);
+Obj x140421012514759 = makeCons(__symbolTable[132], x140421012514055);
+Obj x140421012514791 = makeCons(__symbolTable[138], x140421012514759);
+Obj x140421012514823 = makeCons(__symbolTable[147], x140421012514791);
+Obj x140421012514855 = makeCons(__symbolTable[149], x140421012514823);
+Obj x140421012514887 = makeCons(__symbolTable[39], x140421012514855);
+Obj x140421012514919 = makeCons(__symbolTable[40], x140421012514887);
+Obj x140421012514951 = makeCons(__symbolTable[41], x140421012514919);
+Obj x140421012514983 = makeCons(__symbolTable[81], x140421012514951);
+Obj x140421012515015 = makeCons(__symbolTable[42], x140421012514983);
+Obj x140421012515047 = makeCons(__symbolTable[43], x140421012515015);
+Obj x140421012515111 = makeCons(__symbolTable[70], x140421012515047);
+Obj x140421012515143 = makeCons(__symbolTable[44], x140421012515111);
+Obj x140421012515175 = makeCons(__symbolTable[45], x140421012515143);
+Obj x140421012515207 = makeCons(__symbolTable[46], x140421012515175);
+Obj x140421012515239 = makeCons(__symbolTable[47], x140421012515207);
+Obj x140421012515271 = makeCons(__symbolTable[48], x140421012515239);
+Obj x140421012515303 = makeCons(__symbolTable[49], x140421012515271);
+Obj x140421012515335 = makeCons(__symbolTable[50], x140421012515303);
+Obj x140421012515367 = makeCons(__symbolTable[51], x140421012515335);
+Obj x140421012515431 = makeCons(__symbolTable[52], x140421012515367);
+Obj x140421012515463 = makeCons(__symbolTable[72], x140421012515431);
+Obj x140421012515495 = makeCons(__symbolTable[74], x140421012515463);
+Obj x140421012515527 = makeCons(__symbolTable[73], x140421012515495);
+Obj x140421012515559 = makeCons(__symbolTable[161], x140421012515527);
+Obj x140421012515623 = makeCons(__symbolTable[54], x140421012515559);
+Obj x140421012515655 = makeCons(__symbolTable[121], x140421012515623);
+Obj x140421012515687 = makeCons(__symbolTable[131], x140421012515655);
+Obj x140421012515719 = makeCons(__symbolTable[151], x140421012515687);
+Obj x140421012515751 = makeCons(__symbolTable[154], x140421012515719);
+Obj x140421012515815 = makeCons(__symbolTable[155], x140421012515751);
+Obj x140421012515847 = makeCons(__symbolTable[156], x140421012515815);
+Obj x140421012515879 = makeCons(__symbolTable[157], x140421012515847);
+Obj x140421012515911 = makeCons(__symbolTable[158], x140421012515879);
+Obj x140421012515943 = makeCons(__symbolTable[159], x140421012515911);
+Obj x140421012515975 = makeCons(__symbolTable[160], x140421012515943);
+Obj x140421012516007 = primSet(co, __symbolTable[53], x140421012515975);
+Obj x140421012516199 = primSet(co, __symbolTable[38], globalRef(__symbolTable[160]));
+Obj x140421012516423 = primSet(co, __symbolTable[37], globalRef(__symbolTable[159]));
+Obj x140421012516647 = primSet(co, __symbolTable[36], globalRef(__symbolTable[158]));
+Obj x140421012516807 = primSet(co, __symbolTable[35], globalRef(__symbolTable[157]));
+Obj x140421012390087 = primSet(co, __symbolTable[34], globalRef(__symbolTable[156]));
+Obj x140421012390279 = primSet(co, __symbolTable[33], globalRef(__symbolTable[155]));
+Obj x140421012390471 = primSet(co, __symbolTable[32], globalRef(__symbolTable[154]));
+Obj x140421012390663 = primSet(co, __symbolTable[31], globalRef(__symbolTable[151]));
+Obj x140421012393767 = primSet(co, __symbolTable[30], globalRef(__symbolTable[131]));
+Obj x140421012393927 = primSet(co, __symbolTable[29], globalRef(__symbolTable[121]));
+Obj x140421012119655 = primSet(co, __symbolTable[28], globalRef(__symbolTable[161]));
+Obj x140421012119815 = primSet(co, __symbolTable[27], globalRef(__symbolTable[54]));
+Obj x140421012119975 = primSet(co, __symbolTable[26], globalRef(__symbolTable[73]));
+Obj x140421012120135 = primSet(co, __symbolTable[25], globalRef(__symbolTable[74]));
+Obj x140421012120295 = primSet(co, __symbolTable[24], globalRef(__symbolTable[72]));
+Obj x140421012120455 = primSet(co, __symbolTable[23], globalRef(__symbolTable[52]));
+Obj x140421012120615 = primSet(co, __symbolTable[22], globalRef(__symbolTable[51]));
+Obj x140421012120775 = primSet(co, __symbolTable[21], globalRef(__symbolTable[50]));
+Obj x140421012120935 = primSet(co, __symbolTable[20], globalRef(__symbolTable[49]));
+Obj x140421012121095 = primSet(co, __symbolTable[19], globalRef(__symbolTable[48]));
+Obj x140421012121255 = primSet(co, __symbolTable[18], globalRef(__symbolTable[47]));
+Obj x140421012121415 = primSet(co, __symbolTable[17], globalRef(__symbolTable[46]));
+Obj x140421012121575 = primSet(co, __symbolTable[16], globalRef(__symbolTable[44]));
+Obj x140421012121735 = primSet(co, __symbolTable[15], globalRef(__symbolTable[70]));
+Obj x140421012121895 = primSet(co, __symbolTable[14], globalRef(__symbolTable[45]));
+Obj x140421012122055 = primSet(co, __symbolTable[13], globalRef(__symbolTable[43]));
+Obj x140421012122215 = primSet(co, __symbolTable[12], globalRef(__symbolTable[41]));
+Obj x140421012122375 = primSet(co, __symbolTable[11], globalRef(__symbolTable[42]));
+Obj x140421012122535 = primSet(co, __symbolTable[10], globalRef(__symbolTable[81]));
+Obj x140421012122695 = primSet(co, __symbolTable[9], globalRef(__symbolTable[40]));
+Obj x140421012122855 = primSet(co, __symbolTable[8], globalRef(__symbolTable[39]));
+Obj x140421012123015 = primSet(co, __symbolTable[7], globalRef(__symbolTable[149]));
+Obj x140421012123175 = primSet(co, __symbolTable[6], globalRef(__symbolTable[147]));
+Obj x140421012123335 = primSet(co, __symbolTable[5], globalRef(__symbolTable[138]));
+Obj x140421012123495 = primSet(co, __symbolTable[4], globalRef(__symbolTable[132]));
+Obj x140421012094983 = primSet(co, __symbolTable[3], globalRef(__symbolTable[101]));
+Obj x140421012095143 = primSet(co, __symbolTable[2], globalRef(__symbolTable[99]));
+Obj x140421012095303 = primSet(co, __symbolTable[1], globalRef(__symbolTable[98]));
+Obj x140421012095399 = primSet(co, __symbolTable[0], globalRef(__symbolTable[56]));
 __nargs = 2;
-__arg1 = x139709264789799;
+__arg1 = x140421012095399;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -786,15 +628,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj x139709265472327 = __arg1;
-Obj x139709265472423 = __arg2;
-Obj x139709265472455 = __arg3;
-Obj x139709265472519 = co->args[4];
-Obj x139709265470503 = makeNative(20, clofun0, 1, 4, x139709265472327, x139709265472423, x139709265472455, x139709265472519);
-pushCont(co, 17, clofun0, 2, x139709265472519, x139709265470503);
+Obj x140421015032135 = __arg1;
+Obj x140421015032167 = __arg2;
+Obj x140421015032199 = __arg3;
+Obj x140421015032231 = co->args[4];
+Obj x140421015384199 = makeNative(20, clofun0, 1, 4, x140421015032135, x140421015032167, x140421015032199, x140421015032231);
+pushCont(co, 17, clofun0, 2, x140421015032231, x140421015384199);
 __nargs = 2;
-__arg0 = globalRef(symnumber_63);
-__arg1 = x139709265472519;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = x140421015032231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -804,12 +646,12 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139709264892103 = __arg1;
-Obj x139709265472519= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265470503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264892103) {
+Obj x140421012993031 = __arg1;
+Obj x140421015032231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015384199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421012993031) {
 __nargs = 2;
-__arg0 = x139709265470503;
+__arg0 = x140421015384199;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -817,10 +659,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709264892359 = primIsString(x139709265472519);
-if (True == x139709264892359) {
+Obj x140421012993191 = primIsString(x140421015032231);
+if (True == x140421012993191) {
 __nargs = 2;
-__arg0 = x139709265470503;
+__arg0 = x140421015384199;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -828,10 +670,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, clofun0, 2, x139709265472519, x139709265470503);
+pushCont(co, 18, clofun0, 2, x140421015032231, x140421015384199);
 __nargs = 2;
-__arg0 = globalRef(symboolean_63);
-__arg1 = x139709265472519;
+__arg0 = globalRef(__symbolTable[121]);
+__arg1 = x140421015032231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -843,12 +685,12 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139709264894311 = __arg1;
-Obj x139709265472519= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265470503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264894311) {
+Obj x140421012993383 = __arg1;
+Obj x140421015032231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015384199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421012993383) {
 __nargs = 2;
-__arg0 = x139709265470503;
+__arg0 = x140421015384199;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -856,10 +698,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 19, clofun0, 1, x139709265470503);
+pushCont(co, 19, clofun0, 1, x140421015384199);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265472519;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421015032231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -870,11 +712,11 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139709264894471 = __arg1;
-Obj x139709265470503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139709264894471) {
+Obj x140421012993543 = __arg1;
+Obj x140421015384199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421012993543) {
 __nargs = 2;
-__arg0 = x139709265470503;
+__arg0 = x140421015384199;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -883,7 +725,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470503;
+__arg0 = x140421015384199;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -895,40 +737,40 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139709265470567 = __arg1;
-if (True == x139709265470567) {
+Obj x140421015384231 = __arg1;
+if (True == x140421015384231) {
 __nargs = 2;
 __arg1 = closureRef(co, 3);
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265470823 = makeNative(21, clofun0, 0, 4, closureRef(co, 3), closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139709264901799 = PRIM_ISCONS(closureRef(co, 3));
-if (True == x139709264901799) {
-Obj x139709264902151 = PRIM_CAR(closureRef(co, 3));
-Obj x139709264902183 = PRIM_EQ(symquote, x139709264902151);
-if (True == x139709264902183) {
-Obj x139709264902535 = PRIM_CDR(closureRef(co, 3));
-Obj x139709264902567 = PRIM_ISCONS(x139709264902535);
-if (True == x139709264902567) {
-Obj x139709264902919 = PRIM_CDR(closureRef(co, 3));
-Obj x139709264902951 = PRIM_CAR(x139709264902919);
-Obj x = x139709264902951;
-Obj x139709264903367 = PRIM_CDR(closureRef(co, 3));
-Obj x139709264903399 = PRIM_CDR(x139709264903367);
-Obj x139709264903431 = PRIM_EQ(Nil, x139709264903399);
-if (True == x139709264903431) {
-Obj x139709264903687 = makeCons(x, Nil);
-Obj x139709264903719 = makeCons(symquote, x139709264903687);
+Obj x140421015033063 = makeNative(21, clofun0, 0, 4, closureRef(co, 3), closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421013092071 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140421013092071) {
+Obj x140421013092423 = PRIM_CAR(closureRef(co, 3));
+Obj x140421013092455 = PRIM_EQ(__symbolTable[139], x140421013092423);
+if (True == x140421013092455) {
+Obj x140421013092935 = PRIM_CDR(closureRef(co, 3));
+Obj x140421013092967 = PRIM_ISCONS(x140421013092935);
+if (True == x140421013092967) {
+Obj x140421013093447 = PRIM_CDR(closureRef(co, 3));
+Obj x140421013093575 = PRIM_CAR(x140421013093447);
+Obj x = x140421013093575;
+Obj x140421013094247 = PRIM_CDR(closureRef(co, 3));
+Obj x140421013094279 = PRIM_CDR(x140421013094247);
+Obj x140421013094311 = PRIM_EQ(Nil, x140421013094279);
+if (True == x140421013094311) {
+Obj x140421012992231 = makeCons(x, Nil);
+Obj x140421012992263 = makeCons(__symbolTable[139], x140421012992231);
 __nargs = 2;
-__arg1 = x139709264903719;
+__arg1 = x140421012992263;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265470823;
+__arg0 = x140421015033063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -937,7 +779,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470823;
+__arg0 = x140421015033063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -946,7 +788,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470823;
+__arg0 = x140421015033063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -955,7 +797,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470823;
+__arg0 = x140421015033063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -967,11 +809,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139709265371111 = primIsSymbol(closureRef(co, 0));
-if (True == x139709265371111) {
+Obj x140421012391783 = primIsSymbol(closureRef(co, 0));
+if (True == x140421012391783) {
 PUSH_CONT_0(co, 40, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symelem_63);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -980,34 +822,34 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265428679 = makeNative(24, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139709264905703 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709264905703) {
-Obj x139709264905959 = PRIM_CAR(closureRef(co, 0));
-Obj x139709264905991 = PRIM_EQ(symlambda, x139709264905959);
-if (True == x139709264905991) {
-Obj x139709264906343 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264906375 = PRIM_ISCONS(x139709264906343);
-if (True == x139709264906375) {
-Obj x139709264907047 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264907079 = PRIM_CAR(x139709264907047);
-Obj args = x139709264907079;
-Obj x139709264907431 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264907463 = PRIM_CDR(x139709264907431);
-Obj x139709264907495 = PRIM_ISCONS(x139709264907463);
-if (True == x139709264907495) {
-Obj x139709264907975 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264908007 = PRIM_CDR(x139709264907975);
-Obj x139709264908039 = PRIM_CAR(x139709264908007);
-Obj body = x139709264908039;
-Obj x139709264900263 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264900327 = PRIM_CDR(x139709264900263);
-Obj x139709264900359 = PRIM_CDR(x139709264900327);
-Obj x139709264900391 = PRIM_EQ(Nil, x139709264900359);
-if (True == x139709264900391) {
+Obj x140421015034471 = makeNative(24, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421013273319 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013273319) {
+Obj x140421013273735 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013273767 = PRIM_EQ(__symbolTable[140], x140421013273735);
+if (True == x140421013273767) {
+Obj x140421013274151 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013274183 = PRIM_ISCONS(x140421013274151);
+if (True == x140421013274183) {
+Obj x140421013107367 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013107591 = PRIM_CAR(x140421013107367);
+Obj args = x140421013107591;
+Obj x140421013109287 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013109319 = PRIM_CDR(x140421013109287);
+Obj x140421013109415 = PRIM_ISCONS(x140421013109319);
+if (True == x140421013109415) {
+Obj x140421013109799 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013109831 = PRIM_CDR(x140421013109799);
+Obj x140421013110055 = PRIM_CAR(x140421013109831);
+Obj body = x140421013110055;
+Obj x140421013110599 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013110631 = PRIM_CDR(x140421013110599);
+Obj x140421013110663 = PRIM_CDR(x140421013110631);
+Obj x140421013110695 = PRIM_EQ(Nil, x140421013110663);
+if (True == x140421013110695) {
 pushCont(co, 22, clofun0, 2, body, args);
 __nargs = 3;
-__arg0 = globalRef(symappend);
+__arg0 = globalRef(__symbolTable[98]);
 __arg1 = args;
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -1017,7 +859,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265428679;
+__arg0 = x140421015034471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1026,7 +868,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428679;
+__arg0 = x140421015034471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1035,7 +877,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428679;
+__arg0 = x140421015034471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1044,7 +886,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428679;
+__arg0 = x140421015034471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1053,7 +895,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428679;
+__arg0 = x140421015034471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1065,13 +907,13 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139709264900839 = __arg1;
+Obj x140421013090823 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 23, clofun0, 1, args);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x139709264900839;
+__arg0 = globalRef(__symbolTable[93]);
+__arg1 = x140421013090823;
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
 co->args[4] = body;
@@ -1084,13 +926,13 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139709264901031 = __arg1;
+Obj x140421013090983 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709264901063 = makeCons(x139709264901031, Nil);
-Obj x139709264901095 = makeCons(args, x139709264901063);
-Obj x139709264901159 = makeCons(symlambda, x139709264901095);
+Obj x140421013091015 = makeCons(x140421013090983, Nil);
+Obj x140421013091143 = makeCons(args, x140421013091015);
+Obj x140421013091175 = makeCons(__symbolTable[140], x140421013091143);
 __nargs = 2;
-__arg1 = x139709264901159;
+__arg1 = x140421013091175;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1098,64 +940,64 @@ goto *jumpTable[co->ctx.pc.label];
 
 label24:
 {
-Obj x139709265429479 = makeNative(27, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139709264983239 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709264983239) {
-Obj x139709264983623 = PRIM_CAR(closureRef(co, 0));
-Obj x139709264983655 = PRIM_EQ(symdo, x139709264983623);
-if (True == x139709264983655) {
-Obj x139709264984071 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264984103 = PRIM_ISCONS(x139709264984071);
-if (True == x139709264984103) {
-Obj x139709264984615 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264984647 = PRIM_CAR(x139709264984615);
-Obj x139709264984679 = PRIM_ISCONS(x139709264984647);
-if (True == x139709264984679) {
-Obj x139709264985255 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264985287 = PRIM_CAR(x139709264985255);
-Obj x139709264985415 = PRIM_CAR(x139709264985287);
-Obj x139709264985447 = PRIM_EQ(symimport, x139709264985415);
-if (True == x139709264985447) {
-Obj x139709264986023 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264961639 = PRIM_CAR(x139709264986023);
-Obj x139709264961671 = PRIM_CDR(x139709264961639);
-Obj x139709264961703 = PRIM_ISCONS(x139709264961671);
-if (True == x139709264961703) {
-Obj x139709264962279 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264962311 = PRIM_CAR(x139709264962279);
-Obj x139709264962439 = PRIM_CDR(x139709264962311);
-Obj x139709264962471 = PRIM_CAR(x139709264962439);
-Obj pkg = x139709264962471;
-Obj x139709264963207 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264963239 = PRIM_CAR(x139709264963207);
-Obj x139709264963271 = PRIM_CDR(x139709264963239);
-Obj x139709264963303 = PRIM_CDR(x139709264963271);
-Obj x139709264963335 = PRIM_EQ(Nil, x139709264963303);
-if (True == x139709264963335) {
-Obj x139709264963687 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264963847 = PRIM_CDR(x139709264963687);
-Obj x139709264963879 = PRIM_ISCONS(x139709264963847);
-if (True == x139709264963879) {
-Obj x139709264964231 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264964263 = PRIM_CDR(x139709264964231);
-Obj x139709264964295 = PRIM_CAR(x139709264964263);
-Obj y = x139709264964295;
-Obj x139709264964711 = PRIM_CDR(closureRef(co, 0));
-Obj x139709264964743 = PRIM_CDR(x139709264964711);
-Obj x139709264964775 = PRIM_CDR(x139709264964743);
-Obj x139709264964807 = PRIM_EQ(Nil, x139709264964775);
-if (True == x139709264964807) {
-Obj x139709264964967 = primIsString(pkg);
-if (True == x139709264964967) {
-Obj x139709264965607 = makeCons(pkg, Nil);
-Obj x139709264904199 = makeCons(symimport, x139709264965607);
+Obj x140421015035527 = makeNative(27, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421013564583 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013564583) {
+Obj x140421013565063 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013565095 = PRIM_EQ(__symbolTable[90], x140421013565063);
+if (True == x140421013565095) {
+Obj x140421013467367 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013467463 = PRIM_ISCONS(x140421013467367);
+if (True == x140421013467463) {
+Obj x140421013468231 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013468263 = PRIM_CAR(x140421013468231);
+Obj x140421013468295 = PRIM_ISCONS(x140421013468263);
+if (True == x140421013468295) {
+Obj x140421013468903 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013468935 = PRIM_CAR(x140421013468903);
+Obj x140421013468967 = PRIM_CAR(x140421013468935);
+Obj x140421013468999 = PRIM_EQ(__symbolTable[81], x140421013468967);
+if (True == x140421013468999) {
+Obj x140421013469479 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013469511 = PRIM_CAR(x140421013469479);
+Obj x140421013469543 = PRIM_CDR(x140421013469511);
+Obj x140421013469575 = PRIM_ISCONS(x140421013469543);
+if (True == x140421013469575) {
+Obj x140421013470471 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013470503 = PRIM_CAR(x140421013470471);
+Obj x140421013470599 = PRIM_CDR(x140421013470503);
+Obj x140421013470631 = PRIM_CAR(x140421013470599);
+Obj pkg = x140421013470631;
+Obj x140421013389703 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013389735 = PRIM_CAR(x140421013389703);
+Obj x140421013389831 = PRIM_CDR(x140421013389735);
+Obj x140421013389863 = PRIM_CDR(x140421013389831);
+Obj x140421013390023 = PRIM_EQ(Nil, x140421013389863);
+if (True == x140421013390023) {
+Obj x140421013390407 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013390439 = PRIM_CDR(x140421013390407);
+Obj x140421013390663 = PRIM_ISCONS(x140421013390439);
+if (True == x140421013390663) {
+Obj x140421013391271 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013391303 = PRIM_CDR(x140421013391271);
+Obj x140421013391431 = PRIM_CAR(x140421013391303);
+Obj y = x140421013391431;
+Obj x140421013392263 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013392295 = PRIM_CDR(x140421013392263);
+Obj x140421013392487 = PRIM_CDR(x140421013392295);
+Obj x140421013392519 = PRIM_EQ(Nil, x140421013392487);
+if (True == x140421013392519) {
+Obj x140421013392935 = primIsString(pkg);
+if (True == x140421013392935) {
+Obj x140421013271111 = makeCons(pkg, Nil);
+Obj x140421013271239 = makeCons(__symbolTable[81], x140421013271111);
 pushCont(co, 25, clofun0, 2, pkg, y);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
-co->args[4] = x139709264904199;
+co->args[4] = x140421013271239;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1163,16 +1005,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1181,7 +1014,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1190,7 +1023,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1199,7 +1032,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1208,7 +1041,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1217,7 +1050,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1226,7 +1059,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1235,7 +1068,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1244,7 +1077,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265429479;
+__arg0 = x140421015035527;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421015035527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1255,16 +1097,16 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139709264904231 = __arg1;
+Obj x140421013271271 = __arg1;
 Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709264904583 = makeCons(pkg, closureRef(co, 3));
-pushCont(co, 26, clofun0, 1, x139709264904231);
+Obj x140421013271783 = makeCons(pkg, closureRef(co, 3));
+pushCont(co, 26, clofun0, 1, x140421013271271);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
-__arg3 = x139709264904583;
+__arg3 = x140421013271783;
 co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1275,13 +1117,13 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139709264904615 = __arg1;
-Obj x139709264904231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709264904647 = makeCons(x139709264904615, Nil);
-Obj x139709264904711 = makeCons(x139709264904231, x139709264904647);
-Obj x139709264904743 = makeCons(symdo, x139709264904711);
+Obj x140421013271815 = __arg1;
+Obj x140421013271271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013271879 = makeCons(x140421013271815, Nil);
+Obj x140421013271911 = makeCons(x140421013271271, x140421013271879);
+Obj x140421013271943 = makeCons(__symbolTable[90], x140421013271911);
 __nargs = 2;
-__arg1 = x139709264904743;
+__arg1 = x140421013271943;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1289,18 +1131,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj x139709265430503 = makeNative(31, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139709265045767 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265045767) {
-Obj x139709265046247 = PRIM_CAR(closureRef(co, 0));
-Obj op = x139709265046247;
-Obj x139709265046535 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139709265046535;
-Obj x139709265470599 = makeNative(28, clofun0, 1, 6, op, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), args, x139709265430503);
-Obj x139709264982727 = PRIM_EQ(op, symif);
-if (True == x139709264982727) {
+Obj x140421013682887 = makeNative(31, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421013561607 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013561607) {
+Obj x140421013561927 = PRIM_CAR(closureRef(co, 0));
+Obj op = x140421013561927;
+Obj x140421013562311 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421013562311;
+Obj x140421015384263 = makeNative(28, clofun0, 1, 6, op, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), args, x140421013682887);
+Obj x140421013563911 = PRIM_EQ(op, __symbolTable[126]);
+if (True == x140421013563911) {
 __nargs = 2;
-__arg0 = x139709265470599;
+__arg0 = x140421015384263;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1308,10 +1150,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709264982983 = PRIM_EQ(op, symdo);
-if (True == x139709264982983) {
+Obj x140421013564167 = PRIM_EQ(op, __symbolTable[90]);
+if (True == x140421013564167) {
 __nargs = 2;
-__arg0 = x139709265470599;
+__arg0 = x140421015384263;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1320,7 +1162,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470599;
+__arg0 = x140421015384263;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1331,7 +1173,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265430503;
+__arg0 = x140421013682887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1342,11 +1184,11 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139709265470695 = __arg1;
-if (True == x139709265470695) {
+Obj x140421015384295 = __arg1;
+if (True == x140421015384295) {
 PUSH_CONT_0(co, 29, clofun0);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
@@ -1368,11 +1210,11 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139709265047527 = __arg1;
+Obj x140421013563335 = __arg1;
 PUSH_CONT_0(co, 30, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x139709265047527;
+__arg0 = globalRef(__symbolTable[147]);
+__arg1 = x140421013563335;
 __arg2 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1383,10 +1225,10 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139709264982087 = __arg1;
-Obj x139709264982119 = makeCons(closureRef(co, 0), x139709264982087);
+Obj x140421013563399 = __arg1;
+Obj x140421013563431 = makeCons(closureRef(co, 0), x140421013563399);
 __nargs = 2;
-__arg1 = x139709264982119;
+__arg1 = x140421013563431;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1394,45 +1236,45 @@ goto *jumpTable[co->ctx.pc.label];
 
 label31:
 {
-Obj x139709265431079 = makeNative(34, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
-Obj x139709265144839 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265144839) {
-Obj x139709265145255 = PRIM_CAR(closureRef(co, 0));
-Obj x139709265145287 = PRIM_EQ(symlet, x139709265145255);
-if (True == x139709265145287) {
-Obj x139709265145703 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265145735 = PRIM_ISCONS(x139709265145703);
-if (True == x139709265145735) {
-Obj x139709265109191 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265109223 = PRIM_CAR(x139709265109191);
-Obj a = x139709265109223;
-Obj x139709265109703 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265109767 = PRIM_CDR(x139709265109703);
-Obj x139709265109799 = PRIM_ISCONS(x139709265109767);
-if (True == x139709265109799) {
-Obj x139709265110247 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265110279 = PRIM_CDR(x139709265110247);
-Obj x139709265110311 = PRIM_CAR(x139709265110279);
-Obj b = x139709265110311;
-Obj x139709265110983 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265111015 = PRIM_CDR(x139709265110983);
-Obj x139709265111047 = PRIM_CDR(x139709265111015);
-Obj x139709265111239 = PRIM_ISCONS(x139709265111047);
-if (True == x139709265111239) {
-Obj x139709265111815 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265111847 = PRIM_CDR(x139709265111815);
-Obj x139709265111879 = PRIM_CDR(x139709265111847);
-Obj x139709265111943 = PRIM_CAR(x139709265111879);
-Obj c = x139709265111943;
-Obj x139709265112711 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265112743 = PRIM_CDR(x139709265112711);
-Obj x139709265112807 = PRIM_CDR(x139709265112743);
-Obj x139709265112903 = PRIM_CDR(x139709265112807);
-Obj x139709265112935 = PRIM_EQ(Nil, x139709265112903);
-if (True == x139709265112935) {
+Obj x140421013624007 = makeNative(34, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
+Obj x140421013681191 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013681191) {
+Obj x140421013681575 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013681607 = PRIM_EQ(__symbolTable[129], x140421013681575);
+if (True == x140421013681607) {
+Obj x140421013682151 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013682183 = PRIM_ISCONS(x140421013682151);
+if (True == x140421013682183) {
+Obj x140421013682631 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013682663 = PRIM_CAR(x140421013682631);
+Obj a = x140421013682663;
+Obj x140421013683175 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013683207 = PRIM_CDR(x140421013683175);
+Obj x140421013683239 = PRIM_ISCONS(x140421013683207);
+if (True == x140421013683239) {
+Obj x140421013683751 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013684007 = PRIM_CDR(x140421013683751);
+Obj x140421013684039 = PRIM_CAR(x140421013684007);
+Obj b = x140421013684039;
+Obj x140421013623143 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013623175 = PRIM_CDR(x140421013623143);
+Obj x140421013623335 = PRIM_CDR(x140421013623175);
+Obj x140421013623367 = PRIM_ISCONS(x140421013623335);
+if (True == x140421013623367) {
+Obj x140421013623847 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013623975 = PRIM_CDR(x140421013623847);
+Obj x140421013624071 = PRIM_CDR(x140421013623975);
+Obj x140421013624103 = PRIM_CAR(x140421013624071);
+Obj c = x140421013624103;
+Obj x140421013624871 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013624903 = PRIM_CDR(x140421013624871);
+Obj x140421013624935 = PRIM_CDR(x140421013624903);
+Obj x140421013624967 = PRIM_CDR(x140421013624935);
+Obj x140421013625127 = PRIM_EQ(Nil, x140421013624967);
+if (True == x140421013625127) {
 pushCont(co, 32, clofun0, 2, c, a);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
@@ -1444,7 +1286,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1453,7 +1295,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1462,7 +1304,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1471,7 +1313,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1480,7 +1322,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1489,7 +1331,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265431079;
+__arg0 = x140421013624007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1500,14 +1342,14 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139709265044007 = __arg1;
+Obj x140421013625607 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265044551 = makeCons(a, closureRef(co, 1));
-pushCont(co, 33, clofun0, 2, x139709265044007, a);
+Obj x140421013625959 = makeCons(a, closureRef(co, 1));
+pushCont(co, 33, clofun0, 2, x140421013625607, a);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
-__arg1 = x139709265044551;
+__arg0 = globalRef(__symbolTable[93]);
+__arg1 = x140421013625959;
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
@@ -1520,15 +1362,15 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139709265044775 = __arg1;
-Obj x139709265044007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013626087 = __arg1;
+Obj x140421013625607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265044807 = makeCons(x139709265044775, Nil);
-Obj x139709265044839 = makeCons(x139709265044007, x139709265044807);
-Obj x139709265044871 = makeCons(a, x139709265044839);
-Obj x139709265044967 = makeCons(symlet, x139709265044871);
+Obj x140421013626151 = makeCons(x140421013626087, Nil);
+Obj x140421013626183 = makeCons(x140421013625607, x140421013626151);
+Obj x140421013626215 = makeCons(a, x140421013626183);
+Obj x140421013626247 = makeCons(__symbolTable[129], x140421013626215);
 __nargs = 2;
-__arg1 = x139709265044967;
+__arg1 = x140421013626247;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1536,44 +1378,44 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj x139709265471559 = makeNative(35, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
-Obj x139709265228487 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139709265228487) {
-Obj x139709265228871 = PRIM_CAR(closureRef(co, 2));
-Obj x139709265228935 = PRIM_EQ(symns, x139709265228871);
-if (True == x139709265228935) {
-Obj x139709265229479 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265229511 = PRIM_ISCONS(x139709265229479);
-if (True == x139709265229511) {
-Obj x139709265229831 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265229863 = PRIM_CAR(x139709265229831);
-Obj path = x139709265229863;
-Obj x139709265230631 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265230695 = PRIM_CDR(x139709265230631);
-Obj x139709265230887 = PRIM_ISCONS(x139709265230695);
-if (True == x139709265230887) {
-Obj x139709265231303 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265231335 = PRIM_CDR(x139709265231303);
-Obj x139709265231367 = PRIM_CAR(x139709265231335);
-Obj import = x139709265231367;
-Obj x139709265141831 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265141863 = PRIM_CDR(x139709265141831);
-Obj x139709265141895 = PRIM_CDR(x139709265141863);
-Obj x139709265141927 = PRIM_ISCONS(x139709265141895);
-if (True == x139709265141927) {
-Obj x139709265142471 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265142503 = PRIM_CDR(x139709265142471);
-Obj x139709265142727 = PRIM_CDR(x139709265142503);
-Obj x139709265142759 = PRIM_CAR(x139709265142727);
-Obj body = x139709265142759;
-Obj x139709265143463 = PRIM_CDR(closureRef(co, 2));
-Obj x139709265143495 = PRIM_CDR(x139709265143463);
-Obj x139709265143527 = PRIM_CDR(x139709265143495);
-Obj x139709265143623 = PRIM_CDR(x139709265143527);
-Obj x139709265143655 = PRIM_EQ(Nil, x139709265143623);
-if (True == x139709265143655) {
+Obj x140421013626279 = makeNative(35, clofun0, 0, 4, closureRef(co, 2), closureRef(co, 3), closureRef(co, 0), closureRef(co, 1));
+Obj x140421015344935 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140421015344935) {
+Obj x140421015345351 = PRIM_CAR(closureRef(co, 2));
+Obj x140421015345383 = PRIM_EQ(__symbolTable[78], x140421015345351);
+if (True == x140421015345383) {
+Obj x140421015345671 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015345703 = PRIM_ISCONS(x140421015345671);
+if (True == x140421015345703) {
+Obj x140421015346439 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015346503 = PRIM_CAR(x140421015346439);
+Obj path = x140421015346503;
+Obj x140421015346951 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015347047 = PRIM_CDR(x140421015346951);
+Obj x140421015347079 = PRIM_ISCONS(x140421015347047);
+if (True == x140421015347079) {
+Obj x140421015032679 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015032711 = PRIM_CDR(x140421015032679);
+Obj x140421015032743 = PRIM_CAR(x140421015032711);
+Obj import = x140421015032743;
+Obj x140421015033511 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015033575 = PRIM_CDR(x140421015033511);
+Obj x140421015033639 = PRIM_CDR(x140421015033575);
+Obj x140421015033671 = PRIM_ISCONS(x140421015033639);
+if (True == x140421015033671) {
+Obj x140421015034439 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015034503 = PRIM_CDR(x140421015034439);
+Obj x140421015034535 = PRIM_CDR(x140421015034503);
+Obj x140421015034919 = PRIM_CAR(x140421015034535);
+Obj body = x140421015034919;
+Obj x140421015035655 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015035687 = PRIM_CDR(x140421015035655);
+Obj x140421015035719 = PRIM_CDR(x140421015035687);
+Obj x140421015035783 = PRIM_CDR(x140421015035719);
+Obj x140421015035815 = PRIM_EQ(Nil, x140421015035783);
+if (True == x140421015035815) {
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 3);
 __arg2 = path;
 __arg3 = import;
@@ -1585,7 +1427,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1594,7 +1436,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1603,7 +1445,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1612,7 +1454,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1621,7 +1463,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1630,7 +1472,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471559;
+__arg0 = x140421013626279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1641,34 +1483,34 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139709265428743 = makeNative(38, clofun0, 0, 4, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 0));
-Obj x139709265341191 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265341191) {
-Obj x139709265341703 = PRIM_CAR(closureRef(co, 0));
-Obj x139709265341959 = PRIM_EQ(symdef, x139709265341703);
-if (True == x139709265341959) {
-Obj x139709265342343 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265342375 = PRIM_ISCONS(x139709265342343);
-if (True == x139709265342375) {
-Obj x139709265264903 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265264935 = PRIM_CAR(x139709265264903);
-Obj var = x139709265264935;
-Obj x139709265265319 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265265415 = PRIM_CDR(x139709265265319);
-Obj x139709265265447 = PRIM_ISCONS(x139709265265415);
-if (True == x139709265265447) {
-Obj x139709265266183 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265266215 = PRIM_CDR(x139709265266183);
-Obj x139709265266247 = PRIM_CAR(x139709265266215);
-Obj val = x139709265266247;
-Obj x139709265266855 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265266983 = PRIM_CDR(x139709265266855);
-Obj x139709265267015 = PRIM_CDR(x139709265266983);
-Obj x139709265267079 = PRIM_EQ(Nil, x139709265267015);
-if (True == x139709265267079) {
+Obj x140421013563111 = makeNative(38, clofun0, 0, 4, closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 0));
+Obj x140421012393671 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012393671) {
+Obj x140421015384551 = PRIM_CAR(closureRef(co, 0));
+Obj x140421015384583 = PRIM_EQ(__symbolTable[133], x140421015384551);
+if (True == x140421015384583) {
+Obj x140421015385031 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015385063 = PRIM_ISCONS(x140421015385031);
+if (True == x140421015385063) {
+Obj x140421015385703 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015385767 = PRIM_CAR(x140421015385703);
+Obj var = x140421015385767;
+Obj x140421015386215 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015386247 = PRIM_CDR(x140421015386215);
+Obj x140421015386311 = PRIM_ISCONS(x140421015386247);
+if (True == x140421015386311) {
+Obj x140421015386759 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015386791 = PRIM_CDR(x140421015386759);
+Obj x140421015386823 = PRIM_CAR(x140421015386791);
+Obj val = x140421015386823;
+Obj x140421015387623 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015387655 = PRIM_CDR(x140421015387623);
+Obj x140421015387783 = PRIM_CDR(x140421015387655);
+Obj x140421015387815 = PRIM_EQ(Nil, x140421015387783);
+if (True == x140421015387815) {
 pushCont(co, 36, clofun0, 1, val);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35var_45with_45ns);
+__arg0 = globalRef(__symbolTable[76]);
 __arg1 = var;
 __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
@@ -1678,7 +1520,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265428743;
+__arg0 = x140421013563111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1687,7 +1529,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428743;
+__arg0 = x140421013563111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1696,7 +1538,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428743;
+__arg0 = x140421013563111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1705,7 +1547,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428743;
+__arg0 = x140421013563111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1714,7 +1556,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265428743;
+__arg0 = x140421013563111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1725,14 +1567,14 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139709265267271 = __arg1;
+Obj x140421015388071 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj var1 = x139709265267271;
-Obj x139709265267751 = makeCons(var1, Nil);
-Obj x139709265267783 = makeCons(symquote, x139709265267751);
-pushCont(co, 37, clofun0, 1, x139709265267783);
+Obj var1 = x140421015388071;
+Obj x140421015343431 = makeCons(var1, Nil);
+Obj x140421015343463 = makeCons(__symbolTable[139], x140421015343431);
+pushCont(co, 37, clofun0, 1, x140421015343463);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
@@ -1746,13 +1588,13 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139709265268455 = __arg1;
-Obj x139709265267783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265268487 = makeCons(x139709265268455, Nil);
-Obj x139709265268519 = makeCons(x139709265267783, x139709265268487);
-Obj x139709265268551 = makeCons(symset, x139709265268519);
+Obj x140421015343783 = __arg1;
+Obj x140421015343463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015343815 = makeCons(x140421015343783, Nil);
+Obj x140421015343847 = makeCons(x140421015343463, x140421015343815);
+Obj x140421015344103 = makeCons(__symbolTable[68], x140421015343847);
 __nargs = 2;
-__arg1 = x139709265268551;
+__arg1 = x140421015344103;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1762,7 +1604,7 @@ label38:
 {
 PUSH_CONT_0(co, 39, clofun0);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 1);
 __arg3 = closureRef(co, 2);
@@ -1775,10 +1617,10 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139709265340935 = __arg1;
+Obj x140421012393447 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = x139709265340935;
+__arg0 = globalRef(__symbolTable[147]);
+__arg1 = x140421012393447;
 __arg2 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1789,8 +1631,8 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139709265338631 = __arg1;
-if (True == x139709265338631) {
+Obj x140421012392007 = __arg1;
+if (True == x140421012392007) {
 __nargs = 2;
 __arg1 = closureRef(co, 0);
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1799,7 +1641,7 @@ goto *jumpTable[co->ctx.pc.label];
 } else {
 PUSH_CONT_0(co, 41, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35builtin_63);
+__arg0 = globalRef(__symbolTable[55]);
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1811,8 +1653,8 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139709265338983 = __arg1;
-if (True == x139709265338983) {
+Obj x140421012392231 = __arg1;
+if (True == x140421012392231) {
 __nargs = 2;
 __arg1 = closureRef(co, 0);
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1820,7 +1662,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35lookup_45var);
+__arg0 = globalRef(__symbolTable[71]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
@@ -1837,9 +1679,9 @@ label42:
 Obj x = __arg1;
 PUSH_CONT_0(co, 43, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symassq);
+__arg0 = globalRef(__symbolTable[56]);
 __arg1 = x;
-__arg2 = globalRef(symcora_47init_35_42builtin_45prims_42);
+__arg2 = globalRef(__symbolTable[69]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1849,11 +1691,11 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139709265369831 = __arg1;
+Obj x140421012390951 = __arg1;
 PUSH_CONT_0(co, 44, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265369831;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421012390951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1863,10 +1705,10 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139709265369863 = __arg1;
-Obj x139709265369895 = primNot(x139709265369863);
+Obj x140421012390983 = __arg1;
+Obj x140421012391015 = primNot(x140421012390983);
 __nargs = 2;
-__arg1 = x139709265369895;
+__arg1 = x140421012391015;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1874,40 +1716,40 @@ goto *jumpTable[co->ctx.pc.label];
 
 label45:
 {
-Obj x139709265469959 = __arg1;
-Obj x139709265470023 = __arg2;
-Obj x139709265430535 = PRIM_EQ(Nil, x139709265470023);
-if (True == x139709265430535) {
+Obj x140421015035847 = __arg1;
+Obj x140421015035879 = __arg2;
+Obj x140421012515079 = PRIM_EQ(Nil, x140421015035879);
+if (True == x140421012515079) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265470631 = makeNative(46, clofun0, 0, 2, x139709265470023, x139709265469959);
-Obj x139709265432359 = PRIM_ISCONS(x139709265470023);
-if (True == x139709265432359) {
-Obj x139709265367175 = PRIM_CAR(x139709265470023);
-Obj x139709265367207 = PRIM_ISCONS(x139709265367175);
-if (True == x139709265367207) {
-Obj x139709265367559 = PRIM_CAR(x139709265470023);
-Obj x139709265367751 = PRIM_CAR(x139709265367559);
-Obj x = x139709265367751;
-Obj x139709265368007 = PRIM_CAR(x139709265470023);
-Obj x139709265368071 = PRIM_CDR(x139709265368007);
-Obj y = x139709265368071;
-Obj x139709265368423 = PRIM_CDR(x139709265470023);
-Obj x139709265368583 = PRIM_EQ(x139709265469959, x);
-if (True == x139709265368583) {
-Obj x139709265368935 = makeCons(x, y);
+Obj x140421013681927 = makeNative(46, clofun0, 0, 2, x140421015035879, x140421015035847);
+Obj x140421012516103 = PRIM_ISCONS(x140421015035879);
+if (True == x140421012516103) {
+Obj x140421012516327 = PRIM_CAR(x140421015035879);
+Obj x140421012516359 = PRIM_ISCONS(x140421012516327);
+if (True == x140421012516359) {
+Obj x140421012516583 = PRIM_CAR(x140421015035879);
+Obj x140421012516615 = PRIM_CAR(x140421012516583);
+Obj x = x140421012516615;
+Obj x140421012516839 = PRIM_CAR(x140421015035879);
+Obj x140421012389895 = PRIM_CDR(x140421012516839);
+Obj y = x140421012389895;
+Obj x140421012390055 = PRIM_CDR(x140421015035879);
+Obj x140421012390215 = PRIM_EQ(x140421015035847, x);
+if (True == x140421012390215) {
+Obj x140421012390311 = makeCons(x, y);
 __nargs = 2;
-__arg1 = x139709265368935;
+__arg1 = x140421012390311;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265470631;
+__arg0 = x140421013681927;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1916,7 +1758,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470631;
+__arg0 = x140421013681927;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1925,7 +1767,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470631;
+__arg0 = x140421013681927;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1937,13 +1779,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139709265431143 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265431143) {
-Obj x139709265431431 = PRIM_CAR(closureRef(co, 0));
-Obj x139709265431719 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139709265431719;
+Obj x140421012515399 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012515399) {
+Obj x140421012515591 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012515783 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421012515783;
 __nargs = 3;
-__arg0 = globalRef(symassq);
+__arg0 = globalRef(__symbolTable[56]);
 __arg1 = closureRef(co, 1);
 __arg2 = y;
 co->ctx.frees = __arg0;
@@ -1953,7 +1795,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1965,30 +1807,30 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139709265469863 = __arg1;
-Obj x139709265469895 = __arg2;
-Obj x139709265469927 = __arg3;
-Obj x139709264908263 = PRIM_EQ(Nil, x139709265469927);
-if (True == x139709264908263) {
+Obj x140421015034599 = __arg1;
+Obj x140421015034631 = __arg2;
+Obj x140421015034663 = __arg3;
+Obj x140421013110439 = PRIM_EQ(Nil, x140421015034663);
+if (True == x140421013110439) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35var_45with_45ns);
-__arg1 = x139709265469863;
-__arg2 = x139709265469895;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = x140421015034599;
+__arg2 = x140421015034631;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709264900295 = PRIM_ISCONS(x139709265469927);
-if (True == x139709264900295) {
-Obj x139709264900455 = PRIM_CAR(x139709265469927);
-Obj import = x139709264900455;
-Obj x139709264900615 = PRIM_CDR(x139709265469927);
-Obj more = x139709264900615;
-pushCont(co, 48, clofun0, 4, import, x139709265469863, x139709265469895, more);
+Obj x140421013110727 = PRIM_ISCONS(x140421015034663);
+if (True == x140421013110727) {
+Obj x140421013090471 = PRIM_CAR(x140421015034663);
+Obj import = x140421013090471;
+Obj x140421013090695 = PRIM_CDR(x140421015034663);
+Obj more = x140421013090695;
+pushCont(co, 48, clofun0, 4, import, x140421015034599, x140421015034631, more);
 __nargs = 3;
-__arg0 = globalRef(symstring_45append);
+__arg0 = globalRef(__symbolTable[73]);
 __arg1 = import;
 __arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
@@ -1998,7 +1840,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2011,15 +1853,15 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139709264900903 = __arg1;
+Obj x140421013091047 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265469863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265469895= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421015034599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015034631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 49, clofun0, 4, import, x139709265469863, x139709265469895, more);
+pushCont(co, 49, clofun0, 4, import, x140421015034599, x140421015034631, more);
 __nargs = 2;
-__arg0 = globalRef(symintern);
-__arg1 = x139709264900903;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = x140421013091047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2029,15 +1871,15 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139709264900935 = __arg1;
+Obj x140421013091079 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265469863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265469895= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421015034599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015034631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 0, clofun1, 4, import, x139709265469863, x139709265469895, more);
+pushCont(co, 0, clofun1, 4, import, x140421015034599, x140421015034631, more);
 __nargs = 3;
-__arg0 = globalRef(symvalue_45or);
-__arg1 = x139709264900935;
+__arg0 = globalRef(__symbolTable[70]);
+__arg1 = x140421013091079;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2068,16 +1910,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139709264900967 = __arg1;
+Obj x140421013091111 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265469863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265469895= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421015034599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015034631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = x139709264900967;
-pushCont(co, 1, clofun1, 4, import, x139709265469863, x139709265469895, more);
+Obj export = x140421013091111;
+pushCont(co, 1, clofun1, 4, import, x140421015034599, x140421015034631, more);
 __nargs = 3;
-__arg0 = globalRef(symelem_63);
-__arg1 = x139709265469863;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = x140421015034599;
 __arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2088,16 +1930,16 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139709264901127 = __arg1;
+Obj x140421013091303 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265469863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265469895= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421015034599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015034631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x139709264901127) {
+if (True == x140421013091303) {
 pushCont(co, 2, clofun1, 1, import);
 __nargs = 2;
-__arg0 = globalRef(symsymbol_45_62string);
-__arg1 = x139709265469863;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421015034599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2105,9 +1947,9 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35lookup_45var);
-__arg1 = x139709265469863;
-__arg2 = x139709265469895;
+__arg0 = globalRef(__symbolTable[71]);
+__arg1 = x140421015034599;
+__arg2 = x140421015034631;
 __arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2119,13 +1961,13 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139709264901415 = __arg1;
+Obj x140421013091655 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 3, clofun1, 1, import);
 __nargs = 3;
-__arg0 = globalRef(symstring_45append);
+__arg0 = globalRef(__symbolTable[73]);
 __arg1 = makeCString("#");
-__arg2 = x139709264901415;
+__arg2 = x140421013091655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2135,13 +1977,13 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139709264901447 = __arg1;
+Obj x140421013091687 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 4, clofun1);
 __nargs = 3;
-__arg0 = globalRef(symstring_45append);
+__arg0 = globalRef(__symbolTable[73]);
 __arg1 = import;
-__arg2 = x139709264901447;
+__arg2 = x140421013091687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2151,10 +1993,10 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139709264901479 = __arg1;
+Obj x140421013091719 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symintern);
-__arg1 = x139709264901479;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = x140421013091719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2166,8 +2008,8 @@ label5:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj x139709264907367 = PRIM_EQ(ns, makeCString(""));
-if (True == x139709264907367) {
+Obj x140421013109351 = PRIM_EQ(ns, makeCString(""));
+if (True == x140421013109351) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2176,7 +2018,7 @@ goto *jumpTable[co->ctx.pc.label];
 } else {
 pushCont(co, 6, clofun1, 2, var, ns);
 __nargs = 2;
-__arg0 = globalRef(symsymbol_45cooked_63);
+__arg0 = globalRef(__symbolTable[75]);
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2188,10 +2030,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139709264907527 = __arg1;
+Obj x140421013109543 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264907527) {
+if (True == x140421013109543) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2200,7 +2042,7 @@ goto *jumpTable[co->ctx.pc.label];
 } else {
 pushCont(co, 7, clofun1, 1, ns);
 __nargs = 2;
-__arg0 = globalRef(symsymbol_45_62string);
+__arg0 = globalRef(__symbolTable[72]);
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2212,13 +2054,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139709264907815 = __arg1;
+Obj x140421013109863 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 8, clofun1, 1, ns);
 __nargs = 3;
-__arg0 = globalRef(symstring_45append);
+__arg0 = globalRef(__symbolTable[73]);
 __arg1 = makeCString("#");
-__arg2 = x139709264907815;
+__arg2 = x140421013109863;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2228,13 +2070,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139709264907847 = __arg1;
+Obj x140421013109895 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 9, clofun1);
 __nargs = 3;
-__arg0 = globalRef(symstring_45append);
+__arg0 = globalRef(__symbolTable[73]);
 __arg1 = ns;
-__arg2 = x139709264907847;
+__arg2 = x140421013109895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2244,10 +2086,10 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139709264907879 = __arg1;
+Obj x140421013109991 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symintern);
-__arg1 = x139709264907879;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = x140421013109991;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2260,7 +2102,7 @@ label10:
 Obj sexp = __arg1;
 pushCont(co, 11, clofun1, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2271,12 +2113,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139709264905031 = __arg1;
+Obj x140421013272711 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = x139709264905031;
+Obj path = x140421013272711;
 pushCont(co, 12, clofun1, 1, path);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2287,12 +2129,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139709264905255 = __arg1;
+Obj x140421013272999 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 13, clofun1, 1, path);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35parse_45package);
-__arg1 = x139709264905255;
+__arg0 = globalRef(__symbolTable[80]);
+__arg1 = x140421013272999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2302,10 +2144,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139709264905287 = __arg1;
+Obj x140421013273031 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = x139709264905287;
+__arg0 = x140421013273031;
 __arg1 = makeNative(14, clofun1, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2319,10 +2161,10 @@ label14:
 Obj import = __arg1;
 Obj export = __arg2;
 Obj body = __arg3;
-Obj x139709264905671 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 15, clofun1, 3, export, body, x139709264905671);
+Obj x140421013273415 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 15, clofun1, 3, export, body, x140421013273415);
 __nargs = 3;
-__arg0 = globalRef(symmap);
+__arg0 = globalRef(__symbolTable[147]);
 __arg1 = makeNative(17, clofun1, 1, 0);
 __arg2 = import;
 co->ctx.frees = __arg0;
@@ -2334,21 +2176,21 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139709264906215 = __arg1;
+Obj x140421013274119 = __arg1;
 Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709264905671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139709264906631 = makeCons(export, Nil);
-Obj x139709264906663 = makeCons(symbackquote, x139709264906631);
-Obj x139709264906695 = makeCons(x139709264906663, Nil);
-Obj x139709264906727 = makeCons(sym_42ns_45export_42, x139709264906695);
-Obj x139709264906759 = makeCons(symdef, x139709264906727);
-Obj x139709264906791 = makeCons(x139709264906759, body);
-pushCont(co, 16, clofun1, 1, x139709264905671);
+Obj x140421013273415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013107911 = makeCons(export, Nil);
+Obj x140421013107943 = makeCons(__symbolTable[86], x140421013107911);
+Obj x140421013107975 = makeCons(x140421013107943, Nil);
+Obj x140421013108199 = makeCons(__symbolTable[77], x140421013107975);
+Obj x140421013108231 = makeCons(__symbolTable[133], x140421013108199);
+Obj x140421013108391 = makeCons(x140421013108231, body);
+pushCont(co, 16, clofun1, 1, x140421013273415);
 __nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = x139709264906215;
-__arg2 = x139709264906791;
+__arg0 = globalRef(__symbolTable[98]);
+__arg1 = x140421013274119;
+__arg2 = x140421013108391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2358,15 +2200,15 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139709264906823 = __arg1;
-Obj x139709264905671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709264906855 = makeCons(symbegin, x139709264906823);
-Obj x139709264906887 = makeCons(x139709264906855, Nil);
-Obj x139709264906919 = makeCons(x139709264905671, x139709264906887);
-Obj x139709264906951 = makeCons(closureRef(co, 0), x139709264906919);
-Obj x139709264906983 = makeCons(symns, x139709264906951);
+Obj x140421013108615 = __arg1;
+Obj x140421013273415= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013108647 = makeCons(__symbolTable[89], x140421013108615);
+Obj x140421013108775 = makeCons(x140421013108647, Nil);
+Obj x140421013108839 = makeCons(x140421013273415, x140421013108775);
+Obj x140421013108871 = makeCons(closureRef(co, 0), x140421013108839);
+Obj x140421013108903 = makeCons(__symbolTable[78], x140421013108871);
 __nargs = 2;
-__arg1 = x139709264906983;
+__arg1 = x140421013108903;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2375,10 +2217,10 @@ goto *jumpTable[co->ctx.pc.label];
 label17:
 {
 Obj imp = __arg1;
-Obj x139709264906151 = makeCons(imp, Nil);
-Obj x139709264906183 = makeCons(symimport, x139709264906151);
+Obj x140421013274055 = makeCons(imp, Nil);
+Obj x140421013274087 = makeCons(__symbolTable[81], x140421013274055);
 __nargs = 2;
-__arg1 = x139709264906183;
+__arg1 = x140421013274087;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2389,7 +2231,7 @@ label18:
 Obj data = __arg1;
 Obj k = __arg2;
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45package_45h);
+__arg0 = globalRef(__symbolTable[83]);
 __arg1 = data;
 __arg2 = Nil;
 __arg3 = Nil;
@@ -2403,42 +2245,42 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139709265469671 = __arg1;
-Obj x139709265469703 = __arg2;
-Obj x139709265469767 = __arg3;
-Obj x139709265469799 = co->args[4];
-Obj x139709265469991 = makeNative(20, clofun1, 0, 4, x139709265469767, x139709265469671, x139709265469703, x139709265469799);
-Obj x139709264985799 = PRIM_ISCONS(x139709265469671);
-if (True == x139709264985799) {
-Obj x139709264986055 = PRIM_CAR(x139709265469671);
-Obj x139709264961607 = PRIM_ISCONS(x139709264986055);
-if (True == x139709264961607) {
-Obj x139709264961895 = PRIM_CAR(x139709265469671);
-Obj x139709264961927 = PRIM_CAR(x139709264961895);
-Obj x139709264961959 = PRIM_EQ(symimport, x139709264961927);
-if (True == x139709264961959) {
-Obj x139709264962343 = PRIM_CAR(x139709265469671);
-Obj x139709264962375 = PRIM_CDR(x139709264962343);
-Obj x139709264962407 = PRIM_ISCONS(x139709264962375);
-if (True == x139709264962407) {
-Obj x139709264962727 = PRIM_CAR(x139709265469671);
-Obj x139709264962759 = PRIM_CDR(x139709264962727);
-Obj x139709264962791 = PRIM_CAR(x139709264962759);
-Obj lib = x139709264962791;
-Obj x139709264965063 = PRIM_CAR(x139709265469671);
-Obj x139709264965095 = PRIM_CDR(x139709264965063);
-Obj x139709264965127 = PRIM_CDR(x139709264965095);
-Obj x139709264965159 = PRIM_EQ(Nil, x139709264965127);
-if (True == x139709264965159) {
-Obj x139709264965319 = PRIM_CDR(x139709265469671);
-Obj rest = x139709264965319;
-Obj x139709264965479 = makeCons(lib, x139709265469703);
+Obj x140421015031975 = __arg1;
+Obj x140421015032039 = __arg2;
+Obj x140421015032071 = __arg3;
+Obj x140421015032103 = co->args[4];
+Obj x140421015032295 = makeNative(20, clofun1, 0, 4, x140421015032071, x140421015031975, x140421015032039, x140421015032103);
+Obj x140421013390375 = PRIM_ISCONS(x140421015031975);
+if (True == x140421013390375) {
+Obj x140421013390791 = PRIM_CAR(x140421015031975);
+Obj x140421013390855 = PRIM_ISCONS(x140421013390791);
+if (True == x140421013390855) {
+Obj x140421013391335 = PRIM_CAR(x140421015031975);
+Obj x140421013391367 = PRIM_CAR(x140421013391335);
+Obj x140421013391399 = PRIM_EQ(__symbolTable[81], x140421013391367);
+if (True == x140421013391399) {
+Obj x140421013391847 = PRIM_CAR(x140421015031975);
+Obj x140421013391879 = PRIM_CDR(x140421013391847);
+Obj x140421013392103 = PRIM_ISCONS(x140421013391879);
+if (True == x140421013392103) {
+Obj x140421013392679 = PRIM_CAR(x140421015031975);
+Obj x140421013392711 = PRIM_CDR(x140421013392679);
+Obj x140421013392775 = PRIM_CAR(x140421013392711);
+Obj lib = x140421013392775;
+Obj x140421013393287 = PRIM_CAR(x140421015031975);
+Obj x140421013270599 = PRIM_CDR(x140421013393287);
+Obj x140421013270631 = PRIM_CDR(x140421013270599);
+Obj x140421013270663 = PRIM_EQ(Nil, x140421013270631);
+if (True == x140421013270663) {
+Obj x140421013270823 = PRIM_CDR(x140421015031975);
+Obj rest = x140421013270823;
+Obj x140421013271079 = makeCons(lib, x140421015032039);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45package_45h);
+__arg0 = globalRef(__symbolTable[83]);
 __arg1 = rest;
-__arg2 = x139709264965479;
-__arg3 = x139709265469767;
-co->args[4] = x139709265469799;
+__arg2 = x140421013271079;
+__arg3 = x140421015032071;
+co->args[4] = x140421015032103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2446,16 +2288,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265469991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139709265469991;
+__arg0 = x140421015032295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2464,7 +2297,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469991;
+__arg0 = x140421015032295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2473,7 +2306,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469991;
+__arg0 = x140421015032295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2482,7 +2315,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469991;
+__arg0 = x140421015032295;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421015032295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2493,23 +2335,23 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139709265470983 = makeNative(21, clofun1, 0, 4, closureRef(co, 3), closureRef(co, 2), closureRef(co, 0), closureRef(co, 1));
-Obj x139709264983687 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139709264983687) {
-Obj x139709264983975 = PRIM_CAR(closureRef(co, 1));
-Obj x139709264984039 = PRIM_ISCONS(x139709264983975);
-if (True == x139709264984039) {
-Obj x139709264984391 = PRIM_CAR(closureRef(co, 1));
-Obj x139709264984455 = PRIM_CAR(x139709264984391);
-Obj x139709264984519 = PRIM_EQ(symexport, x139709264984455);
-if (True == x139709264984519) {
-Obj x139709264984775 = PRIM_CAR(closureRef(co, 1));
-Obj x139709264984807 = PRIM_CDR(x139709264984775);
-Obj more = x139709264984807;
-Obj x139709264985095 = PRIM_CDR(closureRef(co, 1));
-Obj rest = x139709264985095;
+Obj x140421015033223 = makeNative(21, clofun1, 0, 4, closureRef(co, 3), closureRef(co, 2), closureRef(co, 0), closureRef(co, 1));
+Obj x140421013469607 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421013469607) {
+Obj x140421013469991 = PRIM_CAR(closureRef(co, 1));
+Obj x140421013470119 = PRIM_ISCONS(x140421013469991);
+if (True == x140421013470119) {
+Obj x140421013470727 = PRIM_CAR(closureRef(co, 1));
+Obj x140421013470759 = PRIM_CAR(x140421013470727);
+Obj x140421013470791 = PRIM_EQ(__symbolTable[82], x140421013470759);
+if (True == x140421013470791) {
+Obj x140421013389319 = PRIM_CAR(closureRef(co, 1));
+Obj x140421013389351 = PRIM_CDR(x140421013389319);
+Obj more = x140421013389351;
+Obj x140421013389671 = PRIM_CDR(closureRef(co, 1));
+Obj rest = x140421013389671;
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse_45package_45h);
+__arg0 = globalRef(__symbolTable[83]);
 __arg1 = rest;
 __arg2 = closureRef(co, 2);
 __arg3 = more;
@@ -2521,7 +2363,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265470983;
+__arg0 = x140421015033223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2530,7 +2372,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470983;
+__arg0 = x140421015033223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2539,7 +2381,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470983;
+__arg0 = x140421015033223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2552,7 +2394,7 @@ label21:
 {
 PUSH_CONT_0(co, 22, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2563,10 +2405,10 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139709264983367 = __arg1;
+Obj x140421013469351 = __arg1;
 __nargs = 4;
 __arg0 = closureRef(co, 0);
-__arg1 = x139709264983367;
+__arg1 = x140421013469351;
 __arg2 = closureRef(co, 2);
 __arg3 = closureRef(co, 3);
 co->ctx.frees = __arg0;
@@ -2581,7 +2423,7 @@ label23:
 Obj exp = __arg1;
 pushCont(co, 24, clofun1, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2592,11 +2434,11 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139709264982407 = __arg1;
+Obj x140421013468359 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 25, clofun1, 1, x139709264982407);
+pushCont(co, 25, clofun1, 1, x140421013468359);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2607,12 +2449,12 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139709264982503 = __arg1;
-Obj x139709264982407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013468519 = __arg1;
+Obj x140421013468359= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
-__arg1 = x139709264982407;
-__arg2 = x139709264982503;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = x140421013468359;
+__arg2 = x140421013468519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2626,7 +2468,7 @@ Obj fn = __arg1;
 Obj arglist = __arg2;
 pushCont(co, 27, clofun1, 2, arglist, fn);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = arglist;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2637,13 +2479,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139709265046055 = __arg1;
+Obj x140421013564519 = __arg1;
 Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 28, clofun1, 2, arglist, fn);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265046055;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421013564519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2653,14 +2495,14 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139709265046087 = __arg1;
+Obj x140421013564551 = __arg1;
 Obj arglist= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709265046087) {
-Obj x139709265046375 = PRIM_CAR(arglist);
-pushCont(co, 30, clofun1, 2, x139709265046375, fn);
+if (True == x140421013564551) {
+Obj x140421013564967 = PRIM_CAR(arglist);
+pushCont(co, 30, clofun1, 2, x140421013564967, fn);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = arglist;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2668,13 +2510,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265046983 = PRIM_CAR(arglist);
-Obj x139709265047207 = PRIM_CDR(arglist);
-pushCont(co, 29, clofun1, 2, x139709265046983, fn);
+Obj x140421013467303 = PRIM_CAR(arglist);
+Obj x140421013467591 = PRIM_CDR(arglist);
+pushCont(co, 29, clofun1, 2, x140421013467303, fn);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35rewrite_45fold_45apply);
+__arg0 = globalRef(__symbolTable[85]);
 __arg1 = fn;
-__arg2 = x139709265047207;
+__arg2 = x140421013467591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2685,14 +2527,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139709265047239 = __arg1;
-Obj x139709265046983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013467623 = __arg1;
+Obj x140421013467303= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265047271 = makeCons(x139709265047239, Nil);
-Obj x139709265047303 = makeCons(x139709265046983, x139709265047271);
-Obj x139709265047335 = makeCons(fn, x139709265047303);
+Obj x140421013467655 = makeCons(x140421013467623, Nil);
+Obj x140421013467687 = makeCons(x140421013467303, x140421013467655);
+Obj x140421013467719 = makeCons(fn, x140421013467687);
 __nargs = 2;
-__arg1 = x139709265047335;
+__arg1 = x140421013467719;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2700,14 +2542,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label30:
 {
-Obj x139709265046599 = __arg1;
-Obj x139709265046375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013565127 = __arg1;
+Obj x140421013564967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265046631 = makeCons(x139709265046599, Nil);
-Obj x139709265046663 = makeCons(x139709265046375, x139709265046631);
-Obj x139709265046695 = makeCons(fn, x139709265046663);
+Obj x140421013565159 = makeCons(x140421013565127, Nil);
+Obj x140421013565191 = makeCons(x140421013564967, x140421013565159);
+Obj x140421013565351 = makeCons(fn, x140421013565191);
 __nargs = 2;
-__arg1 = x139709265046695;
+__arg1 = x140421013565351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2718,7 +2560,7 @@ label31:
 Obj exp = __arg1;
 PUSH_CONT_0(co, 32, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2729,10 +2571,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139709265045351 = __arg1;
+Obj x140421013563943 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = x139709265045351;
+__arg0 = globalRef(__symbolTable[88]);
+__arg1 = x140421013563943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2742,33 +2584,33 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139709265470855 = __arg1;
-Obj x139709265110599 = primIsSymbol(x139709265470855);
-if (True == x139709265110599) {
-Obj x139709265110855 = makeCons(x139709265470855, Nil);
-Obj x139709265110919 = makeCons(symquote, x139709265110855);
+Obj x140421015034055 = __arg1;
+Obj x140421013625479 = primIsSymbol(x140421015034055);
+if (True == x140421013625479) {
+Obj x140421013625671 = makeCons(x140421015034055, Nil);
+Obj x140421013625703 = makeCons(__symbolTable[139], x140421013625671);
 __nargs = 2;
-__arg1 = x139709265110919;
+__arg1 = x140421013625703;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265471239 = makeNative(34, clofun1, 0, 1, x139709265470855);
-Obj x139709265112423 = PRIM_ISCONS(x139709265470855);
-if (True == x139709265112423) {
-Obj x139709265112839 = PRIM_CAR(x139709265470855);
-Obj x139709265112871 = PRIM_EQ(symunquote, x139709265112839);
-if (True == x139709265112871) {
-Obj x139709265043559 = PRIM_CDR(x139709265470855);
-Obj x139709265043591 = PRIM_ISCONS(x139709265043559);
-if (True == x139709265043591) {
-Obj x139709265043911 = PRIM_CDR(x139709265470855);
-Obj x139709265043943 = PRIM_CAR(x139709265043911);
-Obj x = x139709265043943;
-Obj x139709265044423 = PRIM_CDR(x139709265470855);
-Obj x139709265044455 = PRIM_CDR(x139709265044423);
-Obj x139709265044487 = PRIM_EQ(Nil, x139709265044455);
-if (True == x139709265044487) {
+Obj x140421015034343 = makeNative(34, clofun1, 0, 1, x140421015034055);
+Obj x140421013561543 = PRIM_ISCONS(x140421015034055);
+if (True == x140421013561543) {
+Obj x140421013561831 = PRIM_CAR(x140421015034055);
+Obj x140421013561863 = PRIM_EQ(__symbolTable[87], x140421013561831);
+if (True == x140421013561863) {
+Obj x140421013562215 = PRIM_CDR(x140421015034055);
+Obj x140421013562247 = PRIM_ISCONS(x140421013562215);
+if (True == x140421013562247) {
+Obj x140421013562631 = PRIM_CDR(x140421015034055);
+Obj x140421013562663 = PRIM_CAR(x140421013562631);
+Obj x = x140421013562663;
+Obj x140421013563079 = PRIM_CDR(x140421015034055);
+Obj x140421013563143 = PRIM_CDR(x140421013563079);
+Obj x140421013563175 = PRIM_EQ(Nil, x140421013563143);
+if (True == x140421013563175) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2776,7 +2618,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265471239;
+__arg0 = x140421015034343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2785,7 +2627,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471239;
+__arg0 = x140421015034343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2794,7 +2636,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471239;
+__arg0 = x140421015034343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2803,7 +2645,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265471239;
+__arg0 = x140421015034343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2815,18 +2657,18 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139709265111399 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265111399) {
-Obj x139709265111623 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139709265111623;
-Obj x139709265111911 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139709265111911;
-Obj x139709265112135 = makeCons(x, more);
+Obj x140421013626055 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013626055) {
+Obj x140421013626311 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421013626311;
+Obj x140421013626535 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421013626535;
+Obj x140421013626759 = makeCons(x, more);
 PUSH_CONT_0(co, 35, clofun1);
 __nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = x139709265112135;
+__arg0 = globalRef(__symbolTable[147]);
+__arg1 = globalRef(__symbolTable[88]);
+__arg2 = x140421013626759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2843,10 +2685,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label35:
 {
-Obj x139709265112167 = __arg1;
-Obj x139709265112199 = makeCons(symlist, x139709265112167);
+Obj x140421013626855 = __arg1;
+Obj x140421013561351 = makeCons(__symbolTable[135], x140421013626855);
 __nargs = 2;
-__arg1 = x139709265112199;
+__arg1 = x140421013561351;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2855,10 +2697,10 @@ goto *jumpTable[co->ctx.pc.label];
 label36:
 {
 Obj exp = __arg1;
-Obj x139709265110151 = PRIM_CDR(exp);
+Obj x140421013625063 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = x139709265110151;
+__arg0 = globalRef(__symbolTable[91]);
+__arg1 = x140421013625063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2868,15 +2710,15 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139709265469607 = __arg1;
-Obj x139709265469735 = makeNative(38, clofun1, 0, 1, x139709265469607);
-Obj x139709265109063 = PRIM_ISCONS(x139709265469607);
-if (True == x139709265109063) {
-Obj x139709265109255 = PRIM_CAR(x139709265469607);
-Obj x = x139709265109255;
-Obj x139709265109511 = PRIM_CDR(x139709265469607);
-Obj x139709265109543 = PRIM_EQ(Nil, x139709265109511);
-if (True == x139709265109543) {
+Obj x140421015032903 = __arg1;
+Obj x140421015032999 = makeNative(38, clofun1, 0, 1, x140421015032903);
+Obj x140421013623719 = PRIM_ISCONS(x140421015032903);
+if (True == x140421013623719) {
+Obj x140421013623943 = PRIM_CAR(x140421015032903);
+Obj x = x140421013623943;
+Obj x140421013624231 = PRIM_CDR(x140421015032903);
+Obj x140421013624295 = PRIM_EQ(Nil, x140421013624231);
+if (True == x140421013624295) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2884,7 +2726,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265469735;
+__arg0 = x140421015032999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2893,7 +2735,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469735;
+__arg0 = x140421015032999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2904,32 +2746,32 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139709265470055 = makeNative(39, clofun1, 0, 1, closureRef(co, 0));
-Obj x139709265143687 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265143687) {
-Obj x139709265143879 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139709265143879;
-Obj x139709265144231 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265144263 = PRIM_ISCONS(x139709265144231);
-if (True == x139709265144263) {
-Obj x139709265144551 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265144775 = PRIM_CAR(x139709265144551);
-Obj y = x139709265144775;
-Obj x139709265145159 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265145191 = PRIM_CDR(x139709265145159);
-Obj x139709265145223 = PRIM_EQ(Nil, x139709265145191);
-if (True == x139709265145223) {
-Obj x139709265145447 = makeCons(y, Nil);
-Obj x139709265145511 = makeCons(x, x139709265145447);
-Obj x139709265145543 = makeCons(symdo, x139709265145511);
+Obj x140421015033319 = makeNative(39, clofun1, 0, 1, closureRef(co, 0));
+Obj x140421013682823 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013682823) {
+Obj x140421013683111 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421013683111;
+Obj x140421013683431 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013683495 = PRIM_ISCONS(x140421013683431);
+if (True == x140421013683495) {
+Obj x140421013683783 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013683815 = PRIM_CAR(x140421013683783);
+Obj y = x140421013683815;
+Obj x140421013622855 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013622951 = PRIM_CDR(x140421013622855);
+Obj x140421013622983 = PRIM_EQ(Nil, x140421013622951);
+if (True == x140421013622983) {
+Obj x140421013623207 = makeCons(y, Nil);
+Obj x140421013623239 = makeCons(x, x140421013623207);
+Obj x140421013623303 = makeCons(__symbolTable[90], x140421013623239);
 __nargs = 2;
-__arg1 = x139709265145543;
+__arg1 = x140421013623303;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265470055;
+__arg0 = x140421015033319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2938,7 +2780,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470055;
+__arg0 = x140421015033319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2947,7 +2789,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470055;
+__arg0 = x140421015033319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2958,15 +2800,15 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139709265142311 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265142311) {
-Obj x139709265142695 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139709265142695;
-Obj x139709265142887 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139709265142887;
+Obj x140421013681447 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013681447) {
+Obj x140421013681671 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421013681671;
+Obj x140421013682087 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421013682087;
 pushCont(co, 40, clofun1, 1, x);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45begin);
+__arg0 = globalRef(__symbolTable[91]);
 __arg1 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2975,7 +2817,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2987,13 +2829,13 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139709265143239 = __arg1;
+Obj x140421013682439 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265143271 = makeCons(x139709265143239, Nil);
-Obj x139709265143303 = makeCons(x, x139709265143271);
-Obj x139709265143335 = makeCons(symdo, x139709265143303);
+Obj x140421013682471 = makeCons(x140421013682439, Nil);
+Obj x140421013682503 = makeCons(x, x140421013682471);
+Obj x140421013682535 = makeCons(__symbolTable[90], x140421013682503);
 __nargs = 2;
-__arg1 = x139709265143335;
+__arg1 = x140421013682535;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3004,7 +2846,7 @@ label41:
 Obj exp = __arg1;
 PUSH_CONT_0(co, 42, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg0 = globalRef(__symbolTable[141]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3015,11 +2857,11 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139709265231527 = __arg1;
+Obj x140421013680583 = __arg1;
 PUSH_CONT_0(co, 43, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45namespace);
-__arg1 = x139709265231527;
+__arg0 = globalRef(__symbolTable[94]);
+__arg1 = x140421013680583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3029,10 +2871,10 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139709265231559 = __arg1;
+Obj x140421013680615 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35peval);
-__arg1 = x139709265231559;
+__arg0 = globalRef(__symbolTable[92]);
+__arg1 = x140421013680615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3054,7 +2896,7 @@ label45:
 {
 Obj exp = __arg1;
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35parse);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = Nil;
 __arg2 = makeCString("");
 __arg3 = Nil;
@@ -3071,7 +2913,7 @@ label46:
 Obj exp = __arg1;
 pushCont(co, 47, clofun1, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3082,12 +2924,12 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139709265228711 = __arg1;
+Obj x140421015033127 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 48, clofun1, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = x139709265228711;
+__arg0 = globalRef(__symbolTable[104]);
+__arg1 = x140421015033127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3097,12 +2939,12 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139709265228775 = __arg1;
+Obj x140421015033159 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = x139709265228775;
+Obj body = x140421015033159;
 pushCont(co, 49, clofun1, 2, exp, body);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rules_45arg_45count);
+__arg0 = globalRef(__symbolTable[97]);
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3113,13 +2955,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139709265228967 = __arg1;
+Obj x140421015033415 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = x139709265228967;
+Obj nargs = x140421015033415;
 pushCont(co, 0, clofun2, 2, exp, body);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
+__arg0 = globalRef(__symbolTable[96]);
 __arg1 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3150,13 +2992,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139709265229351 = __arg1;
+Obj x140421015033607 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = x139709265229351;
+Obj args = x140421015033607;
 pushCont(co, 1, clofun2, 2, body, args);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3167,18 +3009,18 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139709265229575 = __arg1;
+Obj x140421015034087 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265230023 = makeCons(symlist, args);
-Obj x139709265230055 = makeCons(x139709265230023, body);
-Obj x139709265230087 = makeCons(symmatch, x139709265230055);
-Obj x139709265230119 = makeCons(x139709265230087, Nil);
-Obj x139709265230215 = makeCons(args, x139709265230119);
-Obj x139709265230247 = makeCons(x139709265229575, x139709265230215);
-Obj x139709265230279 = makeCons(symdefun, x139709265230247);
+Obj x140421015034567 = makeCons(__symbolTable[135], args);
+Obj x140421015034695 = makeCons(x140421015034567, body);
+Obj x140421015034727 = makeCons(__symbolTable[107], x140421015034695);
+Obj x140421015034759 = makeCons(x140421015034727, Nil);
+Obj x140421015034791 = makeCons(args, x140421015034759);
+Obj x140421015034823 = makeCons(x140421015034087, x140421015034791);
+Obj x140421015034855 = makeCons(__symbolTable[134], x140421015034823);
 __nargs = 2;
-__arg1 = x139709265230279;
+__arg1 = x140421015034855;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3187,20 +3029,20 @@ goto *jumpTable[co->ctx.pc.label];
 label2:
 {
 Obj n = __arg1;
-Obj x139709265268615 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == x139709265268615) {
+Obj x140421015346919 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == x140421015346919) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265227879 = primGenSym();
-Obj x139709265228039 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 3, clofun2, 1, x139709265227879);
+Obj x140421015347143 = primGenSym();
+Obj x140421015032263 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 3, clofun2, 1, x140421015347143);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = x139709265228039;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = x140421015032263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3211,11 +3053,11 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139709265228071 = __arg1;
-Obj x139709265227879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265228103 = makeCons(x139709265227879, x139709265228071);
+Obj x140421015032327 = __arg1;
+Obj x140421015347143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015032487 = makeCons(x140421015347143, x140421015032327);
 __nargs = 2;
-__arg1 = x139709265228103;
+__arg1 = x140421015032487;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3226,7 +3068,7 @@ label4:
 Obj rules = __arg1;
 PUSH_CONT_0(co, 5, clofun2);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
+__arg0 = globalRef(__symbolTable[103]);
 __arg1 = Nil;
 __arg2 = rules;
 co->ctx.frees = __arg0;
@@ -3238,11 +3080,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139709265266279 = __arg1;
-Obj pats = x139709265266279;
+Obj x140421015344679 = __arg1;
+Obj pats = x140421015344679;
 PUSH_CONT_0(co, 6, clofun2);
 __nargs = 3;
-__arg0 = globalRef(symmap);
+__arg0 = globalRef(__symbolTable[147]);
 __arg1 = makeNative(10, clofun2, 1, 0);
 __arg2 = pats;
 co->ctx.frees = __arg0;
@@ -3254,16 +3096,16 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139709265266791 = __arg1;
-Obj counts = x139709265266791;
-Obj x139709265267047 = PRIM_CAR(counts);
-Obj n = x139709265267047;
-Obj x139709265267815 = PRIM_CDR(counts);
+Obj x140421015345159 = __arg1;
+Obj counts = x140421015345159;
+Obj x140421015345319 = PRIM_CAR(counts);
+Obj n = x140421015345319;
+Obj x140421015346279 = PRIM_CDR(counts);
 pushCont(co, 7, clofun2, 1, n);
 __nargs = 3;
-__arg0 = globalRef(symfilter);
+__arg0 = globalRef(__symbolTable[99]);
 __arg1 = makeNative(9, clofun2, 1, 1, n);
-__arg2 = x139709265267815;
+__arg2 = x140421015346279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3273,12 +3115,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139709265267847 = __arg1;
+Obj x140421015346311 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 8, clofun2, 1, n);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265267847;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421015346311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3288,12 +3130,12 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139709265267911 = __arg1;
+Obj x140421015346343 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265267943 = primNot(x139709265267911);
-if (True == x139709265267943) {
+Obj x140421015346375 = primNot(x140421015346343);
+if (True == x140421015346375) {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("inconsistent func rule args count");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3312,10 +3154,10 @@ goto *jumpTable[co->ctx.pc.label];
 label9:
 {
 Obj x = __arg1;
-Obj x139709265267655 = PRIM_EQ(closureRef(co, 0), x);
-Obj x139709265267687 = primNot(x139709265267655);
+Obj x140421015345895 = PRIM_EQ(closureRef(co, 0), x);
+Obj x140421015345927 = primNot(x140421015345895);
 __nargs = 2;
-__arg1 = x139709265267687;
+__arg1 = x140421015345927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3324,10 +3166,10 @@ goto *jumpTable[co->ctx.pc.label];
 label10:
 {
 Obj x = __arg1;
-Obj x139709265266759 = PRIM_CDR(x);
+Obj x140421015345063 = PRIM_CDR(x);
 __nargs = 2;
-__arg0 = globalRef(symlength);
-__arg1 = x139709265266759;
+__arg0 = globalRef(__symbolTable[101]);
+__arg1 = x140421015345063;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3339,20 +3181,20 @@ label11:
 {
 Obj l1 = __arg1;
 Obj l2 = __arg2;
-Obj x139709265265191 = PRIM_EQ(l1, Nil);
-if (True == x139709265265191) {
+Obj x140421015343559 = PRIM_EQ(l1, Nil);
+if (True == x140421015343559) {
 __nargs = 2;
 __arg1 = l2;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265265383 = PRIM_CAR(l1);
-Obj x139709265265799 = PRIM_CDR(l1);
-pushCont(co, 12, clofun2, 1, x139709265265383);
+Obj x140421015343719 = PRIM_CAR(l1);
+Obj x140421015343879 = PRIM_CDR(l1);
+pushCont(co, 12, clofun2, 1, x140421015343719);
 __nargs = 3;
-__arg0 = globalRef(symappend);
-__arg1 = x139709265265799;
+__arg0 = globalRef(__symbolTable[98]);
+__arg1 = x140421015343879;
 __arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3364,11 +3206,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139709265265831 = __arg1;
-Obj x139709265265383= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265265863 = makeCons(x139709265265383, x139709265265831);
+Obj x140421015343911 = __arg1;
+Obj x140421015343719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015344039 = makeCons(x140421015343719, x140421015343911);
 __nargs = 2;
-__arg1 = x139709265265863;
+__arg1 = x140421015344039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3379,7 +3221,7 @@ label13:
 Obj fn = __arg1;
 Obj l = __arg2;
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg0 = globalRef(__symbolTable[100]);
 __arg1 = Nil;
 __arg2 = fn;
 __arg3 = l;
@@ -3395,13 +3237,13 @@ label14:
 Obj res = __arg1;
 Obj fn = __arg2;
 Obj l = __arg3;
-Obj x139709265341031 = PRIM_ISCONS(l);
-if (True == x139709265341031) {
-Obj x139709265341255 = PRIM_CAR(l);
+Obj x140421015386663 = PRIM_ISCONS(l);
+if (True == x140421015386663) {
+Obj x140421015386951 = PRIM_CAR(l);
 pushCont(co, 15, clofun2, 3, l, res, fn);
 __nargs = 2;
 __arg0 = fn;
-__arg1 = x139709265341255;
+__arg1 = x140421015386951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3409,7 +3251,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3421,31 +3263,31 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139709265341383 = __arg1;
+Obj x140421015386983 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139709265341383) {
-Obj x139709265341607 = PRIM_CAR(l);
-Obj x139709265341671 = makeCons(x139709265341607, res);
-Obj x139709265341991 = PRIM_CDR(l);
+if (True == x140421015386983) {
+Obj x140421015387239 = PRIM_CAR(l);
+Obj x140421015387271 = makeCons(x140421015387239, res);
+Obj x140421015387527 = PRIM_CDR(l);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = x139709265341671;
+__arg0 = globalRef(__symbolTable[100]);
+__arg1 = x140421015387271;
 __arg2 = fn;
-__arg3 = x139709265341991;
+__arg3 = x140421015387527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265342183 = PRIM_CDR(l);
+Obj x140421015387751 = PRIM_CDR(l);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35filter_45h);
+__arg0 = globalRef(__symbolTable[100]);
 __arg1 = res;
 __arg2 = fn;
-__arg3 = x139709265342183;
+__arg3 = x140421015387751;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3458,7 +3300,7 @@ label16:
 {
 Obj l = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
+__arg0 = globalRef(__symbolTable[102]);
 __arg1 = MAKE_NUMBER(0);
 __arg2 = l;
 co->ctx.frees = __arg0;
@@ -3472,20 +3314,20 @@ label17:
 {
 Obj i = __arg1;
 Obj l = __arg2;
-Obj x139709265339911 = PRIM_EQ(l, Nil);
-if (True == x139709265339911) {
+Obj x140421015385447 = PRIM_EQ(l, Nil);
+if (True == x140421015385447) {
 __nargs = 2;
 __arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265340135 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj x139709265340231 = PRIM_CDR(l);
+Obj x140421015385735 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x140421015385831 = PRIM_CDR(l);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = x139709265340135;
-__arg2 = x139709265340231;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = x140421015385735;
+__arg2 = x140421015385831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3500,7 +3342,7 @@ Obj res = __arg1;
 Obj rules = __arg2;
 pushCont(co, 19, clofun2, 2, res, rules);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
+__arg0 = globalRef(__symbolTable[161]);
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3511,12 +3353,12 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139709265338759 = __arg1;
+Obj x140421015384327 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709265338759) {
+if (True == x140421015384327) {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3524,11 +3366,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265339207 = PRIM_CAR(rules);
-Obj x139709265339239 = makeCons(x139709265339207, res);
-pushCont(co, 20, clofun2, 1, x139709265339239);
+Obj x140421015384647 = PRIM_CAR(rules);
+Obj x140421015384711 = makeCons(x140421015384647, res);
+pushCont(co, 20, clofun2, 1, x140421015384711);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3540,12 +3382,12 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139709265339335 = __arg1;
-Obj x139709265339239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015384807 = __arg1;
+Obj x140421015384711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = x139709265339239;
-__arg2 = x139709265339335;
+__arg0 = globalRef(__symbolTable[103]);
+__arg1 = x140421015384711;
+__arg2 = x140421015384807;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3557,7 +3399,7 @@ label21:
 {
 Obj input = __arg1;
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg0 = globalRef(__symbolTable[106]);
 __arg1 = input;
 __arg2 = Nil;
 __arg3 = Nil;
@@ -3573,10 +3415,10 @@ label22:
 Obj input = __arg1;
 Obj current = __arg2;
 Obj result = __arg3;
-Obj x139709264964455 = PRIM_EQ(Nil, input);
-if (True == x139709264964455) {
+Obj x140421013106887 = PRIM_EQ(Nil, input);
+if (True == x140421013106887) {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = result;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3584,45 +3426,45 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265469639 = makeNative(24, clofun2, 0, 3, input, current, result);
-Obj x139709265431271 = PRIM_ISCONS(input);
-if (True == x139709265431271) {
-Obj x139709265431495 = PRIM_CAR(input);
-Obj x139709265431527 = PRIM_EQ(sym_61_62, x139709265431495);
-if (True == x139709265431527) {
-Obj x139709265431783 = PRIM_CDR(input);
-Obj x139709265431879 = PRIM_ISCONS(x139709265431783);
-if (True == x139709265431879) {
-Obj x139709265432167 = PRIM_CDR(input);
-Obj x139709265432263 = PRIM_CAR(x139709265432167);
-Obj act = x139709265432263;
-Obj x139709265432551 = PRIM_CDR(input);
-Obj x139709265367079 = PRIM_CDR(x139709265432551);
-Obj x139709265367111 = PRIM_ISCONS(x139709265367079);
-if (True == x139709265367111) {
-Obj x139709265367623 = PRIM_CDR(input);
-Obj x139709265367655 = PRIM_CDR(x139709265367623);
-Obj x139709265367687 = PRIM_CAR(x139709265367655);
-Obj x139709265367719 = PRIM_EQ(symwhere, x139709265367687);
-if (True == x139709265367719) {
-Obj x139709265368135 = PRIM_CDR(input);
-Obj x139709265368167 = PRIM_CDR(x139709265368135);
-Obj x139709265368199 = PRIM_CDR(x139709265368167);
-Obj x139709265368231 = PRIM_ISCONS(x139709265368199);
-if (True == x139709265368231) {
-Obj x139709265368647 = PRIM_CDR(input);
-Obj x139709265368679 = PRIM_CDR(x139709265368647);
-Obj x139709265368839 = PRIM_CDR(x139709265368679);
-Obj x139709265368871 = PRIM_CAR(x139709265368839);
-Obj pred = x139709265368871;
-Obj x139709265369255 = PRIM_CDR(input);
-Obj x139709265369287 = PRIM_CDR(x139709265369255);
-Obj x139709265369319 = PRIM_CDR(x139709265369287);
-Obj x139709265369351 = PRIM_CDR(x139709265369319);
-Obj remain = x139709265369351;
+Obj x140421015032007 = makeNative(24, clofun2, 0, 3, input, current, result);
+Obj x140421013091271 = PRIM_ISCONS(input);
+if (True == x140421013091271) {
+Obj x140421013091495 = PRIM_CAR(input);
+Obj x140421013091527 = PRIM_EQ(__symbolTable[105], x140421013091495);
+if (True == x140421013091527) {
+Obj x140421013091751 = PRIM_CDR(input);
+Obj x140421013091783 = PRIM_ISCONS(x140421013091751);
+if (True == x140421013091783) {
+Obj x140421013092007 = PRIM_CDR(input);
+Obj x140421013092039 = PRIM_CAR(x140421013092007);
+Obj act = x140421013092039;
+Obj x140421013092327 = PRIM_CDR(input);
+Obj x140421013092359 = PRIM_CDR(x140421013092327);
+Obj x140421013092391 = PRIM_ISCONS(x140421013092359);
+if (True == x140421013092391) {
+Obj x140421013092743 = PRIM_CDR(input);
+Obj x140421013092775 = PRIM_CDR(x140421013092743);
+Obj x140421013092807 = PRIM_CAR(x140421013092775);
+Obj x140421013092839 = PRIM_EQ(__symbolTable[110], x140421013092807);
+if (True == x140421013092839) {
+Obj x140421013093191 = PRIM_CDR(input);
+Obj x140421013093223 = PRIM_CDR(x140421013093191);
+Obj x140421013093255 = PRIM_CDR(x140421013093223);
+Obj x140421013093287 = PRIM_ISCONS(x140421013093255);
+if (True == x140421013093287) {
+Obj x140421013093639 = PRIM_CDR(input);
+Obj x140421013093671 = PRIM_CDR(x140421013093639);
+Obj x140421013093703 = PRIM_CDR(x140421013093671);
+Obj x140421013093735 = PRIM_CAR(x140421013093703);
+Obj pred = x140421013093735;
+Obj x140421013094087 = PRIM_CDR(input);
+Obj x140421013094119 = PRIM_CDR(x140421013094087);
+Obj x140421013094151 = PRIM_CDR(x140421013094119);
+Obj x140421013094183 = PRIM_CDR(x140421013094151);
+Obj remain = x140421013094183;
 pushCont(co, 23, clofun2, 4, act, pred, result, remain);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = current;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3631,7 +3473,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3640,7 +3482,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3649,7 +3491,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3658,7 +3500,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3667,7 +3509,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3676,7 +3518,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265469639;
+__arg0 = x140421015032007;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3688,23 +3530,23 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139709265369575 = __arg1;
+Obj x140421012992007 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj result= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139709265369607 = makeCons(symlist, x139709265369575);
-Obj pat = x139709265369607;
-Obj x139709265370023 = makeCons(act, Nil);
-Obj x139709265370055 = makeCons(pred, x139709265370023);
-Obj x139709265370087 = makeCons(symwhere, x139709265370055);
-Obj x139709265370215 = makeCons(pat, result);
-Obj x139709265370247 = makeCons(x139709265370087, x139709265370215);
+Obj x140421012992039 = makeCons(__symbolTable[135], x140421012992007);
+Obj pat = x140421012992039;
+Obj x140421012992391 = makeCons(act, Nil);
+Obj x140421012992423 = makeCons(pred, x140421012992391);
+Obj x140421012992455 = makeCons(__symbolTable[110], x140421012992423);
+Obj x140421012992551 = makeCons(pat, result);
+Obj x140421012992583 = makeCons(x140421012992455, x140421012992551);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg0 = globalRef(__symbolTable[106]);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x139709265370247;
+__arg3 = x140421012992583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3714,24 +3556,24 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139709265470087 = makeNative(26, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139709265472679 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265472679) {
-Obj x139709265473383 = PRIM_CAR(closureRef(co, 0));
-Obj x139709265428615 = PRIM_EQ(sym_61_62, x139709265473383);
-if (True == x139709265428615) {
-Obj x139709265429031 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265429063 = PRIM_ISCONS(x139709265429031);
-if (True == x139709265429063) {
-Obj x139709265429511 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265429543 = PRIM_CAR(x139709265429511);
-Obj act = x139709265429543;
-Obj x139709265429927 = PRIM_CDR(closureRef(co, 0));
-Obj x139709265429959 = PRIM_CDR(x139709265429927);
-Obj remain = x139709265429959;
+Obj x140421015032455 = makeNative(26, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421013109671 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013109671) {
+Obj x140421013109927 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013109959 = PRIM_EQ(__symbolTable[105], x140421013109927);
+if (True == x140421013109959) {
+Obj x140421013110215 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013110247 = PRIM_ISCONS(x140421013110215);
+if (True == x140421013110247) {
+Obj x140421013110503 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013110535 = PRIM_CAR(x140421013110503);
+Obj act = x140421013110535;
+Obj x140421013090311 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013090343 = PRIM_CDR(x140421013090311);
+Obj remain = x140421013090343;
 pushCont(co, 25, clofun2, 2, act, remain);
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3740,7 +3582,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139709265470087;
+__arg0 = x140421015032455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3749,7 +3591,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470087;
+__arg0 = x140421015032455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3758,7 +3600,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139709265470087;
+__arg0 = x140421015032455;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3769,18 +3611,18 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139709265430215 = __arg1;
+Obj x140421013090599 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265430279 = makeCons(symlist, x139709265430215);
-Obj pat = x139709265430279;
-Obj x139709265430599 = makeCons(pat, closureRef(co, 2));
-Obj x139709265430631 = makeCons(act, x139709265430599);
+Obj x140421013090631 = makeCons(__symbolTable[135], x140421013090599);
+Obj pat = x140421013090631;
+Obj x140421013090887 = makeCons(pat, closureRef(co, 2));
+Obj x140421013090919 = makeCons(act, x140421013090887);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg0 = globalRef(__symbolTable[106]);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = x139709265430631;
+__arg3 = x140421013090919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3790,17 +3632,17 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139709265470247 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139709265470247) {
-Obj x139709265470951 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139709265470951;
-Obj x139709265471335 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139709265471335;
-Obj x139709265471815 = makeCons(x, closureRef(co, 1));
+Obj x140421013108807 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013108807) {
+Obj x140421013108999 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421013108999;
+Obj x140421013109191 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421013109191;
+Obj x140421013109383 = makeCons(x, closureRef(co, 1));
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35extract_45rules1);
+__arg0 = globalRef(__symbolTable[106]);
 __arg1 = y;
-__arg2 = x139709265471815;
+__arg2 = x140421013109383;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3809,7 +3651,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3823,7 +3665,7 @@ label27:
 {
 Obj exp = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45match);
+__arg0 = globalRef(__symbolTable[108]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3837,7 +3679,7 @@ label28:
 Obj exp = __arg1;
 pushCont(co, 29, clofun2, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3848,12 +3690,12 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139709264961991 = __arg1;
+Obj x140421013271015 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun2, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
-__arg1 = x139709264961991;
+__arg0 = globalRef(__symbolTable[138]);
+__arg1 = x140421013271015;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3863,12 +3705,12 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139709264962023 = __arg1;
+Obj x140421013271047 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = x139709264962023;
+Obj value = x140421013271047;
 pushCont(co, 31, clofun2, 1, value);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3879,18 +3721,18 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139709264962183 = __arg1;
+Obj x140421013271335 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = x139709264962183;
-Obj x139709265470439 = makeNative(32, clofun2, 1, 2, value, rules);
-Obj x139709264963431 = PRIM_ISCONS(value);
-if (True == x139709264963431) {
-Obj x139709264963719 = PRIM_CAR(value);
-Obj x139709264963751 = PRIM_EQ(symcons, x139709264963719);
-Obj x139709264963783 = primNot(x139709264963751);
-if (True == x139709264963783) {
+Obj rules = x140421013271335;
+Obj x140421015384135 = makeNative(32, clofun2, 1, 2, value, rules);
+Obj x140421013272871 = PRIM_ISCONS(value);
+if (True == x140421013272871) {
+Obj x140421013273607 = PRIM_CAR(value);
+Obj x140421013273639 = PRIM_EQ(__symbolTable[152], x140421013273607);
+Obj x140421013273671 = primNot(x140421013273639);
+if (True == x140421013273671) {
 __nargs = 2;
-__arg0 = x139709265470439;
+__arg0 = x140421015384135;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3899,7 +3741,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470439;
+__arg0 = x140421015384135;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3909,7 +3751,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
-__arg0 = x139709265470439;
+__arg0 = x140421015384135;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3921,13 +3763,13 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139709265470471 = __arg1;
-if (True == x139709265470471) {
-Obj x139709264962535 = primGenSym();
-Obj val = x139709264962535;
+Obj x140421015384167 = __arg1;
+if (True == x140421015384167) {
+Obj x140421013271751 = primGenSym();
+Obj val = x140421013271751;
 pushCont(co, 33, clofun2, 1, val);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg0 = globalRef(__symbolTable[109]);
 __arg1 = val;
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -3937,7 +3779,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg0 = globalRef(__symbolTable[109]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -3950,14 +3792,14 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139709264962951 = __arg1;
+Obj x140421013272263 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709264962983 = makeCons(x139709264962951, Nil);
-Obj x139709264963015 = makeCons(closureRef(co, 0), x139709264962983);
-Obj x139709264963047 = makeCons(val, x139709264963015);
-Obj x139709264963079 = makeCons(symlet, x139709264963047);
+Obj x140421013272295 = makeCons(x140421013272263, Nil);
+Obj x140421013272327 = makeCons(closureRef(co, 0), x140421013272295);
+Obj x140421013272359 = makeCons(val, x140421013272327);
+Obj x140421013272391 = makeCons(__symbolTable[129], x140421013272359);
 __nargs = 2;
-__arg1 = x139709264963079;
+__arg1 = x140421013272391;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3969,7 +3811,7 @@ Obj value = __arg1;
 Obj rules = __arg2;
 pushCont(co, 35, clofun2, 2, value, rules);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
+__arg0 = globalRef(__symbolTable[161]);
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3980,22 +3822,22 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139709264983271 = __arg1;
+Obj x140421013389607 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264983271) {
-Obj x139709264983431 = makeCons(makeCString("no match-help found!"), Nil);
-Obj x139709264983463 = makeCons(symerror, x139709264983431);
+if (True == x140421013389607) {
+Obj x140421013389767 = makeCons(makeCString("no match-help found!"), Nil);
+Obj x140421013389799 = makeCons(__symbolTable[127], x140421013389767);
 __nargs = 2;
-__arg1 = x139709264983463;
+__arg1 = x140421013389799;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265470375 = makeNative(38, clofun2, 1, 2, value, rules);
-pushCont(co, 36, clofun2, 2, rules, x139709265470375);
+Obj x140421015384071 = makeNative(38, clofun2, 1, 2, value, rules);
+pushCont(co, 36, clofun2, 2, rules, x140421015384071);
 __nargs = 2;
-__arg0 = globalRef(sympair_63);
+__arg0 = globalRef(__symbolTable[151]);
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4007,15 +3849,15 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139709264985863 = __arg1;
+Obj x140421013393031 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265470375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264985863) {
-Obj x139709264986087 = PRIM_CDR(rules);
-pushCont(co, 37, clofun2, 1, x139709265470375);
+Obj x140421015384071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421013393031) {
+Obj x140421013393319 = PRIM_CDR(rules);
+pushCont(co, 37, clofun2, 1, x140421015384071);
 __nargs = 2;
-__arg0 = globalRef(sympair_63);
-__arg1 = x139709264986087;
+__arg0 = globalRef(__symbolTable[151]);
+__arg1 = x140421013393319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4023,7 +3865,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470375;
+__arg0 = x140421015384071;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4035,11 +3877,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139709264961543 = __arg1;
-Obj x139709265470375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139709264961543) {
+Obj x140421013270535 = __arg1;
+Obj x140421015384071= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421013270535) {
 __nargs = 2;
-__arg0 = x139709265470375;
+__arg0 = x140421015384071;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4048,7 +3890,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470375;
+__arg0 = x140421015384071;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4060,15 +3902,15 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139709265470407 = __arg1;
-if (True == x139709265470407) {
-Obj x139709264983847 = PRIM_CAR(closureRef(co, 1));
-Obj pat = x139709264983847;
-Obj x139709264984007 = primGenSym();
-Obj cc = x139709264984007;
+Obj x140421015384103 = __arg1;
+if (True == x140421015384103) {
+Obj x140421013390311 = PRIM_CAR(closureRef(co, 1));
+Obj pat = x140421013390311;
+Obj x140421013390631 = primGenSym();
+Obj cc = x140421013390631;
 pushCont(co, 39, clofun2, 2, pat, cc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35extract_45rule_45action);
+__arg0 = globalRef(__symbolTable[111]);
 __arg1 = closureRef(co, 1);
 __arg2 = cc;
 co->ctx.frees = __arg0;
@@ -4078,7 +3920,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4090,13 +3932,13 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139709264984199 = __arg1;
+Obj x140421013390823 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj action = x139709264984199;
+Obj action = x140421013390823;
 pushCont(co, 40, clofun2, 2, action, cc);
 __nargs = 2;
-__arg0 = globalRef(symmacroexpand);
+__arg0 = globalRef(__symbolTable[138]);
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4107,13 +3949,13 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139709264984423 = __arg1;
+Obj x140421013391175 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 41, clofun2, 1, cc);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
-__arg1 = x139709264984423;
+__arg0 = globalRef(__symbolTable[117]);
+__arg1 = x140421013391175;
 __arg2 = closureRef(co, 0);
 __arg3 = action;
 co->args[4] = cc;
@@ -4126,16 +3968,16 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139709264984487 = __arg1;
+Obj x140421013391239 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = x139709264984487;
-Obj x139709264984839 = PRIM_CDR(closureRef(co, 1));
-Obj x139709264984871 = PRIM_CDR(x139709264984839);
+Obj curr = x140421013391239;
+Obj x140421013391623 = PRIM_CDR(closureRef(co, 1));
+Obj x140421013391655 = PRIM_CDR(x140421013391623);
 pushCont(co, 42, clofun2, 2, curr, cc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35match_45helper);
+__arg0 = globalRef(__symbolTable[109]);
 __arg1 = closureRef(co, 0);
-__arg2 = x139709264984871;
+__arg2 = x140421013391655;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4145,19 +3987,19 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139709264984903 = __arg1;
+Obj x140421013391719 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = x139709264984903;
-Obj x139709264985319 = makeCons(rest, Nil);
-Obj x139709264985351 = makeCons(Nil, x139709264985319);
-Obj x139709264985383 = makeCons(symlambda, x139709264985351);
-Obj x139709264985479 = makeCons(curr, Nil);
-Obj x139709264985511 = makeCons(x139709264985383, x139709264985479);
-Obj x139709264985543 = makeCons(cc, x139709264985511);
-Obj x139709264985575 = makeCons(symlet, x139709264985543);
+Obj rest = x140421013391719;
+Obj x140421013392327 = makeCons(rest, Nil);
+Obj x140421013392423 = makeCons(Nil, x140421013392327);
+Obj x140421013392455 = makeCons(__symbolTable[140], x140421013392423);
+Obj x140421013392551 = makeCons(curr, Nil);
+Obj x140421013392583 = makeCons(x140421013392455, x140421013392551);
+Obj x140421013392615 = makeCons(cc, x140421013392583);
+Obj x140421013392647 = makeCons(__symbolTable[129], x140421013392615);
 __nargs = 2;
-__arg1 = x139709264985575;
+__arg1 = x140421013392647;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4167,13 +4009,13 @@ label43:
 {
 Obj rules = __arg1;
 Obj cc = __arg2;
-Obj x139709265046919 = PRIM_CDR(rules);
-Obj x139709265046951 = PRIM_CAR(x139709265046919);
-Obj action = x139709265046951;
-Obj x139709265470279 = makeNative(45, clofun2, 1, 2, cc, action);
-pushCont(co, 44, clofun2, 2, action, x139709265470279);
+Obj x140421013469191 = PRIM_CDR(rules);
+Obj x140421013469223 = PRIM_CAR(x140421013469191);
+Obj action = x140421013469223;
+Obj x140421015385319 = makeNative(45, clofun2, 1, 2, cc, action);
+pushCont(co, 44, clofun2, 2, action, x140421015385319);
 __nargs = 2;
-__arg0 = globalRef(sympair_63);
+__arg0 = globalRef(__symbolTable[151]);
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4184,15 +4026,15 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139709264982631 = __arg1;
+Obj x140421013470695 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265470279= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139709264982631) {
-Obj x139709264982855 = PRIM_CAR(action);
-Obj x139709264982887 = PRIM_EQ(x139709264982855, symwhere);
-if (True == x139709264982887) {
+Obj x140421015385319= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421013470695) {
+Obj x140421013471015 = PRIM_CAR(action);
+Obj x140421013471047 = PRIM_EQ(x140421013471015, __symbolTable[110]);
+if (True == x140421013471047) {
 __nargs = 2;
-__arg0 = x139709265470279;
+__arg0 = x140421015385319;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4201,7 +4043,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470279;
+__arg0 = x140421015385319;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4211,7 +4053,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
-__arg0 = x139709265470279;
+__arg0 = x140421015385319;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4223,11 +4065,11 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139709265470311 = __arg1;
-if (True == x139709265470311) {
+Obj x140421015385351 = __arg1;
+if (True == x140421015385351) {
 PUSH_CONT_0(co, 46, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4245,10 +4087,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj x139709265047399 = __arg1;
-pushCont(co, 47, clofun2, 1, x139709265047399);
+Obj x140421013469735 = __arg1;
+pushCont(co, 47, clofun2, 1, x140421013469735);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4259,15 +4101,15 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139709264982055 = __arg1;
-Obj x139709265047399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709264982247 = makeCons(closureRef(co, 0), Nil);
-Obj x139709264982279 = makeCons(x139709264982247, Nil);
-Obj x139709264982311 = makeCons(x139709264982055, x139709264982279);
-Obj x139709264982343 = makeCons(x139709265047399, x139709264982311);
-Obj x139709264982375 = makeCons(symif, x139709264982343);
+Obj x140421013469927 = __arg1;
+Obj x140421013469735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013470215 = makeCons(closureRef(co, 0), Nil);
+Obj x140421013470247 = makeCons(x140421013470215, Nil);
+Obj x140421013470279 = makeCons(x140421013469927, x140421013470247);
+Obj x140421013470311 = makeCons(x140421013469735, x140421013470279);
+Obj x140421013470343 = makeCons(__symbolTable[126], x140421013470311);
 __nargs = 2;
-__arg1 = x139709264982375;
+__arg1 = x140421013470343;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4292,50 +4134,50 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139709265112551 = __arg1;
+Obj x140421013563847 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x139709265112551) {
-Obj x139709265112775 = PRIM_EQ(pat, expr);
-if (True == x139709265112775) {
+if (True == x140421013563847) {
+Obj x140421013564007 = PRIM_EQ(pat, expr);
+if (True == x140421013564007) {
 __nargs = 2;
 __arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265043783 = makeCons(expr, Nil);
-Obj x139709265043815 = makeCons(pat, x139709265043783);
-Obj x139709265043847 = makeCons(sym_61, x139709265043815);
-Obj x139709265044071 = makeCons(cc, Nil);
-Obj x139709265044103 = makeCons(x139709265044071, Nil);
-Obj x139709265044135 = makeCons(body, x139709265044103);
-Obj x139709265044167 = makeCons(x139709265043847, x139709265044135);
-Obj x139709265044199 = makeCons(symif, x139709265044167);
+Obj x140421013564359 = makeCons(expr, Nil);
+Obj x140421013564391 = makeCons(pat, x140421013564359);
+Obj x140421013564423 = makeCons(__symbolTable[113], x140421013564391);
+Obj x140421013564647 = makeCons(cc, Nil);
+Obj x140421013564679 = makeCons(x140421013564647, Nil);
+Obj x140421013564711 = makeCons(body, x140421013564679);
+Obj x140421013564743 = makeCons(x140421013564423, x140421013564711);
+Obj x140421013564775 = makeCons(__symbolTable[126], x140421013564743);
 __nargs = 2;
-__arg1 = x139709265044199;
+__arg1 = x140421013564775;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
-Obj x139709265044359 = primIsSymbol(pat);
-if (True == x139709265044359) {
-Obj x139709265044647 = makeCons(body, Nil);
-Obj x139709265044679 = makeCons(expr, x139709265044647);
-Obj x139709265044711 = makeCons(pat, x139709265044679);
-Obj x139709265044743 = makeCons(symlet, x139709265044711);
+Obj x140421013564935 = primIsSymbol(pat);
+if (True == x140421013564935) {
+Obj x140421013565223 = makeCons(body, Nil);
+Obj x140421013565255 = makeCons(expr, x140421013565223);
+Obj x140421013565287 = makeCons(pat, x140421013565255);
+Obj x140421013565319 = makeCons(__symbolTable[129], x140421013565287);
 __nargs = 2;
-__arg1 = x139709265044743;
+__arg1 = x140421013565319;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 pushCont(co, 0, clofun3, 4, expr, body, cc, pat);
 __nargs = 2;
-__arg0 = globalRef(sympair_63);
+__arg0 = globalRef(__symbolTable[151]);
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4368,34 +4210,34 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139709265044903 = __arg1;
+Obj x140421013467175 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == x139709265044903) {
-Obj x139709265045127 = PRIM_CAR(pat);
-Obj x139709265045159 = PRIM_EQ(x139709265045127, symquote);
-if (True == x139709265045159) {
-Obj x139709265045511 = makeCons(expr, Nil);
-Obj x139709265045543 = makeCons(pat, x139709265045511);
-Obj x139709265045575 = makeCons(sym_61, x139709265045543);
-Obj x139709265045799 = makeCons(cc, Nil);
-Obj x139709265045831 = makeCons(x139709265045799, Nil);
-Obj x139709265045863 = makeCons(body, x139709265045831);
-Obj x139709265045895 = makeCons(x139709265045575, x139709265045863);
-Obj x139709265045927 = makeCons(symif, x139709265045895);
+if (True == x140421013467175) {
+Obj x140421013467399 = PRIM_CAR(pat);
+Obj x140421013467431 = PRIM_EQ(x140421013467399, __symbolTable[139]);
+if (True == x140421013467431) {
+Obj x140421013467783 = makeCons(expr, Nil);
+Obj x140421013467815 = makeCons(pat, x140421013467783);
+Obj x140421013467847 = makeCons(__symbolTable[113], x140421013467815);
+Obj x140421013468071 = makeCons(cc, Nil);
+Obj x140421013468103 = makeCons(x140421013468071, Nil);
+Obj x140421013468135 = makeCons(body, x140421013468103);
+Obj x140421013468167 = makeCons(x140421013467847, x140421013468135);
+Obj x140421013468199 = makeCons(__symbolTable[126], x140421013468167);
 __nargs = 2;
-__arg1 = x139709265045927;
+__arg1 = x140421013468199;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265046151 = PRIM_CAR(pat);
-Obj x139709265046183 = PRIM_EQ(x139709265046151, symcons);
-if (True == x139709265046183) {
+Obj x140421013468423 = PRIM_CAR(pat);
+Obj x140421013468455 = PRIM_EQ(x140421013468423, __symbolTable[152]);
+if (True == x140421013468455) {
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match_45cons_45expander);
+__arg0 = globalRef(__symbolTable[118]);
 __arg1 = pat;
 __arg2 = expr;
 __arg3 = body;
@@ -4407,7 +4249,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symerror);
+__arg0 = globalRef(__symbolTable[127]);
 __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4419,7 +4261,7 @@ goto *jumpTable[ps.label];
 } else {
 PUSH_CONT_0(co, 1, clofun3);
 __nargs = 3;
-__arg0 = globalRef(symstr);
+__arg0 = globalRef(__symbolTable[112]);
 __arg1 = makeCString("match fail ");
 __arg2 = pat;
 co->ctx.frees = __arg0;
@@ -4432,10 +4274,10 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139709265046471 = __arg1;
+Obj x140421013468743 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symerror);
-__arg1 = x139709265046471;
+__arg0 = globalRef(__symbolTable[127]);
+__arg1 = x140421013468743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4448,7 +4290,7 @@ label2:
 Obj x = __arg1;
 pushCont(co, 3, clofun3, 1, x);
 __nargs = 2;
-__arg0 = globalRef(symatom_63);
+__arg0 = globalRef(__symbolTable[131]);
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4459,12 +4301,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139709265112263 = __arg1;
+Obj x140421013563559 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139709265112263) {
-Obj x139709265112487 = primIsSymbol(x);
-Obj x139709265112519 = primNot(x139709265112487);
-if (True == x139709265112519) {
+if (True == x140421013563559) {
+Obj x140421013563783 = primIsSymbol(x);
+Obj x140421013563815 = primNot(x140421013563783);
+if (True == x140421013563815) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4494,7 +4336,7 @@ Obj body = __arg3;
 Obj cc = co->args[4];
 pushCont(co, 5, clofun3, 4, pat, body, cc, expr);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4505,15 +4347,15 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139709265145479 = __arg1;
+Obj x140421013625383 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = x139709265145479;
+Obj x = x140421013625383;
 pushCont(co, 6, clofun3, 4, x, body, cc, expr);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4524,20 +4366,20 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139709265145639 = __arg1;
+Obj x140421013625543 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = x139709265145639;
-Obj x139709265470119 = makeNative(7, clofun3, 1, 5, x, y, expr, body, cc);
-Obj x139709265111431 = PRIM_ISCONS(expr);
-if (True == x139709265111431) {
-Obj x139709265111655 = PRIM_CAR(expr);
-Obj x139709265111687 = PRIM_EQ(x139709265111655, symcons);
-if (True == x139709265111687) {
+Obj y = x140421013625543;
+Obj x140421015385255 = makeNative(7, clofun3, 1, 5, x, y, expr, body, cc);
+Obj x140421013562695 = PRIM_ISCONS(expr);
+if (True == x140421013562695) {
+Obj x140421013562919 = PRIM_CAR(expr);
+Obj x140421013562951 = PRIM_EQ(x140421013562919, __symbolTable[152]);
+if (True == x140421013562951) {
 __nargs = 2;
-__arg0 = x139709265470119;
+__arg0 = x140421015385255;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4546,7 +4388,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265470119;
+__arg0 = x140421015385255;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4556,7 +4398,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
-__arg0 = x139709265470119;
+__arg0 = x140421015385255;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4568,11 +4410,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139709265470215 = __arg1;
-if (True == x139709265470215) {
+Obj x140421015385287 = __arg1;
+if (True == x140421015385287) {
 PUSH_CONT_0(co, 10, clofun3);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4580,17 +4422,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265109991 = makeCons(closureRef(co, 2), Nil);
-Obj x139709265110023 = makeCons(symcons_63, x139709265109991);
-Obj x139709265110375 = makeCons(closureRef(co, 2), Nil);
-Obj x139709265110407 = makeCons(symcar, x139709265110375);
-Obj x139709265110695 = makeCons(closureRef(co, 2), Nil);
-Obj x139709265110727 = makeCons(symcdr, x139709265110695);
-pushCont(co, 8, clofun3, 2, x139709265110407, x139709265110023);
+Obj x140421013626791 = makeCons(closureRef(co, 2), Nil);
+Obj x140421013626823 = makeCons(__symbolTable[116], x140421013626791);
+Obj x140421013561639 = makeCons(closureRef(co, 2), Nil);
+Obj x140421013561671 = makeCons(__symbolTable[115], x140421013561639);
+Obj x140421013561959 = makeCons(closureRef(co, 2), Nil);
+Obj x140421013561991 = makeCons(__symbolTable[114], x140421013561959);
+pushCont(co, 8, clofun3, 2, x140421013561671, x140421013626823);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
+__arg0 = globalRef(__symbolTable[117]);
 __arg1 = closureRef(co, 1);
-__arg2 = x139709265110727;
+__arg2 = x140421013561991;
 __arg3 = closureRef(co, 3);
 co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
@@ -4603,15 +4445,15 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139709265110823 = __arg1;
-Obj x139709265110407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265110023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 9, clofun3, 1, x139709265110023);
+Obj x140421013562087 = __arg1;
+Obj x140421013561671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013626823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 9, clofun3, 1, x140421013626823);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
+__arg0 = globalRef(__symbolTable[117]);
 __arg1 = closureRef(co, 0);
-__arg2 = x139709265110407;
-__arg3 = x139709265110823;
+__arg2 = x140421013561671;
+__arg3 = x140421013562087;
 co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4622,15 +4464,15 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139709265110887 = __arg1;
-Obj x139709265110023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265111079 = makeCons(closureRef(co, 4), Nil);
-Obj x139709265111111 = makeCons(x139709265111079, Nil);
-Obj x139709265111143 = makeCons(x139709265110887, x139709265111111);
-Obj x139709265111175 = makeCons(x139709265110023, x139709265111143);
-Obj x139709265111207 = makeCons(symif, x139709265111175);
+Obj x140421013562151 = __arg1;
+Obj x140421013626823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013562343 = makeCons(closureRef(co, 4), Nil);
+Obj x140421013562375 = makeCons(x140421013562343, Nil);
+Obj x140421013562407 = makeCons(x140421013562151, x140421013562375);
+Obj x140421013562439 = makeCons(x140421013626823, x140421013562407);
+Obj x140421013562471 = makeCons(__symbolTable[126], x140421013562439);
 __nargs = 2;
-__arg1 = x139709265111207;
+__arg1 = x140421013562471;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4638,11 +4480,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label10:
 {
-Obj x139709265109159 = __arg1;
-Obj e1 = x139709265109159;
+Obj x140421013625927 = __arg1;
+Obj e1 = x140421013625927;
 pushCont(co, 11, clofun3, 1, e1);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4653,12 +4495,12 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139709265109351 = __arg1;
+Obj x140421013626119 = __arg1;
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e2 = x139709265109351;
+Obj e2 = x140421013626119;
 pushCont(co, 12, clofun3, 1, e1);
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
+__arg0 = globalRef(__symbolTable[117]);
 __arg1 = closureRef(co, 1);
 __arg2 = e2;
 __arg3 = closureRef(co, 3);
@@ -4672,13 +4514,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139709265109639 = __arg1;
+Obj x140421013626439 = __arg1;
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
-__arg0 = globalRef(symcora_47init_35match1);
+__arg0 = globalRef(__symbolTable[117]);
 __arg1 = closureRef(co, 0);
 __arg2 = e1;
-__arg3 = x139709265109639;
+__arg3 = x140421013626439;
 co->args[4] = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4690,10 +4532,10 @@ goto *jumpTable[ps.label];
 label13:
 {
 Obj exp = __arg1;
-Obj x139709265145095 = PRIM_CDR(exp);
+Obj x140421013624999 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x139709265145095;
+__arg0 = globalRef(__symbolTable[120]);
+__arg1 = x140421013624999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4704,11 +4546,11 @@ goto *jumpTable[ps.label];
 label14:
 {
 Obj pat = __arg1;
-Obj x139709265144007 = PRIM_CDR(pat);
+Obj x140421013623879 = PRIM_CDR(pat);
 pushCont(co, 15, clofun3, 1, pat);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265144007;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421013623879;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4718,22 +4560,22 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139709265144039 = __arg1;
+Obj x140421013623911 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139709265144039) {
-Obj x139709265144135 = PRIM_CAR(pat);
+if (True == x140421013623911) {
+Obj x140421013624039 = PRIM_CAR(pat);
 __nargs = 2;
-__arg1 = x139709265144135;
+__arg1 = x140421013624039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265144359 = PRIM_CAR(pat);
-Obj x139709265144583 = PRIM_CDR(pat);
-pushCont(co, 16, clofun3, 1, x139709265144359);
+Obj x140421013624263 = PRIM_CAR(pat);
+Obj x140421013624487 = PRIM_CDR(pat);
+pushCont(co, 16, clofun3, 1, x140421013624263);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = x139709265144583;
+__arg0 = globalRef(__symbolTable[120]);
+__arg1 = x140421013624487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4744,13 +4586,13 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139709265144615 = __arg1;
-Obj x139709265144359= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265144647 = makeCons(x139709265144615, Nil);
-Obj x139709265144679 = makeCons(x139709265144359, x139709265144647);
-Obj x139709265144711 = makeCons(symcons, x139709265144679);
+Obj x140421013624519 = __arg1;
+Obj x140421013624263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013624551 = makeCons(x140421013624519, Nil);
+Obj x140421013624583 = makeCons(x140421013624263, x140421013624551);
+Obj x140421013624615 = makeCons(__symbolTable[152], x140421013624583);
 __nargs = 2;
-__arg1 = x139709265144711;
+__arg1 = x140421013624615;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4759,16 +4601,16 @@ goto *jumpTable[co->ctx.pc.label];
 label17:
 {
 Obj x = __arg1;
-Obj x139709265143399 = PRIM_EQ(x, True);
-if (True == x139709265143399) {
+Obj x140421013623271 = PRIM_EQ(x, True);
+if (True == x140421013623271) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265143559 = PRIM_EQ(x, False);
-if (True == x139709265143559) {
+Obj x140421013623431 = PRIM_EQ(x, False);
+if (True == x140421013623431) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -4787,10 +4629,10 @@ goto *jumpTable[co->ctx.pc.label];
 label18:
 {
 Obj exp = __arg1;
-Obj x139709265143015 = PRIM_CDR(exp);
+Obj x140421013622887 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x139709265143015;
+__arg0 = globalRef(__symbolTable[123]);
+__arg1 = x140421013622887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4801,28 +4643,28 @@ goto *jumpTable[ps.label];
 label19:
 {
 Obj l = __arg1;
-Obj x139709265231591 = PRIM_EQ(Nil, l);
-if (True == x139709265231591) {
+Obj x140421013682759 = PRIM_EQ(Nil, l);
+if (True == x140421013682759) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265231815 = PRIM_CAR(l);
-Obj x139709265231847 = PRIM_EQ(x139709265231815, False);
-if (True == x139709265231847) {
+Obj x140421013683015 = PRIM_CAR(l);
+Obj x140421013683047 = PRIM_EQ(x140421013683015, False);
+if (True == x140421013683047) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265141959 = PRIM_CDR(l);
+Obj x140421013683271 = PRIM_CDR(l);
 pushCont(co, 20, clofun3, 1, l);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = x139709265141959;
+__arg0 = globalRef(__symbolTable[123]);
+__arg1 = x140421013683271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4834,24 +4676,24 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139709265141991 = __arg1;
+Obj x140421013683303 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x139709265141991;
-Obj x139709265142151 = PRIM_EQ(more, False);
-if (True == x139709265142151) {
+Obj more = x140421013683303;
+Obj x140421013683463 = PRIM_EQ(more, False);
+if (True == x140421013683463) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265142375 = PRIM_CAR(l);
-Obj x139709265142535 = makeCons(False, Nil);
-Obj x139709265142567 = makeCons(more, x139709265142535);
-Obj x139709265142599 = makeCons(x139709265142375, x139709265142567);
-Obj x139709265142631 = makeCons(symif, x139709265142599);
+Obj x140421013683687 = PRIM_CAR(l);
+Obj x140421013683847 = makeCons(False, Nil);
+Obj x140421013683879 = makeCons(more, x140421013683847);
+Obj x140421013683911 = makeCons(x140421013683687, x140421013683879);
+Obj x140421013683943 = makeCons(__symbolTable[126], x140421013683911);
 __nargs = 2;
-__arg1 = x139709265142631;
+__arg1 = x140421013683943;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4861,10 +4703,10 @@ goto *jumpTable[co->ctx.pc.label];
 label21:
 {
 Obj exp = __arg1;
-Obj x139709265231207 = PRIM_CDR(exp);
+Obj x140421013682375 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x139709265231207;
+__arg0 = globalRef(__symbolTable[125]);
+__arg1 = x140421013682375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4875,28 +4717,28 @@ goto *jumpTable[ps.label];
 label22:
 {
 Obj l = __arg1;
-Obj x139709265229671 = PRIM_EQ(l, Nil);
-if (True == x139709265229671) {
+Obj x140421013680807 = PRIM_EQ(l, Nil);
+if (True == x140421013680807) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265229895 = PRIM_CAR(l);
-Obj x139709265229927 = PRIM_EQ(x139709265229895, True);
-if (True == x139709265229927) {
+Obj x140421013681031 = PRIM_CAR(l);
+Obj x140421013681063 = PRIM_EQ(x140421013681031, True);
+if (True == x140421013681063) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265230151 = PRIM_CDR(l);
+Obj x140421013681287 = PRIM_CDR(l);
 pushCont(co, 23, clofun3, 1, l);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = x139709265230151;
+__arg0 = globalRef(__symbolTable[125]);
+__arg1 = x140421013681287;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4908,24 +4750,24 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139709265230183 = __arg1;
+Obj x140421013681319 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = x139709265230183;
-Obj x139709265230343 = PRIM_EQ(more, True);
-if (True == x139709265230343) {
+Obj more = x140421013681319;
+Obj x140421013681479 = PRIM_EQ(more, True);
+if (True == x140421013681479) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265230567 = PRIM_CAR(l);
-Obj x139709265230727 = makeCons(more, Nil);
-Obj x139709265230759 = makeCons(True, x139709265230727);
-Obj x139709265230791 = makeCons(x139709265230567, x139709265230759);
-Obj x139709265230823 = makeCons(symif, x139709265230791);
+Obj x140421013681703 = PRIM_CAR(l);
+Obj x140421013681863 = makeCons(more, Nil);
+Obj x140421013681895 = makeCons(True, x140421013681863);
+Obj x140421013681959 = makeCons(x140421013681703, x140421013681895);
+Obj x140421013681991 = makeCons(__symbolTable[126], x140421013681959);
 __nargs = 2;
-__arg1 = x139709265230823;
+__arg1 = x140421013681991;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4935,20 +4777,20 @@ goto *jumpTable[co->ctx.pc.label];
 label24:
 {
 Obj exp = __arg1;
-Obj x139709265228135 = PRIM_CDR(exp);
-Obj x139709265228167 = PRIM_EQ(Nil, x139709265228135);
-if (True == x139709265228167) {
-Obj x139709265228327 = makeCons(makeCString("no cond match"), Nil);
-Obj x139709265228359 = makeCons(symerror, x139709265228327);
+Obj x140421015034951 = PRIM_CDR(exp);
+Obj x140421015034983 = PRIM_EQ(Nil, x140421015034951);
+if (True == x140421015034983) {
+Obj x140421015035143 = makeCons(makeCString("no cond match"), Nil);
+Obj x140421015035175 = makeCons(__symbolTable[127], x140421015035143);
 __nargs = 2;
-__arg1 = x139709265228359;
+__arg1 = x140421015035175;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 pushCont(co, 25, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4960,13 +4802,13 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139709265228519 = __arg1;
+Obj x140421015035335 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = x139709265228519;
-Obj x139709265228743 = PRIM_CAR(curr);
-pushCont(co, 26, clofun3, 2, exp, x139709265228743);
+Obj curr = x140421015035335;
+Obj x140421015035591 = PRIM_CAR(curr);
+pushCont(co, 26, clofun3, 2, exp, x140421015035591);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = curr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4977,12 +4819,12 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139709265228903 = __arg1;
+Obj x140421015035751 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265228743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 27, clofun3, 2, x139709265228903, x139709265228743);
+Obj x140421015035591= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 27, clofun3, 2, x140421015035751, x140421015035591);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4993,16 +4835,16 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139709265229127 = __arg1;
-Obj x139709265228903= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265228743= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265229159 = makeCons(symcond, x139709265229127);
-Obj x139709265229191 = makeCons(x139709265229159, Nil);
-Obj x139709265229223 = makeCons(x139709265228903, x139709265229191);
-Obj x139709265229255 = makeCons(x139709265228743, x139709265229223);
-Obj x139709265229287 = makeCons(symif, x139709265229255);
+Obj x140421013680263 = __arg1;
+Obj x140421015035751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015035591= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680295 = makeCons(__symbolTable[128], x140421013680263);
+Obj x140421013680327 = makeCons(x140421013680295, Nil);
+Obj x140421013680359 = makeCons(x140421015035751, x140421013680327);
+Obj x140421013680391 = makeCons(x140421015035591, x140421013680359);
+Obj x140421013680423 = makeCons(__symbolTable[126], x140421013680391);
 __nargs = 2;
-__arg1 = x139709265229287;
+__arg1 = x140421013680423;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5011,10 +4853,10 @@ goto *jumpTable[co->ctx.pc.label];
 label28:
 {
 Obj exp = __arg1;
-Obj x139709265268647 = PRIM_CDR(exp);
+Obj x140421015034375 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x139709265268647;
+__arg0 = globalRef(__symbolTable[130]);
+__arg1 = x140421015034375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5025,11 +4867,11 @@ goto *jumpTable[ps.label];
 label29:
 {
 Obj exp = __arg1;
-Obj x139709265267367 = PRIM_CDR(exp);
+Obj x140421015032871 = PRIM_CDR(exp);
 pushCont(co, 30, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symnull_63);
-__arg1 = x139709265267367;
+__arg0 = globalRef(__symbolTable[161]);
+__arg1 = x140421015032871;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5039,20 +4881,20 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139709265267399 = __arg1;
+Obj x140421015032935 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139709265267399) {
-Obj x139709265267495 = PRIM_CAR(exp);
+if (True == x140421015032935) {
+Obj x140421015033095 = PRIM_CAR(exp);
 __nargs = 2;
-__arg1 = x139709265267495;
+__arg1 = x140421015033095;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265267719 = PRIM_CAR(exp);
-pushCont(co, 31, clofun3, 2, exp, x139709265267719);
+Obj x140421015033383 = PRIM_CAR(exp);
+pushCont(co, 31, clofun3, 2, exp, x140421015033383);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5064,12 +4906,12 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139709265267879 = __arg1;
+Obj x140421015033543 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265267719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 32, clofun3, 2, x139709265267879, x139709265267719);
+Obj x140421015033383= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 32, clofun3, 2, x140421015033543, x140421015033383);
 __nargs = 2;
-__arg0 = globalRef(symcddr);
+__arg0 = globalRef(__symbolTable[157]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5080,13 +4922,13 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139709265268103 = __arg1;
-Obj x139709265267879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265267719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 33, clofun3, 2, x139709265267879, x139709265267719);
+Obj x140421015033767 = __arg1;
+Obj x140421015033543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015033383= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 33, clofun3, 2, x140421015033543, x140421015033383);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = x139709265268103;
+__arg0 = globalRef(__symbolTable[130]);
+__arg1 = x140421015033767;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5096,15 +4938,15 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139709265268135 = __arg1;
-Obj x139709265267879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265267719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265268167 = makeCons(x139709265268135, Nil);
-Obj x139709265268199 = makeCons(x139709265267879, x139709265268167);
-Obj x139709265268231 = makeCons(x139709265267719, x139709265268199);
-Obj x139709265268263 = makeCons(symlet, x139709265268231);
+Obj x140421015033799 = __arg1;
+Obj x140421015033543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015033383= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015033831 = makeCons(x140421015033799, Nil);
+Obj x140421015033863 = makeCons(x140421015033543, x140421015033831);
+Obj x140421015033895 = makeCons(x140421015033383, x140421015033863);
+Obj x140421015033927 = makeCons(__symbolTable[129], x140421015033895);
 __nargs = 2;
-__arg1 = x139709265268263;
+__arg1 = x140421015033927;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5113,10 +4955,10 @@ goto *jumpTable[co->ctx.pc.label];
 label34:
 {
 Obj x = __arg1;
-Obj x139709265266887 = PRIM_ISCONS(x);
-Obj x139709265266919 = primNot(x139709265266887);
+Obj x140421015032359 = PRIM_ISCONS(x);
+Obj x140421015032391 = primNot(x140421015032359);
 __nargs = 2;
-__arg1 = x139709265266919;
+__arg1 = x140421015032391;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5126,22 +4968,22 @@ label35:
 {
 Obj x = __arg1;
 Obj l = __arg2;
-Obj x139709265266087 = PRIM_ISCONS(l);
-if (True == x139709265266087) {
-Obj x139709265266311 = PRIM_CAR(l);
-Obj x139709265266343 = PRIM_EQ(x139709265266311, x);
-if (True == x139709265266343) {
+Obj x140421015346567 = PRIM_ISCONS(l);
+if (True == x140421015346567) {
+Obj x140421015346791 = PRIM_CAR(l);
+Obj x140421015346823 = PRIM_EQ(x140421015346791, x);
+if (True == x140421015346823) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265266503 = PRIM_CDR(l);
+Obj x140421015346983 = PRIM_CDR(l);
 __nargs = 3;
-__arg0 = globalRef(symelem_63);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = x;
-__arg2 = x139709265266503;
+__arg2 = x140421015346983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5162,7 +5004,7 @@ label36:
 Obj exp = __arg1;
 pushCont(co, 37, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5173,11 +5015,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139709265265063 = __arg1;
+Obj x140421015345543 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 38, clofun3, 2, exp, x139709265265063);
+pushCont(co, 38, clofun3, 2, exp, x140421015345543);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5188,12 +5030,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139709265265351 = __arg1;
+Obj x140421015345831 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265265063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 39, clofun3, 2, x139709265265351, x139709265265063);
+Obj x140421015345543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 39, clofun3, 2, x140421015345831, x140421015345543);
 __nargs = 2;
-__arg0 = globalRef(symcadddr);
+__arg0 = globalRef(__symbolTable[155]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5204,17 +5046,17 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139709265265511 = __arg1;
-Obj x139709265265351= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265265063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265265543 = makeCons(x139709265265511, Nil);
-Obj x139709265265575 = makeCons(x139709265265351, x139709265265543);
-Obj x139709265265607 = makeCons(symlambda, x139709265265575);
-Obj x139709265265639 = makeCons(x139709265265607, Nil);
-Obj x139709265265671 = makeCons(x139709265265063, x139709265265639);
-Obj x139709265265703 = makeCons(symdef, x139709265265671);
+Obj x140421015345991 = __arg1;
+Obj x140421015345831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015345543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015346023 = makeCons(x140421015345991, Nil);
+Obj x140421015346055 = makeCons(x140421015345831, x140421015346023);
+Obj x140421015346087 = makeCons(__symbolTable[140], x140421015346055);
+Obj x140421015346119 = makeCons(x140421015346087, Nil);
+Obj x140421015346151 = makeCons(x140421015345543, x140421015346119);
+Obj x140421015346183 = makeCons(__symbolTable[133], x140421015346151);
 __nargs = 2;
-__arg1 = x139709265265703;
+__arg1 = x140421015346183;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5223,10 +5065,10 @@ goto *jumpTable[co->ctx.pc.label];
 label40:
 {
 Obj exp = __arg1;
-Obj x139709265342439 = PRIM_CDR(exp);
+Obj x140421015345095 = PRIM_CDR(exp);
 __nargs = 2;
-__arg0 = globalRef(symrcons);
-__arg1 = x139709265342439;
+__arg0 = globalRef(__symbolTable[153]);
+__arg1 = x140421015345095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5239,7 +5081,7 @@ label41:
 Obj exp = __arg1;
 pushCont(co, 42, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5250,13 +5092,13 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139709265341287 = __arg1;
+Obj x140421015343943 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265341319 = makeCons(x139709265341287, Nil);
-Obj x139709265341351 = makeCons(symquote, x139709265341319);
-pushCont(co, 43, clofun3, 2, exp, x139709265341351);
+Obj x140421015343975 = makeCons(x140421015343943, Nil);
+Obj x140421015344007 = makeCons(__symbolTable[139], x140421015343975);
+pushCont(co, 43, clofun3, 2, exp, x140421015344007);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5267,12 +5109,12 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139709265341639 = __arg1;
+Obj x140421015344295 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265341351= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 44, clofun3, 2, x139709265341639, x139709265341351);
+Obj x140421015344007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 44, clofun3, 2, x140421015344295, x140421015344007);
 __nargs = 2;
-__arg0 = globalRef(symcdddr);
+__arg0 = globalRef(__symbolTable[154]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5283,16 +5125,16 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139709265341735 = __arg1;
-Obj x139709265341639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265341351= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139709265341767 = makeCons(x139709265341639, x139709265341735);
-Obj x139709265341799 = makeCons(symlambda, x139709265341767);
-Obj x139709265341831 = makeCons(x139709265341799, Nil);
-Obj x139709265341863 = makeCons(x139709265341351, x139709265341831);
-Obj x139709265341895 = makeCons(symcora_47init_35add_45to_45_42macros_42, x139709265341863);
+Obj x140421015344391 = __arg1;
+Obj x140421015344295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015344007= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421015344423 = makeCons(x140421015344295, x140421015344391);
+Obj x140421015344455 = makeCons(__symbolTable[140], x140421015344423);
+Obj x140421015344487 = makeCons(x140421015344455, Nil);
+Obj x140421015344519 = makeCons(x140421015344007, x140421015344487);
+Obj x140421015344551 = makeCons(__symbolTable[144], x140421015344519);
 __nargs = 2;
-__arg1 = x139709265341895;
+__arg1 = x140421015344551;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5301,24 +5143,24 @@ goto *jumpTable[co->ctx.pc.label];
 label45:
 {
 Obj exp = __arg1;
-Obj x139709265338567 = PRIM_ISCONS(exp);
-if (True == x139709265338567) {
-Obj x139709265338791 = PRIM_CAR(exp);
-Obj x139709265338823 = PRIM_EQ(x139709265338791, globalRef(sym_42protect_45symbol_42));
-if (True == x139709265338823) {
-Obj x139709265338919 = PRIM_CDR(exp);
+Obj x140421015386279 = PRIM_ISCONS(exp);
+if (True == x140421015386279) {
+Obj x140421015386503 = PRIM_CAR(exp);
+Obj x140421015386535 = PRIM_EQ(x140421015386503, globalRef(__symbolTable[145]));
+if (True == x140421015386535) {
+Obj x140421015386631 = PRIM_CDR(exp);
 __nargs = 2;
-__arg1 = x139709265338919;
+__arg1 = x140421015386631;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265339143 = PRIM_CAR(exp);
-Obj x139709265339175 = PRIM_EQ(x139709265339143, symlambda);
-if (True == x139709265339175) {
+Obj x140421015386855 = PRIM_CAR(exp);
+Obj x140421015386887 = PRIM_EQ(x140421015386855, __symbolTable[140]);
+if (True == x140421015386887) {
 pushCont(co, 48, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcadr);
+__arg0 = globalRef(__symbolTable[160]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5326,9 +5168,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265339975 = PRIM_CAR(exp);
-Obj x139709265340007 = PRIM_EQ(x139709265339975, symquote);
-if (True == x139709265340007) {
+Obj x140421015387687 = PRIM_CAR(exp);
+Obj x140421015387719 = PRIM_EQ(x140421015387687, __symbolTable[139]);
+if (True == x140421015387719) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5337,7 +5179,7 @@ goto *jumpTable[co->ctx.pc.label];
 } else {
 pushCont(co, 46, clofun3, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand1);
+__arg0 = globalRef(__symbolTable[142]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5358,11 +5200,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj x139709265340551 = __arg1;
+Obj x140421015343207 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = makeNative(47, clofun3, 1, 1, exp);
-__arg1 = x139709265340551;
+__arg1 = x140421015343207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5373,11 +5215,11 @@ goto *jumpTable[ps.label];
 label47:
 {
 Obj exp1 = __arg1;
-Obj x139709265340327 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == x139709265340327) {
+Obj x140421015388039 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == x140421015388039) {
 __nargs = 3;
-__arg0 = globalRef(symmap);
-__arg1 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg0 = globalRef(__symbolTable[147]);
+__arg1 = globalRef(__symbolTable[141]);
 __arg2 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5386,7 +5228,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
+__arg0 = globalRef(__symbolTable[141]);
 __arg1 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5398,11 +5240,11 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139709265339399 = __arg1;
+Obj x140421015387111 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 49, clofun3, 1, x139709265339399);
+pushCont(co, 49, clofun3, 1, x140421015387111);
 __nargs = 2;
-__arg0 = globalRef(symcaddr);
+__arg0 = globalRef(__symbolTable[156]);
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5413,12 +5255,12 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139709265339623 = __arg1;
-Obj x139709265339399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 0, clofun4, 1, x139709265339399);
+Obj x140421015387335 = __arg1;
+Obj x140421015387111= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun4, 1, x140421015387111);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = x139709265339623;
+__arg0 = globalRef(__symbolTable[141]);
+__arg1 = x140421015387335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5448,13 +5290,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139709265339655 = __arg1;
-Obj x139709265339399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265339687 = makeCons(x139709265339655, Nil);
-Obj x139709265339719 = makeCons(x139709265339399, x139709265339687);
-Obj x139709265339751 = makeCons(symlambda, x139709265339719);
+Obj x140421015387367 = __arg1;
+Obj x140421015387111= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421015387399 = makeCons(x140421015387367, Nil);
+Obj x140421015387431 = makeCons(x140421015387111, x140421015387399);
+Obj x140421015387463 = makeCons(__symbolTable[140], x140421015387431);
 __nargs = 2;
-__arg1 = x139709265339751;
+__arg1 = x140421015387463;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5464,9 +5306,9 @@ label1:
 {
 Obj exp = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
+__arg0 = globalRef(__symbolTable[143]);
 __arg1 = exp;
-__arg2 = globalRef(sym_42macros_42);
+__arg2 = globalRef(__symbolTable[146]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5478,18 +5320,18 @@ label2:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj x139709265369159 = PRIM_EQ(Nil, macros);
-if (True == x139709265369159) {
+Obj x140421013272967 = PRIM_EQ(Nil, macros);
+if (True == x140421013272967) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139709265370663 = PRIM_CAR(macros);
+Obj x140421015385607 = PRIM_CAR(macros);
 __nargs = 2;
 __arg0 = makeNative(3, clofun4, 1, 2, macros, exp);
-__arg1 = x139709265370663;
+__arg1 = x140421015385607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5501,15 +5343,15 @@ goto *jumpTable[ps.label];
 label3:
 {
 Obj item = __arg1;
-Obj x139709265428711 = makeNative(4, clofun4, 1, 3, item, closureRef(co, 1), closureRef(co, 0));
-Obj x139709265370183 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139709265370183) {
-Obj x139709265370439 = PRIM_CAR(closureRef(co, 1));
-Obj x139709265370535 = PRIM_CAR(item);
-Obj x139709265370567 = PRIM_EQ(x139709265370439, x139709265370535);
-if (True == x139709265370567) {
+Obj x140421015385191 = makeNative(4, clofun4, 1, 3, item, closureRef(co, 1), closureRef(co, 0));
+Obj x140421015384935 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421015384935) {
+Obj x140421015385383 = PRIM_CAR(closureRef(co, 1));
+Obj x140421015385479 = PRIM_CAR(item);
+Obj x140421015385511 = PRIM_EQ(x140421015385383, x140421015385479);
+if (True == x140421015385511) {
 __nargs = 2;
-__arg0 = x139709265428711;
+__arg0 = x140421015385191;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5518,7 +5360,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139709265428711;
+__arg0 = x140421015385191;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5528,7 +5370,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
-__arg0 = x139709265428711;
+__arg0 = x140421015385191;
 __arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5540,11 +5382,11 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139709265428775 = __arg1;
-if (True == x139709265428775) {
-Obj x139709265369671 = PRIM_CDR(closureRef(co, 0));
+Obj x140421015385223 = __arg1;
+if (True == x140421015385223) {
+Obj x140421015384423 = PRIM_CDR(closureRef(co, 0));
 __nargs = 2;
-__arg0 = x139709265369671;
+__arg0 = x140421015384423;
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5552,11 +5394,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139709265369927 = PRIM_CDR(closureRef(co, 2));
+Obj x140421015384679 = PRIM_CDR(closureRef(co, 2));
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35macroexpand1_45h);
+__arg0 = globalRef(__symbolTable[143]);
 __arg1 = closureRef(co, 1);
-__arg2 = x139709265369927;
+__arg2 = x140421015384679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5569,11 +5411,11 @@ label5:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj x139709265368711 = makeCons(n, v);
-Obj x139709265368743 = makeCons(x139709265368711, globalRef(sym_42macros_42));
-Obj x139709265368775 = primSet(co, sym_42macros_42, x139709265368743);
+Obj x140421013272519 = makeCons(n, v);
+Obj x140421013272551 = makeCons(x140421013272519, globalRef(__symbolTable[146]));
+Obj x140421013272583 = primSet(co, __symbolTable[146], x140421013272551);
 __nargs = 2;
-__arg1 = x139709265368775;
+__arg1 = x140421013272583;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5584,7 +5426,7 @@ label6:
 Obj f = __arg1;
 Obj l = __arg2;
 __nargs = 4;
-__arg0 = globalRef(symmap_45h);
+__arg0 = globalRef(__symbolTable[148]);
 __arg1 = Nil;
 __arg2 = f;
 __arg3 = l;
@@ -5600,13 +5442,13 @@ label7:
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj x139709265367047 = PRIM_ISCONS(l);
-if (True == x139709265367047) {
-Obj x139709265367335 = PRIM_CAR(l);
+Obj x140421013270855 = PRIM_ISCONS(l);
+if (True == x140421013270855) {
+Obj x140421013271143 = PRIM_CAR(l);
 pushCont(co, 8, clofun4, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = x139709265367335;
+__arg1 = x140421013271143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5614,7 +5456,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symreverse);
+__arg0 = globalRef(__symbolTable[149]);
 __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5626,17 +5468,17 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139709265367367 = __arg1;
+Obj x140421013271175 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139709265367399 = makeCons(x139709265367367, res);
-Obj x139709265367495 = PRIM_CDR(l);
+Obj x140421013271207 = makeCons(x140421013271175, res);
+Obj x140421013271303 = PRIM_CDR(l);
 __nargs = 4;
-__arg0 = globalRef(symmap_45h);
-__arg1 = x139709265367399;
+__arg0 = globalRef(__symbolTable[148]);
+__arg1 = x140421013271207;
 __arg2 = f;
-__arg3 = x139709265367495;
+__arg3 = x140421013271303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5648,15 +5490,15 @@ label9:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj x139709265431591 = PRIM_ISCONS(l);
-if (True == x139709265431591) {
-Obj x139709265431815 = PRIM_CAR(l);
-Obj x139709265431847 = makeCons(x139709265431815, res);
-Obj x139709265431943 = PRIM_CDR(l);
+Obj x140421013392743 = PRIM_ISCONS(l);
+if (True == x140421013392743) {
+Obj x140421013392967 = PRIM_CAR(l);
+Obj x140421013392999 = makeCons(x140421013392967, res);
+Obj x140421013393095 = PRIM_CDR(l);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = x139709265431847;
-__arg2 = x139709265431943;
+__arg0 = globalRef(__symbolTable[150]);
+__arg1 = x140421013392999;
+__arg2 = x140421013393095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5674,9 +5516,9 @@ goto *jumpTable[co->ctx.pc.label];
 label10:
 {
 Obj x = __arg1;
-Obj x139709265431207 = PRIM_ISCONS(x);
+Obj x140421013392359 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = x139709265431207;
+__arg1 = x140421013392359;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5685,14 +5527,14 @@ goto *jumpTable[co->ctx.pc.label];
 label11:
 {
 Obj exp = __arg1;
-Obj x139709265430247 = PRIM_ISCONS(exp);
-if (True == x139709265430247) {
-Obj x139709265430471 = PRIM_CAR(exp);
-Obj x139709265430727 = PRIM_CDR(exp);
-pushCont(co, 12, clofun4, 1, x139709265430471);
+Obj x140421013391463 = PRIM_ISCONS(exp);
+if (True == x140421013391463) {
+Obj x140421013391687 = PRIM_CAR(exp);
+Obj x140421013391911 = PRIM_CDR(exp);
+pushCont(co, 12, clofun4, 1, x140421013391687);
 __nargs = 2;
-__arg0 = globalRef(symrcons);
-__arg1 = x139709265430727;
+__arg0 = globalRef(__symbolTable[153]);
+__arg1 = x140421013391911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5709,13 +5551,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label12:
 {
-Obj x139709265430759 = __arg1;
-Obj x139709265430471= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139709265430791 = makeCons(x139709265430759, Nil);
-Obj x139709265430823 = makeCons(x139709265430471, x139709265430791);
-Obj x139709265430855 = makeCons(symcons, x139709265430823);
+Obj x140421013391943 = __arg1;
+Obj x140421013391687= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013391975 = makeCons(x140421013391943, Nil);
+Obj x140421013392007 = makeCons(x140421013391687, x140421013391975);
+Obj x140421013392039 = makeCons(__symbolTable[152], x140421013392007);
 __nargs = 2;
-__arg1 = x139709265430855;
+__arg1 = x140421013392039;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5724,11 +5566,11 @@ goto *jumpTable[co->ctx.pc.label];
 label13:
 {
 Obj x = __arg1;
-Obj x139709265429799 = PRIM_CDR(x);
-Obj x139709265429831 = PRIM_CDR(x139709265429799);
-Obj x139709265429863 = PRIM_CDR(x139709265429831);
+Obj x140421013391015 = PRIM_CDR(x);
+Obj x140421013391047 = PRIM_CDR(x140421013391015);
+Obj x140421013391079 = PRIM_CDR(x140421013391047);
 __nargs = 2;
-__arg1 = x139709265429863;
+__arg1 = x140421013391079;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5737,12 +5579,12 @@ goto *jumpTable[co->ctx.pc.label];
 label14:
 {
 Obj x = __arg1;
-Obj x139709265429223 = PRIM_CDR(x);
-Obj x139709265429255 = PRIM_CDR(x139709265429223);
-Obj x139709265429287 = PRIM_CDR(x139709265429255);
-Obj x139709265429319 = PRIM_CAR(x139709265429287);
+Obj x140421013390471 = PRIM_CDR(x);
+Obj x140421013390503 = PRIM_CDR(x140421013390471);
+Obj x140421013390535 = PRIM_CDR(x140421013390503);
+Obj x140421013390567 = PRIM_CAR(x140421013390535);
 __nargs = 2;
-__arg1 = x139709265429319;
+__arg1 = x140421013390567;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5751,11 +5593,11 @@ goto *jumpTable[co->ctx.pc.label];
 label15:
 {
 Obj x = __arg1;
-Obj x139709265473447 = PRIM_CDR(x);
-Obj x139709265473479 = PRIM_CDR(x139709265473447);
-Obj x139709265473511 = PRIM_CAR(x139709265473479);
+Obj x140421013389895 = PRIM_CDR(x);
+Obj x140421013389927 = PRIM_CDR(x140421013389895);
+Obj x140421013389959 = PRIM_CAR(x140421013389927);
 __nargs = 2;
-__arg1 = x139709265473511;
+__arg1 = x140421013389959;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5764,10 +5606,10 @@ goto *jumpTable[co->ctx.pc.label];
 label16:
 {
 Obj x = __arg1;
-Obj x139709265472295 = PRIM_CDR(x);
-Obj x139709265472487 = PRIM_CDR(x139709265472295);
+Obj x140421013389415 = PRIM_CDR(x);
+Obj x140421013389447 = PRIM_CDR(x140421013389415);
 __nargs = 2;
-__arg1 = x139709265472487;
+__arg1 = x140421013389447;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5776,10 +5618,10 @@ goto *jumpTable[co->ctx.pc.label];
 label17:
 {
 Obj x = __arg1;
-Obj x139709265471463 = PRIM_CAR(x);
-Obj x139709265471495 = PRIM_CDR(x139709265471463);
+Obj x140421013470919 = PRIM_CAR(x);
+Obj x140421013470951 = PRIM_CDR(x140421013470919);
 __nargs = 2;
-__arg1 = x139709265471495;
+__arg1 = x140421013470951;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5788,10 +5630,10 @@ goto *jumpTable[co->ctx.pc.label];
 label18:
 {
 Obj x = __arg1;
-Obj x139709265470727 = PRIM_CAR(x);
-Obj x139709265470759 = PRIM_CAR(x139709265470727);
+Obj x140421013470439 = PRIM_CAR(x);
+Obj x140421013470535 = PRIM_CAR(x140421013470439);
 __nargs = 2;
-__arg1 = x139709265470759;
+__arg1 = x140421013470535;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5800,10 +5642,10 @@ goto *jumpTable[co->ctx.pc.label];
 label19:
 {
 Obj x = __arg1;
-Obj x139709265112999 = PRIM_CDR(x);
-Obj x139709265113031 = PRIM_CAR(x139709265112999);
+Obj x140421013470023 = PRIM_CDR(x);
+Obj x140421013470055 = PRIM_CAR(x140421013470023);
 __nargs = 2;
-__arg1 = x139709265113031;
+__arg1 = x140421013470055;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5812,9 +5654,9 @@ goto *jumpTable[co->ctx.pc.label];
 label20:
 {
 Obj x = __arg1;
-Obj x139709265112615 = PRIM_EQ(x, Nil);
+Obj x140421013469639 = PRIM_EQ(x, Nil);
 __nargs = 2;
-__arg1 = x139709265112615;
+__arg1 = x140421013469639;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];

--- a/lib/parallel/internal.c
+++ b/lib/parallel/internal.c
@@ -7,10 +7,21 @@
 #include "str.h"
 #include "runtime.h"
 
+
+extern void builtinImport(struct Cora *co);
+
 static void*
 startRoutine(void* arg) {
 	uintptr_t dummy;
 	struct Cora *co = coraInit(&dummy);
+	co->args[1] = makeCString("cora/init");
+	co->nargs = 2;
+	trampoline(co, 0, builtinImport);
+  
+	co->args[1] = makeCString("cora/lib/toc");
+	co->nargs = 2;
+	trampoline(co, 0, builtinImport);
+
 	strBuf path1 = arg;
 	str path = toStr(path1);
 	Obj filePath = makeString(path.str, path.len);

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -10,281 +10,152 @@ static void clofun5(struct Cora* co);
 static void clofun6(struct Cora* co);
 static void clofun7(struct Cora* co);
 static void clofun8(struct Cora* co);
+static void clofun9(struct Cora* co);
 
 
-static Obj symcora_47lib_47io_35close_45output_45file;
-static Obj symcora_47lib_47io_35open_45output_45file;
-static Obj symcora_47init_35macroexpand;
-static Obj symcora_47lib_47toc_35compile_45to_45c;
-static Obj symcora_47init_35read_45file_45as_45sexp;
-static Obj symcora_47lib_47toc_35preprocess;
-static Obj symcora_47lib_47toc_35split_45type_45and_45code_45toplevel;
-static Obj symcora_47lib_47infer_35_42typecheck_42;
-static Obj symcora_47lib_47toc_35generate_45typecheck_45code;
-static Obj symcora_47lib_47toc_35extract_45typecheck_45body;
-static Obj sym_58type;
-static Obj symdeclare;
-static Obj sym_58declare;
-static Obj symcora_47lib_47infer_35tvar;
-static Obj symbackquote;
-static Obj symmacroexpand;
-static Obj symcora_47lib_47infer_35check_45type_33;
-static Obj symcora_47lib_47toc_35split_45type_45and_45code;
-static Obj sympackage;
-static Obj symbegin;
-static Obj symexport;
-static Obj symimport;
-static Obj symcora_47lib_47toc_35handle_45import_45eagerly;
-static Obj symcora_47lib_47toc_35generate_45c;
-static Obj symcora_47init_35symbol_45_62string;
-static Obj symcora_47lib_47toc_35generate_45entry;
-static Obj symcora_47lib_47toc_35group_45by_45mod_45h;
-static Obj symcora_47lib_47toc_35generate_45toplevel_45group;
-static Obj symcora_47lib_47toc_35generate_45jumptable;
-static Obj symcora_47lib_47toc_35compile;
-static Obj symcora_47init_35cddr;
-static Obj sym_45_62;
-static Obj symcora_47init_35add_45to_45_42macros_42;
-static Obj symcora_47lib_47toc_35rewrite_45_45_62macro;
-static Obj symcora_47init_35vector;
-static Obj symcora_47lib_47toc_35collect_45lambda_45pass;
-static Obj symcora_47lib_47toc_35explicit_45stack_45pass;
-static Obj symcora_47lib_47toc_35tailify_45pass;
-static Obj symcora_47lib_47toc_35closure_45convert_45pass;
-static Obj symcora_47lib_47toc_35parse_45pass;
-static Obj symcora_47lib_47io_35display;
-static Obj symcora_47lib_47toc_35code_45gen_45toplevel;
-static Obj symcora_47lib_47toc_35generate_45call_45args_45reverse;
-static Obj symcora_47lib_47toc_35local_45from_45cont;
-static Obj symignore;
-static Obj symcora_47lib_47toc_35local_45from_45params;
-static Obj symcora_47lib_47toc_35code_45gen_45func_45declare;
-static Obj symcora_47lib_47toc_35generate_45inst_45list_45h;
-static Obj symcora_47lib_47toc_35for_45each;
-static Obj sym_37stack_45ref;
-static Obj symcora_47lib_47toc_47internal_35escape_45str;
-static Obj symcora_47lib_47toc_35generate_45inst_45list;
-static Obj symcora_47lib_47toc_35_42mod_45num_42;
-static Obj symcora_47lib_47hash_45h_35mod;
-static Obj symcora_47lib_47toc_35generate_45cont;
-static Obj symcora_47lib_47toc_35generate_45group_45name;
-static Obj symcora_47lib_47toc_47internal_35generate_45sym;
-static Obj symcora_47init_35value;
-static Obj symcora_47lib_47toc_35generate_45inst;
-static Obj symcora_47lib_47toc_47internal_35generate_45num;
-static Obj symcora_47lib_47toc_47internal_35generate_45str;
-static Obj symcora_47lib_47toc_35generate_45call_45list;
-static Obj symcora_47init_35vector_45set_33;
-static Obj symcora_47lib_47toc_35append_45result;
-static Obj symcora_47init_35vector_45ref;
-static Obj symcora_47lib_47toc_35collect_45lambda;
-static Obj sym_37continuation;
-static Obj symcora_47lib_47toc_35explicit_45stack;
-static Obj symcora_47init_35caar;
-static Obj symcora_47init_35pair_63;
-static Obj symcora_47lib_47toc_35wrap_45var;
-static Obj symcora_47init_35reverse;
-static Obj symcora_47lib_47toc_35tailify_45list;
-static Obj symcora_47lib_47toc_35tailify;
-static Obj symcora_47lib_47toc_35id;
-static Obj symcora_47lib_47toc_35closure_45convert;
-static Obj sym_37closure;
-static Obj symreturn;
-static Obj symcall;
-static Obj symtailcall;
-static Obj symcontinuation;
-static Obj symcora_47lib_47toc_35free_45vars;
-static Obj sym_37closure_45ref;
-static Obj symcora_47lib_47toc_35convert_45protect_63;
-static Obj symcora_47lib_47toc_35diff;
-static Obj symcora_47lib_47toc_35union;
-static Obj symcora_47init_35boolean_63;
-static Obj symcora_47init_35number_63;
-static Obj symquote;
-static Obj symdo;
-static Obj symlet;
-static Obj symif;
-static Obj symcora_47init_35append;
-static Obj symlambda;
-static Obj sym_37builtin;
-static Obj symcora_47init_35length;
-static Obj symcora_47init_35map;
-static Obj sym_37global;
-static Obj symcora_47lib_47toc_35add_45symbol_45to_45list;
-static Obj symcora_47init_35elem_63;
-static Obj sym_37const;
-static Obj symcora_47lib_47toc_35parse;
-static Obj symcora_47lib_47toc_35temp_45list;
-static Obj symcora_47init_35cadr;
-static Obj symcora_47lib_47toc_35builtin_45_62args;
-static Obj symcora_47init_35caddr;
-static Obj symcora_47lib_47toc_35builtin_45_62name;
-static Obj symcora_47init_35null_63;
-static Obj symcora_47lib_47toc_35builtin_63;
-static Obj symstring_63;
-static Obj syminteger_63;
-static Obj symnot;
-static Obj symsymbol_63;
-static Obj symgensym;
-static Obj sym_60;
-static Obj sym_62;
-static Obj sym_61;
-static Obj sym_47;
-static Obj sym_42;
-static Obj sym_45;
-static Obj sym_43;
-static Obj symcons_63;
-static Obj symcons;
-static Obj symcdr;
-static Obj symcar;
-static Obj symset;
-static Obj symcora_47lib_47toc_35_42builtin_45prims_42;
-static Obj symcora_47lib_47toc_35exist_45in_45env;
-static Obj symcora_47lib_47toc_35index;
-static Obj symcora_47lib_47toc_35pos_45in_45list0;
-static Obj symcora_47lib_47toc_35foldl;
-static Obj symcora_47lib_47toc_35error;
-static Obj symcora_47lib_47toc_35assq;
-static Obj symcora_47lib_47toc_35_42ns_45export_42;
-static Obj symcora_47init_35import;
+static __thread Obj* __symbolTable;
+
 void entry(struct Cora *co) {
-symcora_47lib_47io_35close_45output_45file = intern("cora/lib/io#close-output-file");
-symcora_47lib_47io_35open_45output_45file = intern("cora/lib/io#open-output-file");
-symcora_47init_35macroexpand = intern("cora/init#macroexpand");
-symcora_47lib_47toc_35compile_45to_45c = intern("cora/lib/toc#compile-to-c");
-symcora_47init_35read_45file_45as_45sexp = intern("cora/init#read-file-as-sexp");
-symcora_47lib_47toc_35preprocess = intern("cora/lib/toc#preprocess");
-symcora_47lib_47toc_35split_45type_45and_45code_45toplevel = intern("cora/lib/toc#split-type-and-code-toplevel");
-symcora_47lib_47infer_35_42typecheck_42 = intern("cora/lib/infer#*typecheck*");
-symcora_47lib_47toc_35generate_45typecheck_45code = intern("cora/lib/toc#generate-typecheck-code");
-symcora_47lib_47toc_35extract_45typecheck_45body = intern("cora/lib/toc#extract-typecheck-body");
-sym_58type = intern(":type");
-symdeclare = intern("declare");
-sym_58declare = intern(":declare");
-symcora_47lib_47infer_35tvar = intern("cora/lib/infer#tvar");
-symbackquote = intern("backquote");
-symmacroexpand = intern("macroexpand");
-symcora_47lib_47infer_35check_45type_33 = intern("cora/lib/infer#check-type!");
-symcora_47lib_47toc_35split_45type_45and_45code = intern("cora/lib/toc#split-type-and-code");
-sympackage = intern("package");
-symbegin = intern("begin");
-symexport = intern("export");
-symimport = intern("import");
-symcora_47lib_47toc_35handle_45import_45eagerly = intern("cora/lib/toc#handle-import-eagerly");
-symcora_47lib_47toc_35generate_45c = intern("cora/lib/toc#generate-c");
-symcora_47init_35symbol_45_62string = intern("cora/init#symbol->string");
-symcora_47lib_47toc_35generate_45entry = intern("cora/lib/toc#generate-entry");
-symcora_47lib_47toc_35group_45by_45mod_45h = intern("cora/lib/toc#group-by-mod-h");
-symcora_47lib_47toc_35generate_45toplevel_45group = intern("cora/lib/toc#generate-toplevel-group");
-symcora_47lib_47toc_35generate_45jumptable = intern("cora/lib/toc#generate-jumptable");
-symcora_47lib_47toc_35compile = intern("cora/lib/toc#compile");
-symcora_47init_35cddr = intern("cora/init#cddr");
-sym_45_62 = intern("->");
-symcora_47init_35add_45to_45_42macros_42 = intern("cora/init#add-to-*macros*");
-symcora_47lib_47toc_35rewrite_45_45_62macro = intern("cora/lib/toc#rewrite-->macro");
-symcora_47init_35vector = intern("cora/init#vector");
-symcora_47lib_47toc_35collect_45lambda_45pass = intern("cora/lib/toc#collect-lambda-pass");
-symcora_47lib_47toc_35explicit_45stack_45pass = intern("cora/lib/toc#explicit-stack-pass");
-symcora_47lib_47toc_35tailify_45pass = intern("cora/lib/toc#tailify-pass");
-symcora_47lib_47toc_35closure_45convert_45pass = intern("cora/lib/toc#closure-convert-pass");
-symcora_47lib_47toc_35parse_45pass = intern("cora/lib/toc#parse-pass");
-symcora_47lib_47io_35display = intern("cora/lib/io#display");
-symcora_47lib_47toc_35code_45gen_45toplevel = intern("cora/lib/toc#code-gen-toplevel");
-symcora_47lib_47toc_35generate_45call_45args_45reverse = intern("cora/lib/toc#generate-call-args-reverse");
-symcora_47lib_47toc_35local_45from_45cont = intern("cora/lib/toc#local-from-cont");
-symignore = intern("ignore");
-symcora_47lib_47toc_35local_45from_45params = intern("cora/lib/toc#local-from-params");
-symcora_47lib_47toc_35code_45gen_45func_45declare = intern("cora/lib/toc#code-gen-func-declare");
-symcora_47lib_47toc_35generate_45inst_45list_45h = intern("cora/lib/toc#generate-inst-list-h");
-symcora_47lib_47toc_35for_45each = intern("cora/lib/toc#for-each");
-sym_37stack_45ref = intern("%stack-ref");
-symcora_47lib_47toc_47internal_35escape_45str = intern("cora/lib/toc/internal#escape-str");
-symcora_47lib_47toc_35generate_45inst_45list = intern("cora/lib/toc#generate-inst-list");
-symcora_47lib_47toc_35_42mod_45num_42 = intern("cora/lib/toc#*mod-num*");
-symcora_47lib_47hash_45h_35mod = intern("cora/lib/hash-h#mod");
-symcora_47lib_47toc_35generate_45cont = intern("cora/lib/toc#generate-cont");
-symcora_47lib_47toc_35generate_45group_45name = intern("cora/lib/toc#generate-group-name");
-symcora_47lib_47toc_47internal_35generate_45sym = intern("cora/lib/toc/internal#generate-sym");
-symcora_47init_35value = intern("cora/init#value");
-symcora_47lib_47toc_35generate_45inst = intern("cora/lib/toc#generate-inst");
-symcora_47lib_47toc_47internal_35generate_45num = intern("cora/lib/toc/internal#generate-num");
-symcora_47lib_47toc_47internal_35generate_45str = intern("cora/lib/toc/internal#generate-str");
-symcora_47lib_47toc_35generate_45call_45list = intern("cora/lib/toc#generate-call-list");
-symcora_47init_35vector_45set_33 = intern("cora/init#vector-set!");
-symcora_47lib_47toc_35append_45result = intern("cora/lib/toc#append-result");
-symcora_47init_35vector_45ref = intern("cora/init#vector-ref");
-symcora_47lib_47toc_35collect_45lambda = intern("cora/lib/toc#collect-lambda");
-sym_37continuation = intern("%continuation");
-symcora_47lib_47toc_35explicit_45stack = intern("cora/lib/toc#explicit-stack");
-symcora_47init_35caar = intern("cora/init#caar");
-symcora_47init_35pair_63 = intern("cora/init#pair?");
-symcora_47lib_47toc_35wrap_45var = intern("cora/lib/toc#wrap-var");
-symcora_47init_35reverse = intern("cora/init#reverse");
-symcora_47lib_47toc_35tailify_45list = intern("cora/lib/toc#tailify-list");
-symcora_47lib_47toc_35tailify = intern("cora/lib/toc#tailify");
-symcora_47lib_47toc_35id = intern("cora/lib/toc#id");
-symcora_47lib_47toc_35closure_45convert = intern("cora/lib/toc#closure-convert");
-sym_37closure = intern("%closure");
-symreturn = intern("return");
-symcall = intern("call");
-symtailcall = intern("tailcall");
-symcontinuation = intern("continuation");
-symcora_47lib_47toc_35free_45vars = intern("cora/lib/toc#free-vars");
-sym_37closure_45ref = intern("%closure-ref");
-symcora_47lib_47toc_35convert_45protect_63 = intern("cora/lib/toc#convert-protect?");
-symcora_47lib_47toc_35diff = intern("cora/lib/toc#diff");
-symcora_47lib_47toc_35union = intern("cora/lib/toc#union");
-symcora_47init_35boolean_63 = intern("cora/init#boolean?");
-symcora_47init_35number_63 = intern("cora/init#number?");
-symquote = intern("quote");
-symdo = intern("do");
-symlet = intern("let");
-symif = intern("if");
-symcora_47init_35append = intern("cora/init#append");
-symlambda = intern("lambda");
-sym_37builtin = intern("%builtin");
-symcora_47init_35length = intern("cora/init#length");
-symcora_47init_35map = intern("cora/init#map");
-sym_37global = intern("%global");
-symcora_47lib_47toc_35add_45symbol_45to_45list = intern("cora/lib/toc#add-symbol-to-list");
-symcora_47init_35elem_63 = intern("cora/init#elem?");
-sym_37const = intern("%const");
-symcora_47lib_47toc_35parse = intern("cora/lib/toc#parse");
-symcora_47lib_47toc_35temp_45list = intern("cora/lib/toc#temp-list");
-symcora_47init_35cadr = intern("cora/init#cadr");
-symcora_47lib_47toc_35builtin_45_62args = intern("cora/lib/toc#builtin->args");
-symcora_47init_35caddr = intern("cora/init#caddr");
-symcora_47lib_47toc_35builtin_45_62name = intern("cora/lib/toc#builtin->name");
-symcora_47init_35null_63 = intern("cora/init#null?");
-symcora_47lib_47toc_35builtin_63 = intern("cora/lib/toc#builtin?");
-symstring_63 = intern("string?");
-syminteger_63 = intern("integer?");
-symnot = intern("not");
-symsymbol_63 = intern("symbol?");
-symgensym = intern("gensym");
-sym_60 = intern("<");
-sym_62 = intern(">");
-sym_61 = intern("=");
-sym_47 = intern("/");
-sym_42 = intern("*");
-sym_45 = intern("-");
-sym_43 = intern("+");
-symcons_63 = intern("cons?");
-symcons = intern("cons");
-symcdr = intern("cdr");
-symcar = intern("car");
-symset = intern("set");
-symcora_47lib_47toc_35_42builtin_45prims_42 = intern("cora/lib/toc#*builtin-prims*");
-symcora_47lib_47toc_35exist_45in_45env = intern("cora/lib/toc#exist-in-env");
-symcora_47lib_47toc_35index = intern("cora/lib/toc#index");
-symcora_47lib_47toc_35pos_45in_45list0 = intern("cora/lib/toc#pos-in-list0");
-symcora_47lib_47toc_35foldl = intern("cora/lib/toc#foldl");
-symcora_47lib_47toc_35error = intern("cora/lib/toc#error");
-symcora_47lib_47toc_35assq = intern("cora/lib/toc#assq");
-symcora_47lib_47toc_35_42ns_45export_42 = intern("cora/lib/toc#*ns-export*");
-symcora_47init_35import = intern("cora/init#import");
+__symbolTable = (Obj*)malloc(sizeof(Obj) * 136);
+__symbolTable[0] = intern("cora/lib/io#close-output-file");
+__symbolTable[1] = intern("cora/lib/io#open-output-file");
+__symbolTable[2] = intern("cora/init#macroexpand");
+__symbolTable[3] = intern("cora/lib/toc#compile-to-c");
+__symbolTable[4] = intern("cora/init#read-file-as-sexp");
+__symbolTable[5] = intern("cora/lib/toc#preprocess");
+__symbolTable[6] = intern("cora/lib/toc#split-type-and-code-toplevel");
+__symbolTable[7] = intern("cora/lib/infer#*typecheck*");
+__symbolTable[8] = intern("cora/lib/toc#generate-typecheck-code");
+__symbolTable[9] = intern("cora/lib/toc#extract-typecheck-body");
+__symbolTable[10] = intern(":type");
+__symbolTable[11] = intern("declare");
+__symbolTable[12] = intern(":declare");
+__symbolTable[13] = intern("cora/lib/infer#tvar");
+__symbolTable[14] = intern("backquote");
+__symbolTable[15] = intern("macroexpand");
+__symbolTable[16] = intern("cora/lib/infer#check-type!");
+__symbolTable[17] = intern("cora/lib/toc#split-type-and-code");
+__symbolTable[18] = intern("package");
+__symbolTable[19] = intern("begin");
+__symbolTable[20] = intern("export");
+__symbolTable[21] = intern("import");
+__symbolTable[22] = intern("cora/lib/toc#handle-import-eagerly");
+__symbolTable[23] = intern("cora/lib/toc#generate-c");
+__symbolTable[24] = intern("cora/init#symbol->string");
+__symbolTable[25] = intern("cora/lib/toc#generate-entry");
+__symbolTable[26] = intern("cora/lib/toc#group-by-mod-h");
+__symbolTable[27] = intern("cora/lib/toc#generate-toplevel-group");
+__symbolTable[28] = intern("cora/lib/toc#generate-jumptable");
+__symbolTable[29] = intern("cora/lib/toc#compile");
+__symbolTable[30] = intern("cora/init#cddr");
+__symbolTable[31] = intern("->");
+__symbolTable[32] = intern("cora/init#add-to-*macros*");
+__symbolTable[33] = intern("cora/lib/toc#rewrite-->macro");
+__symbolTable[34] = intern("cora/init#vector");
+__symbolTable[35] = intern("cora/lib/toc#collect-lambda-pass");
+__symbolTable[36] = intern("cora/lib/toc#explicit-stack-pass");
+__symbolTable[37] = intern("cora/lib/toc#tailify-pass");
+__symbolTable[38] = intern("cora/lib/toc#closure-convert-pass");
+__symbolTable[39] = intern("cora/lib/toc#parse-pass");
+__symbolTable[40] = intern("cora/lib/io#display");
+__symbolTable[41] = intern("cora/lib/toc#code-gen-toplevel");
+__symbolTable[42] = intern("cora/lib/toc#generate-call-args-reverse");
+__symbolTable[43] = intern("cora/lib/toc#local-from-cont");
+__symbolTable[44] = intern("ignore");
+__symbolTable[45] = intern("cora/lib/toc#local-from-params");
+__symbolTable[46] = intern("cora/lib/toc#code-gen-func-declare");
+__symbolTable[47] = intern("cora/lib/toc#for-each");
+__symbolTable[48] = intern("%stack-ref");
+__symbolTable[49] = intern("cora/lib/toc/internal#escape-str");
+__symbolTable[50] = intern("cora/lib/toc#generate-inst-list");
+__symbolTable[51] = intern("cora/lib/toc#*mod-num*");
+__symbolTable[52] = intern("cora/lib/hash-h#mod");
+__symbolTable[53] = intern("cora/lib/toc#generate-cont");
+__symbolTable[54] = intern("cora/lib/toc#generate-group-name");
+__symbolTable[55] = intern("cora/lib/toc/internal#generate-sym");
+__symbolTable[56] = intern("cora/lib/toc#symbol-offset");
+__symbolTable[57] = intern("cora/lib/toc#symbol-offset-h");
+__symbolTable[58] = intern("cora/init#value");
+__symbolTable[59] = intern("cora/lib/toc#generate-inst");
+__symbolTable[60] = intern("cora/lib/toc/internal#generate-num");
+__symbolTable[61] = intern("cora/lib/toc/internal#generate-str");
+__symbolTable[62] = intern("cora/lib/toc#generate-call-list");
+__symbolTable[63] = intern("cora/init#vector-set!");
+__symbolTable[64] = intern("cora/lib/toc#append-result");
+__symbolTable[65] = intern("cora/init#vector-ref");
+__symbolTable[66] = intern("cora/lib/toc#collect-lambda");
+__symbolTable[67] = intern("%continuation");
+__symbolTable[68] = intern("cora/lib/toc#explicit-stack");
+__symbolTable[69] = intern("cora/init#caar");
+__symbolTable[70] = intern("cora/init#pair?");
+__symbolTable[71] = intern("cora/lib/toc#wrap-var");
+__symbolTable[72] = intern("cora/init#reverse");
+__symbolTable[73] = intern("cora/lib/toc#tailify-list");
+__symbolTable[74] = intern("cora/lib/toc#tailify");
+__symbolTable[75] = intern("cora/lib/toc#id");
+__symbolTable[76] = intern("cora/lib/toc#closure-convert");
+__symbolTable[77] = intern("%closure");
+__symbolTable[78] = intern("return");
+__symbolTable[79] = intern("call");
+__symbolTable[80] = intern("tailcall");
+__symbolTable[81] = intern("continuation");
+__symbolTable[82] = intern("cora/lib/toc#free-vars");
+__symbolTable[83] = intern("%closure-ref");
+__symbolTable[84] = intern("cora/lib/toc#convert-protect?");
+__symbolTable[85] = intern("cora/lib/toc#diff");
+__symbolTable[86] = intern("cora/lib/toc#union");
+__symbolTable[87] = intern("cora/init#boolean?");
+__symbolTable[88] = intern("cora/init#number?");
+__symbolTable[89] = intern("quote");
+__symbolTable[90] = intern("do");
+__symbolTable[91] = intern("let");
+__symbolTable[92] = intern("if");
+__symbolTable[93] = intern("cora/init#append");
+__symbolTable[94] = intern("lambda");
+__symbolTable[95] = intern("%builtin");
+__symbolTable[96] = intern("cora/init#length");
+__symbolTable[97] = intern("cora/init#map");
+__symbolTable[98] = intern("%global");
+__symbolTable[99] = intern("cora/lib/toc#add-symbol-to-list");
+__symbolTable[100] = intern("cora/init#elem?");
+__symbolTable[101] = intern("%const");
+__symbolTable[102] = intern("cora/lib/toc#parse");
+__symbolTable[103] = intern("cora/lib/toc#temp-list");
+__symbolTable[104] = intern("cora/init#cadr");
+__symbolTable[105] = intern("cora/lib/toc#builtin->args");
+__symbolTable[106] = intern("cora/init#caddr");
+__symbolTable[107] = intern("cora/lib/toc#builtin->name");
+__symbolTable[108] = intern("cora/init#null?");
+__symbolTable[109] = intern("cora/lib/toc#builtin?");
+__symbolTable[110] = intern("string?");
+__symbolTable[111] = intern("integer?");
+__symbolTable[112] = intern("not");
+__symbolTable[113] = intern("symbol?");
+__symbolTable[114] = intern("gensym");
+__symbolTable[115] = intern("<");
+__symbolTable[116] = intern(">");
+__symbolTable[117] = intern("=");
+__symbolTable[118] = intern("/");
+__symbolTable[119] = intern("*");
+__symbolTable[120] = intern("-");
+__symbolTable[121] = intern("+");
+__symbolTable[122] = intern("cons?");
+__symbolTable[123] = intern("cons");
+__symbolTable[124] = intern("cdr");
+__symbolTable[125] = intern("car");
+__symbolTable[126] = intern("set");
+__symbolTable[127] = intern("cora/lib/toc#*builtin-prims*");
+__symbolTable[128] = intern("cora/lib/toc#exist-in-env");
+__symbolTable[129] = intern("cora/lib/toc#index");
+__symbolTable[130] = intern("cora/lib/toc#pos-in-list0");
+__symbolTable[131] = intern("cora/lib/toc#foldl");
+__symbolTable[132] = intern("cora/lib/toc#error");
+__symbolTable[133] = intern("cora/lib/toc#assq");
+__symbolTable[134] = intern("cora/lib/toc#*ns-export*");
+__symbolTable[135] = intern("cora/init#import");
 clofun0(co);
 }
+
 static void clofun0(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
@@ -300,7 +171,7 @@ label0:
 {
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35import);
+__arg0 = globalRef(__symbolTable[135]);
 __arg1 = makeCString("cora/lib/toc/internal");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -311,10 +182,10 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139886475385895 = __arg1;
+Obj x140421013680455 = __arg1;
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35import);
+__arg0 = globalRef(__symbolTable[135]);
 __arg1 = makeCString("cora/lib/io");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -325,10 +196,10 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139886475386055 = __arg1;
+Obj x140421013681383 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35import);
+__arg0 = globalRef(__symbolTable[135]);
 __arg1 = makeCString("cora/lib/hash-h");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -339,123 +210,124 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139886475386215 = __arg1;
-Obj x139886475386375 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
-Obj x139886475331943 = primSet(co, symcora_47lib_47toc_35assq, makeNative(37, clofun8, 2, 0));
-Obj x139886475333031 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(35, clofun8, 3, 0));
-Obj x139886475269671 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(33, clofun8, 3, 0));
-Obj x139886475269959 = primSet(co, symcora_47lib_47toc_35index, makeNative(32, clofun8, 2, 0));
-Obj x139886475271207 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(30, clofun8, 2, 0));
-Obj x139886475271623 = makeCons(makeCString("primSet"), Nil);
-Obj x139886475271655 = makeCons(MAKE_NUMBER(2), x139886475271623);
-Obj x139886475271687 = makeCons(symset, x139886475271655);
-Obj x139886475271975 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj x139886475272007 = makeCons(MAKE_NUMBER(1), x139886475271975);
-Obj x139886475272039 = makeCons(symcar, x139886475272007);
-Obj x139886475243655 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj x139886475243687 = makeCons(MAKE_NUMBER(1), x139886475243655);
-Obj x139886475243719 = makeCons(symcdr, x139886475243687);
-Obj x139886475244007 = makeCons(makeCString("makeCons"), Nil);
-Obj x139886475244039 = makeCons(MAKE_NUMBER(2), x139886475244007);
-Obj x139886475244071 = makeCons(symcons, x139886475244039);
-Obj x139886475244359 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj x139886475244391 = makeCons(MAKE_NUMBER(1), x139886475244359);
-Obj x139886475244423 = makeCons(symcons_63, x139886475244391);
-Obj x139886475244775 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj x139886475244807 = makeCons(MAKE_NUMBER(2), x139886475244775);
-Obj x139886475244839 = makeCons(sym_43, x139886475244807);
-Obj x139886475245127 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj x139886475245159 = makeCons(MAKE_NUMBER(2), x139886475245127);
-Obj x139886475245191 = makeCons(sym_45, x139886475245159);
-Obj x139886475245479 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj x139886475245511 = makeCons(MAKE_NUMBER(2), x139886475245479);
-Obj x139886475245543 = makeCons(sym_42, x139886475245511);
-Obj x139886475245831 = makeCons(makeCString("primDiv"), Nil);
-Obj x139886475245863 = makeCons(MAKE_NUMBER(2), x139886475245831);
-Obj x139886475245895 = makeCons(sym_47, x139886475245863);
-Obj x139886475246183 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj x139886475246215 = makeCons(MAKE_NUMBER(2), x139886475246183);
-Obj x139886475246247 = makeCons(sym_61, x139886475246215);
-Obj x139886475246535 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj x139886475246567 = makeCons(MAKE_NUMBER(2), x139886475246535);
-Obj x139886475246599 = makeCons(sym_62, x139886475246567);
-Obj x139886475246887 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj x139886475246919 = makeCons(MAKE_NUMBER(2), x139886475246887);
-Obj x139886475246951 = makeCons(sym_60, x139886475246919);
-Obj x139886475247239 = makeCons(makeCString("primGenSym"), Nil);
-Obj x139886475247271 = makeCons(MAKE_NUMBER(0), x139886475247239);
-Obj x139886475247303 = makeCons(symgensym, x139886475247271);
-Obj x139886475247591 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj x139886475190279 = makeCons(MAKE_NUMBER(1), x139886475247591);
-Obj x139886475190311 = makeCons(symsymbol_63, x139886475190279);
-Obj x139886475190599 = makeCons(makeCString("primNot"), Nil);
-Obj x139886475190631 = makeCons(MAKE_NUMBER(1), x139886475190599);
-Obj x139886475190663 = makeCons(symnot, x139886475190631);
-Obj x139886475190951 = makeCons(makeCString("primIsNumber"), Nil);
-Obj x139886475190983 = makeCons(MAKE_NUMBER(1), x139886475190951);
-Obj x139886475191015 = makeCons(syminteger_63, x139886475190983);
-Obj x139886475191303 = makeCons(makeCString("primIsString"), Nil);
-Obj x139886475191335 = makeCons(MAKE_NUMBER(1), x139886475191303);
-Obj x139886475191367 = makeCons(symstring_63, x139886475191335);
-Obj x139886475191399 = makeCons(x139886475191367, Nil);
-Obj x139886475191431 = makeCons(x139886475191015, x139886475191399);
-Obj x139886475191463 = makeCons(x139886475190663, x139886475191431);
-Obj x139886475191495 = makeCons(x139886475190311, x139886475191463);
-Obj x139886475191527 = makeCons(x139886475247303, x139886475191495);
-Obj x139886475191559 = makeCons(x139886475246951, x139886475191527);
-Obj x139886475191591 = makeCons(x139886475246599, x139886475191559);
-Obj x139886475191623 = makeCons(x139886475246247, x139886475191591);
-Obj x139886475191655 = makeCons(x139886475245895, x139886475191623);
-Obj x139886475191687 = makeCons(x139886475245543, x139886475191655);
-Obj x139886475191719 = makeCons(x139886475245191, x139886475191687);
-Obj x139886475191751 = makeCons(x139886475244839, x139886475191719);
-Obj x139886475191783 = makeCons(x139886475244423, x139886475191751);
-Obj x139886475191815 = makeCons(x139886475244071, x139886475191783);
-Obj x139886475191847 = makeCons(x139886475243719, x139886475191815);
-Obj x139886475191879 = makeCons(x139886475272039, x139886475191847);
-Obj x139886475191911 = makeCons(x139886475271687, x139886475191879);
-Obj x139886475191943 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, x139886475191911);
-Obj x139886475192455 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(27, clofun8, 1, 0));
-Obj x139886475193063 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(24, clofun8, 1, 0));
-Obj x139886475193671 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(21, clofun8, 1, 0));
-Obj x139886475182119 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(20, clofun8, 2, 0));
-Obj x139886475597863 = primSet(co, symcora_47lib_47toc_35parse, makeNative(38, clofun7, 3, 0));
-Obj x139886475567335 = primSet(co, symcora_47lib_47toc_35union, makeNative(34, clofun7, 2, 0));
-Obj x139886475569639 = primSet(co, symcora_47lib_47toc_35diff, makeNative(30, clofun7, 2, 0));
-Obj x139886475461351 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(24, clofun7, 1, 0));
-Obj x139886474651463 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(4, clofun7, 1, 0));
-Obj x139886474552167 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(42, clofun6, 2, 0));
-Obj x139886474552583 = primSet(co, symcora_47lib_47toc_35id, makeNative(41, clofun6, 1, 0));
-Obj x139886475984647 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(25, clofun6, 2, 0));
-Obj x139886475567463 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(18, clofun6, 3, 0));
-Obj x139886475464199 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(3, clofun6, 2, 0));
-Obj x139886475243527 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(44, clofun5, 2, 0));
-Obj x139886475245703 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(40, clofun5, 2, 0));
-Obj x139886475247175 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(38, clofun5, 2, 0));
-Obj x139886475183367 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(26, clofun5, 4, 0));
-Obj x139886475184391 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(23, clofun5, 2, 0));
-Obj x139886475570439 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(40, clofun3, 4, 0));
-Obj x139886475463175 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(16, clofun3, 3, 0));
-Obj x139886475383879 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(12, clofun3, 5, 0));
-Obj x139886475384359 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(11, clofun3, 4, 0));
-Obj x139886475384743 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
-Obj x139886475385831 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(9, clofun3, 3, 0));
-Obj x139886475330023 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(5, clofun3, 3, 0));
-Obj x139886475333319 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(48, clofun2, 3, 0));
-Obj x139886475269543 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(43, clofun2, 3, 0));
-Obj x139886475271847 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(41, clofun2, 4, 0));
-Obj x139886474650055 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(30, clofun2, 3, 0));
-Obj x139886474650599 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(29, clofun2, 2, 0));
-Obj x139886474651111 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(28, clofun2, 1, 0));
-Obj x139886474651559 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(27, clofun2, 1, 0));
-Obj x139886474652135 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(26, clofun2, 1, 0));
-Obj x139886474642151 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(20, clofun2, 1, 0));
-Obj x139886474643911 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(19, clofun2, 2, 0));
+Obj x140421013681863 = __arg1;
+Obj x140421013682023 = primSet(co, __symbolTable[134], Nil);
+Obj x140421013625063 = primSet(co, __symbolTable[133], makeNative(12, clofun9, 2, 0));
+Obj x140421013626503 = primSet(co, __symbolTable[131], makeNative(10, clofun9, 3, 0));
+Obj x140421013563751 = primSet(co, __symbolTable[130], makeNative(8, clofun9, 3, 0));
+Obj x140421013564039 = primSet(co, __symbolTable[129], makeNative(7, clofun9, 2, 0));
+Obj x140421013565319 = primSet(co, __symbolTable[128], makeNative(5, clofun9, 2, 0));
+Obj x140421013467495 = makeCons(makeCString("primSet"), Nil);
+Obj x140421013467527 = makeCons(MAKE_NUMBER(2), x140421013467495);
+Obj x140421013467559 = makeCons(__symbolTable[126], x140421013467527);
+Obj x140421013467847 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj x140421013467879 = makeCons(MAKE_NUMBER(1), x140421013467847);
+Obj x140421013467911 = makeCons(__symbolTable[125], x140421013467879);
+Obj x140421013468199 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj x140421013468231 = makeCons(MAKE_NUMBER(1), x140421013468199);
+Obj x140421013468263 = makeCons(__symbolTable[124], x140421013468231);
+Obj x140421013468551 = makeCons(makeCString("makeCons"), Nil);
+Obj x140421013468583 = makeCons(MAKE_NUMBER(2), x140421013468551);
+Obj x140421013468615 = makeCons(__symbolTable[123], x140421013468583);
+Obj x140421013468903 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj x140421013468935 = makeCons(MAKE_NUMBER(1), x140421013468903);
+Obj x140421013468967 = makeCons(__symbolTable[122], x140421013468935);
+Obj x140421013469255 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj x140421013469287 = makeCons(MAKE_NUMBER(2), x140421013469255);
+Obj x140421013469319 = makeCons(__symbolTable[121], x140421013469287);
+Obj x140421013469607 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj x140421013469639 = makeCons(MAKE_NUMBER(2), x140421013469607);
+Obj x140421013469671 = makeCons(__symbolTable[120], x140421013469639);
+Obj x140421013469959 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj x140421013469991 = makeCons(MAKE_NUMBER(2), x140421013469959);
+Obj x140421013470023 = makeCons(__symbolTable[119], x140421013469991);
+Obj x140421013470311 = makeCons(makeCString("primDiv"), Nil);
+Obj x140421013470343 = makeCons(MAKE_NUMBER(2), x140421013470311);
+Obj x140421013470375 = makeCons(__symbolTable[118], x140421013470343);
+Obj x140421013470663 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj x140421013470695 = makeCons(MAKE_NUMBER(2), x140421013470663);
+Obj x140421013470727 = makeCons(__symbolTable[117], x140421013470695);
+Obj x140421013471015 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj x140421013471047 = makeCons(MAKE_NUMBER(2), x140421013471015);
+Obj x140421013471079 = makeCons(__symbolTable[116], x140421013471047);
+Obj x140421013389447 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj x140421013389479 = makeCons(MAKE_NUMBER(2), x140421013389447);
+Obj x140421013389511 = makeCons(__symbolTable[115], x140421013389479);
+Obj x140421013389799 = makeCons(makeCString("primGenSym"), Nil);
+Obj x140421013389831 = makeCons(MAKE_NUMBER(0), x140421013389799);
+Obj x140421013389863 = makeCons(__symbolTable[114], x140421013389831);
+Obj x140421013390151 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj x140421013390183 = makeCons(MAKE_NUMBER(1), x140421013390151);
+Obj x140421013390215 = makeCons(__symbolTable[113], x140421013390183);
+Obj x140421013390503 = makeCons(makeCString("primNot"), Nil);
+Obj x140421013390535 = makeCons(MAKE_NUMBER(1), x140421013390503);
+Obj x140421013390567 = makeCons(__symbolTable[112], x140421013390535);
+Obj x140421013390855 = makeCons(makeCString("primIsNumber"), Nil);
+Obj x140421013390887 = makeCons(MAKE_NUMBER(1), x140421013390855);
+Obj x140421013390919 = makeCons(__symbolTable[111], x140421013390887);
+Obj x140421013391207 = makeCons(makeCString("primIsString"), Nil);
+Obj x140421013391239 = makeCons(MAKE_NUMBER(1), x140421013391207);
+Obj x140421013391271 = makeCons(__symbolTable[110], x140421013391239);
+Obj x140421013391303 = makeCons(x140421013391271, Nil);
+Obj x140421013391335 = makeCons(x140421013390919, x140421013391303);
+Obj x140421013391367 = makeCons(x140421013390567, x140421013391335);
+Obj x140421013391399 = makeCons(x140421013390215, x140421013391367);
+Obj x140421013391431 = makeCons(x140421013389863, x140421013391399);
+Obj x140421013391463 = makeCons(x140421013389511, x140421013391431);
+Obj x140421013391495 = makeCons(x140421013471079, x140421013391463);
+Obj x140421013391527 = makeCons(x140421013470727, x140421013391495);
+Obj x140421013391559 = makeCons(x140421013470375, x140421013391527);
+Obj x140421013391591 = makeCons(x140421013470023, x140421013391559);
+Obj x140421013391623 = makeCons(x140421013469671, x140421013391591);
+Obj x140421013391655 = makeCons(x140421013469319, x140421013391623);
+Obj x140421013391687 = makeCons(x140421013468967, x140421013391655);
+Obj x140421013391719 = makeCons(x140421013468615, x140421013391687);
+Obj x140421013391751 = makeCons(x140421013468263, x140421013391719);
+Obj x140421013391783 = makeCons(x140421013467911, x140421013391751);
+Obj x140421013391815 = makeCons(x140421013467559, x140421013391783);
+Obj x140421013391847 = primSet(co, __symbolTable[127], x140421013391815);
+Obj x140421013392359 = primSet(co, __symbolTable[109], makeNative(2, clofun9, 1, 0));
+Obj x140421013392967 = primSet(co, __symbolTable[107], makeNative(49, clofun8, 1, 0));
+Obj x140421013270695 = primSet(co, __symbolTable[105], makeNative(46, clofun8, 1, 0));
+Obj x140421013271431 = primSet(co, __symbolTable[103], makeNative(45, clofun8, 2, 0));
+Obj x140421012075239 = primSet(co, __symbolTable[102], makeNative(13, clofun8, 3, 0));
+Obj x140421012077447 = primSet(co, __symbolTable[86], makeNative(9, clofun8, 2, 0));
+Obj x140421012039335 = primSet(co, __symbolTable[85], makeNative(5, clofun8, 2, 0));
+Obj x140421011729831 = primSet(co, __symbolTable[84], makeNative(49, clofun7, 1, 0));
+Obj x140421013273287 = primSet(co, __symbolTable[82], makeNative(29, clofun7, 1, 0));
+Obj x140421012515175 = primSet(co, __symbolTable[76], makeNative(17, clofun7, 2, 0));
+Obj x140421012515623 = primSet(co, __symbolTable[75], makeNative(16, clofun7, 1, 0));
+Obj x140421011727079 = primSet(co, __symbolTable[74], makeNative(0, clofun7, 2, 0));
+Obj x140421011690951 = primSet(co, __symbolTable[73], makeNative(43, clofun6, 3, 0));
+Obj x140421011501031 = primSet(co, __symbolTable[68], makeNative(28, clofun6, 2, 0));
+Obj x140421013624071 = primSet(co, __symbolTable[66], makeNative(19, clofun6, 2, 0));
+Obj x140421013626759 = primSet(co, __symbolTable[64], makeNative(15, clofun6, 2, 0));
+Obj x140421013562983 = primSet(co, __symbolTable[71], makeNative(13, clofun6, 2, 0));
+Obj x140421013470119 = primSet(co, __symbolTable[62], makeNative(1, clofun6, 5, 0));
+Obj x140421013389575 = primSet(co, __symbolTable[99], makeNative(48, clofun5, 2, 0));
+Obj x140421013391111 = primSet(co, __symbolTable[57], makeNative(46, clofun5, 3, 0));
+Obj x140421013392231 = primSet(co, __symbolTable[56], makeNative(45, clofun5, 2, 0));
+Obj x140421011305287 = primSet(co, __symbolTable[59], makeNative(45, clofun3, 5, 0));
+Obj x140421011307879 = primSet(co, __symbolTable[50], makeNative(37, clofun3, 5, 0));
+Obj x140421013625863 = primSet(co, __symbolTable[53], makeNative(13, clofun3, 5, 0));
+Obj x140421013626279 = primSet(co, __symbolTable[51], MAKE_NUMBER(50));
+Obj x140421013562631 = primSet(co, __symbolTable[54], makeNative(11, clofun3, 3, 0));
+Obj x140421013564391 = primSet(co, __symbolTable[46], makeNative(7, clofun3, 3, 0));
+Obj x140421013469223 = primSet(co, __symbolTable[45], makeNative(0, clofun3, 3, 0));
+Obj x140421013389383 = primSet(co, __symbolTable[43], makeNative(45, clofun2, 3, 0));
+Obj x140421013392807 = primSet(co, __symbolTable[42], makeNative(43, clofun2, 4, 0));
+Obj x140421012514983 = primSet(co, __symbolTable[41], makeNative(32, clofun2, 4, 0));
+Obj x140421012515335 = primSet(co, __symbolTable[39], makeNative(31, clofun2, 2, 0));
+Obj x140421012515847 = primSet(co, __symbolTable[38], makeNative(30, clofun2, 1, 0));
+Obj x140421012516327 = primSet(co, __symbolTable[37], makeNative(29, clofun2, 1, 0));
+Obj x140421012516807 = primSet(co, __symbolTable[36], makeNative(28, clofun2, 1, 0));
+Obj x140421012392583 = primSet(co, __symbolTable[35], makeNative(22, clofun2, 1, 0));
+Obj x140421012120519 = primSet(co, __symbolTable[33], makeNative(21, clofun2, 2, 0));
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
-__arg1 = sym_45_62;
-__arg2 = makeNative(16, clofun2, 1, 0);
+__arg0 = globalRef(__symbolTable[32]);
+__arg1 = __symbolTable[31];
+__arg2 = makeNative(18, clofun2, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -465,24 +337,24 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139886474644935 = __arg1;
-Obj x139886474580551 = primSet(co, symcora_47lib_47toc_35compile, makeNative(10, clofun2, 2, 0));
-Obj x139886474582439 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(8, clofun2, 2, 0));
-Obj x139886474551847 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(4, clofun2, 3, 0));
-Obj x139886474307143 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(32, clofun1, 3, 0));
-Obj x139886474257575 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(28, clofun1, 4, 0));
-Obj x139886474141703 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(15, clofun1, 2, 0));
-Obj x139886474144327 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(2, clofun1, 3, 0));
-Obj x139886476799943 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(46, clofun0, 1, 0));
-Obj x139886477022407 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(41, clofun0, 4, 0));
-Obj x139886476724135 = primSet(co, symcora_47lib_47toc_35extract_45typecheck_45body, makeNative(32, clofun0, 2, 0));
-Obj x139886476724487 = primSet(co, symcora_47lib_47toc_35generate_45typecheck_45code, makeNative(31, clofun0, 2, 0));
-Obj x139886476145671 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code_45toplevel, makeNative(22, clofun0, 1, 0));
-Obj x139886476146119 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
-Obj x139886476106151 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
-Obj x139886476080583 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
+Obj x140421012121895 = __arg1;
+Obj x140421012123495 = primSet(co, __symbolTable[29], makeNative(12, clofun2, 2, 0));
+Obj x140421012097255 = primSet(co, __symbolTable[47], makeNative(10, clofun2, 2, 0));
+Obj x140421012075303 = primSet(co, __symbolTable[28], makeNative(6, clofun2, 3, 0));
+Obj x140421012041479 = primSet(co, __symbolTable[27], makeNative(34, clofun1, 4, 0));
+Obj x140421011726535 = primSet(co, __symbolTable[26], makeNative(30, clofun1, 4, 0));
+Obj x140421011690599 = primSet(co, __symbolTable[25], makeNative(15, clofun1, 2, 0));
+Obj x140421011628839 = primSet(co, __symbolTable[23], makeNative(3, clofun1, 3, 0));
+Obj x140421011441191 = primSet(co, __symbolTable[22], makeNative(47, clofun0, 1, 0));
+Obj x140421011359687 = primSet(co, __symbolTable[17], makeNative(42, clofun0, 4, 0));
+Obj x140421011265159 = primSet(co, __symbolTable[9], makeNative(33, clofun0, 2, 0));
+Obj x140421011265511 = primSet(co, __symbolTable[8], makeNative(32, clofun0, 2, 0));
+Obj x140421011199143 = primSet(co, __symbolTable[6], makeNative(23, clofun0, 1, 0));
+Obj x140421011199303 = primSet(co, __symbolTable[7], False);
+Obj x140421011201447 = primSet(co, __symbolTable[5], makeNative(13, clofun0, 1, 0));
+Obj x140421011133223 = primSet(co, __symbolTable[3], makeNative(5, clofun0, 2, 0));
 __nargs = 2;
-__arg1 = x139886476080583;
+__arg1 = x140421011133223;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -492,12 +364,12 @@ label5:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-Obj x139886476107047 = primGenSym();
-Obj globals = x139886476107047;
-Obj x139886476107303 = primSet(co, globals, Nil);
+Obj x140421011201735 = primGenSym();
+Obj globals = x140421011201735;
+Obj x140421011201895 = primSet(co, globals, Nil);
 pushCont(co, 6, clofun0, 3, from, to, globals);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35compile);
+__arg0 = globalRef(__symbolTable[29]);
 __arg1 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -508,13 +380,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139886476107655 = __arg1;
+Obj x140421011132487 = __arg1;
 Obj from= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun0, 3, x139886476107655, to, globals);
+pushCont(co, 7, clofun0, 3, x140421011132487, to, globals);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35preprocess);
+__arg0 = globalRef(__symbolTable[5]);
 __arg1 = from;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -525,14 +397,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139886476079463 = __arg1;
-Obj x139886476107655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011132647 = __arg1;
+Obj x140421011132487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun0, 3, x139886476107655, to, globals);
+pushCont(co, 8, clofun0, 3, x140421011132487, to, globals);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35macroexpand);
-__arg1 = x139886476079463;
+__arg0 = globalRef(__symbolTable[2]);
+__arg1 = x140421011132647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -542,14 +414,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886476079495 = __arg1;
-Obj x139886476107655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011132679 = __arg1;
+Obj x140421011132487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 9, clofun0, 2, to, globals);
 __nargs = 2;
-__arg0 = x139886476107655;
-__arg1 = x139886476079495;
+__arg0 = x140421011132487;
+__arg1 = x140421011132679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -559,13 +431,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139886476079527 = __arg1;
+Obj x140421011132711 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj bc = x139886476079527;
-pushCont(co, 10, clofun0, 2, bc, globals);
+Obj bc = x140421011132711;
+pushCont(co, 10, clofun0, 2, globals, bc);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35open_45output_45file);
+__arg0 = globalRef(__symbolTable[1]);
 __arg1 = to;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -576,16 +448,14 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139886476079911 = __arg1;
-Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stream = x139886476079911;
-pushCont(co, 11, clofun0, 1, stream);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45c);
-__arg1 = stream;
-__arg2 = bc;
-__arg3 = globals;
+Obj x140421011132871 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj stream = x140421011132871;
+pushCont(co, 11, clofun0, 2, bc, stream);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -595,11 +465,15 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139886476080295 = __arg1;
-Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35close_45output_45file);
+Obj x140421011133095 = __arg1;
+Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 12, clofun0, 1, stream);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[23]);
 __arg1 = stream;
+__arg2 = bc;
+__arg3 = x140421011133095;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -609,11 +483,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj file_45path = __arg1;
-PUSH_CONT_0(co, 13, clofun0);
+Obj x140421011133127 = __arg1;
+Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35read_45file_45as_45sexp);
-__arg1 = file_45path;
+__arg0 = globalRef(__symbolTable[0]);
+__arg1 = stream;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -623,13 +497,11 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139886476146663 = __arg1;
-Obj sexp = x139886476146663;
-Obj x139886476185639 = makeNative(21, clofun0, 1, 1, sexp);
-pushCont(co, 14, clofun0, 2, x139886476185639, sexp);
+Obj file_45path = __arg1;
+PUSH_CONT_0(co, 14, clofun0);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = sexp;
+__arg0 = globalRef(__symbolTable[4]);
+__arg1 = file_45path;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -639,53 +511,12 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886476148455 = __arg1;
-Obj x139886476185639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886476148455) {
-Obj x139886476103975 = PRIM_CAR(sexp);
-Obj x139886476104007 = PRIM_EQ(symbegin, x139886476103975);
-if (True == x139886476104007) {
-pushCont(co, 19, clofun0, 1, sexp);
+Obj x140421011199655 = __arg1;
+Obj sexp = x140421011199655;
+Obj x140421013681319 = makeNative(22, clofun0, 1, 1, sexp);
+pushCont(co, 15, clofun0, 2, x140421013681319, sexp);
 __nargs = 2;
-__arg0 = x139886476185639;
-__arg1 = True;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 17, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = x139886476185639;
-__arg1 = False;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 15, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = x139886476185639;
-__arg1 = False;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139886476105671 = __arg1;
-Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 16, clofun0, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[70]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -694,12 +525,55 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label15:
+{
+Obj x140421011200391 = __arg1;
+Obj x140421013681319= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421011200391) {
+Obj x140421011200615 = PRIM_CAR(sexp);
+Obj x140421011200647 = PRIM_EQ(__symbolTable[19], x140421011200615);
+if (True == x140421011200647) {
+pushCont(co, 20, clofun0, 1, sexp);
+__nargs = 2;
+__arg0 = x140421013681319;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 18, clofun0, 1, sexp);
+__nargs = 2;
+__arg0 = x140421013681319;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 16, clofun0, 1, sexp);
+__nargs = 2;
+__arg0 = x140421013681319;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label16:
 {
-Obj x139886476106055 = __arg1;
+Obj x140421011201191 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 17, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -710,11 +584,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139886476105287 = __arg1;
+Obj x140421011201351 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 18, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[6]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -725,10 +598,11 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886476105575 = __arg1;
+Obj x140421011200935 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 19, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -739,11 +613,10 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139886476104071 = __arg1;
+Obj x140421011201095 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 20, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[6]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -754,10 +627,11 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139886476105191 = __arg1;
+Obj x140421011200679 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 21, clofun0, 1, sexp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code_45toplevel);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -768,89 +642,88 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139886476185959 = __arg1;
-if (True == x139886476185959) {
-Obj x139886476147655 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011200839 = __arg1;
+Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg1 = x139886476147655;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886476147879 = makeCons(closureRef(co, 0), Nil);
-__nargs = 2;
-__arg1 = x139886476147879;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
+__arg0 = globalRef(__symbolTable[6]);
+__arg1 = sexp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label22:
 {
-Obj x139886476185799 = __arg1;
-Obj x139886476187271 = makeNative(25, clofun0, 0, 1, x139886476185799);
-Obj x139886476188135 = PRIM_ISCONS(x139886476185799);
-if (True == x139886476188135) {
-Obj x139886476188615 = PRIM_CAR(x139886476185799);
-Obj x139886476188647 = PRIM_EQ(sympackage, x139886476188615);
-if (True == x139886476188647) {
-Obj x139886476189319 = PRIM_CDR(x139886476185799);
-Obj more = x139886476189319;
-Obj x139886476144743 = makeCons(sympackage, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = x139886476144743;
-__arg2 = makeNative(23, clofun0, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421013681351 = __arg1;
+if (True == x140421013681351) {
+Obj x140421011200039 = PRIM_CDR(closureRef(co, 0));
+__nargs = 2;
+__arg1 = x140421011200039;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139886476187271;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187271;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421011200167 = makeCons(closureRef(co, 0), Nil);
+__nargs = 2;
+__arg1 = x140421011200167;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label23:
 {
-Obj body = __arg1;
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = body;
-__arg2 = Nil;
-__arg3 = Nil;
-co->args[4] = makeNative(24, clofun0, 2, 0);
+Obj x140421013681415 = __arg1;
+Obj x140421013681671 = makeNative(26, clofun0, 0, 1, x140421013681415);
+Obj x140421011198151 = PRIM_ISCONS(x140421013681415);
+if (True == x140421011198151) {
+Obj x140421011198375 = PRIM_CAR(x140421013681415);
+Obj x140421011198407 = PRIM_EQ(__symbolTable[18], x140421011198375);
+if (True == x140421011198407) {
+Obj x140421011198567 = PRIM_CDR(x140421013681415);
+Obj more = x140421011198567;
+Obj x140421011198727 = makeCons(__symbolTable[18], more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[9]);
+__arg1 = x140421011198727;
+__arg2 = makeNative(24, clofun0, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013681671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013681671;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label24:
 {
-Obj type = __arg1;
-Obj code = __arg2;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
-__arg1 = type;
-__arg2 = code;
+Obj body = __arg1;
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[17]);
+__arg1 = body;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(25, clofun0, 2, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -860,68 +733,68 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139886476188871 = makeNative(28, clofun0, 0, 1, closureRef(co, 0));
-Obj x139886476725575 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476725575) {
-Obj x139886476725831 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476725863 = PRIM_EQ(symbegin, x139886476725831);
-if (True == x139886476725863) {
-Obj x139886476726055 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886476726055;
-Obj x139886476726215 = makeCons(symbegin, more);
+Obj type = __arg1;
+Obj code = __arg2;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = x139886476726215;
-__arg2 = makeNative(26, clofun0, 1, 0);
+__arg0 = globalRef(__symbolTable[8]);
+__arg1 = type;
+__arg2 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476188871;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476188871;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label26:
 {
-Obj body = __arg1;
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = body;
-__arg2 = Nil;
-__arg3 = Nil;
-co->args[4] = makeNative(27, clofun0, 2, 0);
+Obj x140421013682279 = makeNative(29, clofun0, 0, 1, closureRef(co, 0));
+Obj x140421011266599 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011266599) {
+Obj x140421011266855 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011266887 = PRIM_EQ(__symbolTable[19], x140421011266855);
+if (True == x140421011266887) {
+Obj x140421011267079 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011267079;
+Obj x140421011267239 = makeCons(__symbolTable[19], more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[9]);
+__arg1 = x140421011267239;
+__arg2 = makeNative(27, clofun0, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013682279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013682279;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label27:
 {
-Obj type = __arg1;
-Obj code = __arg2;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
-__arg1 = type;
-__arg2 = code;
+Obj body = __arg1;
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[17]);
+__arg1 = body;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(28, clofun0, 2, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -931,27 +804,10 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886476725127 = makeCons(closureRef(co, 0), Nil);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = x139886476725127;
-__arg2 = Nil;
-__arg3 = Nil;
-co->args[4] = makeNative(29, clofun0, 2, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label29:
-{
 Obj type = __arg1;
 Obj code = __arg2;
-PUSH_CONT_0(co, 30, clofun0);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45typecheck_45code);
+__arg0 = globalRef(__symbolTable[8]);
 __arg1 = type;
 __arg2 = code;
 co->ctx.frees = __arg0;
@@ -961,24 +817,56 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
+label29:
+{
+Obj x140421011266151 = makeCons(closureRef(co, 0), Nil);
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[17]);
+__arg1 = x140421011266151;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(30, clofun0, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label30:
 {
-Obj x139886476725351 = __arg1;
-Obj x139886476725383 = makeCons(symbegin, x139886476725351);
+Obj type = __arg1;
+Obj code = __arg2;
+PUSH_CONT_0(co, 31, clofun0);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[8]);
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
+Obj x140421011266375 = __arg1;
+Obj x140421011266407 = makeCons(__symbolTable[19], x140421011266375);
 __nargs = 2;
-__arg1 = x139886476725383;
+__arg1 = x140421011266407;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label31:
+label32:
 {
 Obj type = __arg1;
 Obj code = __arg2;
-if (True == globalRef(symcora_47lib_47infer_35_42typecheck_42)) {
+if (True == globalRef(__symbolTable[7])) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35append);
+__arg0 = globalRef(__symbolTable[93]);
 __arg1 = type;
 __arg2 = code;
 co->ctx.frees = __arg0;
@@ -995,257 +883,196 @@ goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label32:
-{
-Obj x139886476186727 = __arg1;
-Obj x139886476186759 = __arg2;
-Obj x139886476189095 = makeNative(34, clofun0, 0, 2, x139886476186727, x139886476186759);
-Obj x139886476799303 = PRIM_ISCONS(x139886476186727);
-if (True == x139886476799303) {
-Obj x139886476799591 = PRIM_CAR(x139886476186727);
-Obj x139886476799687 = PRIM_EQ(sympackage, x139886476799591);
-if (True == x139886476799687) {
-Obj x139886476799911 = PRIM_CDR(x139886476186727);
-Obj x139886476799975 = PRIM_ISCONS(x139886476799911);
-if (True == x139886476799975) {
-Obj x139886476723335 = PRIM_CDR(x139886476186727);
-Obj x139886476723367 = PRIM_CAR(x139886476723335);
-Obj name = x139886476723367;
-Obj x139886476723591 = PRIM_CDR(x139886476186727);
-Obj x139886476723623 = PRIM_CDR(x139886476723591);
-Obj more = x139886476723623;
-pushCont(co, 33, clofun0, 1, name);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = more;
-__arg2 = x139886476186759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476189095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476189095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476189095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
 label33:
 {
-Obj x139886476723847 = __arg1;
-Obj name= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476723879 = makeCons(name, x139886476723847);
-Obj x139886476723911 = makeCons(sympackage, x139886476723879);
-__nargs = 2;
-__arg1 = x139886476723911;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013561895 = __arg1;
+Obj x140421013561927 = __arg2;
+Obj x140421013562087 = makeNative(35, clofun0, 0, 2, x140421013561895, x140421013561927);
+Obj x140421011263623 = PRIM_ISCONS(x140421013561895);
+if (True == x140421011263623) {
+Obj x140421011263847 = PRIM_CAR(x140421013561895);
+Obj x140421011263879 = PRIM_EQ(__symbolTable[18], x140421011263847);
+if (True == x140421011263879) {
+Obj x140421011264103 = PRIM_CDR(x140421013561895);
+Obj x140421011264135 = PRIM_ISCONS(x140421011264103);
+if (True == x140421011264135) {
+Obj x140421011264359 = PRIM_CDR(x140421013561895);
+Obj x140421011264391 = PRIM_CAR(x140421011264359);
+Obj name = x140421011264391;
+Obj x140421011264615 = PRIM_CDR(x140421013561895);
+Obj x140421011264647 = PRIM_CDR(x140421011264615);
+Obj more = x140421011264647;
+pushCont(co, 34, clofun0, 1, name);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[9]);
+__arg1 = more;
+__arg2 = x140421013561927;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013562087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label34:
 {
-Obj x139886476147143 = makeNative(36, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886477008647 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477008647) {
-Obj x139886476795975 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476796007 = PRIM_ISCONS(x139886476795975);
-if (True == x139886476796007) {
-Obj x139886476796359 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476796391 = PRIM_CAR(x139886476796359);
-Obj x139886476796423 = PRIM_EQ(symimport, x139886476796391);
-if (True == x139886476796423) {
-Obj x139886476796903 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476796935 = PRIM_CDR(x139886476796903);
-Obj x139886476796967 = PRIM_ISCONS(x139886476796935);
-if (True == x139886476796967) {
-Obj x139886476797383 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476797415 = PRIM_CDR(x139886476797383);
-Obj x139886476797447 = PRIM_CAR(x139886476797415);
-Obj pkg = x139886476797447;
-Obj x139886476797863 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476797895 = PRIM_CDR(x139886476797863);
-Obj x139886476797927 = PRIM_CDR(x139886476797895);
-Obj x139886476797959 = PRIM_EQ(Nil, x139886476797927);
-if (True == x139886476797959) {
-Obj x139886476798215 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886476798215;
-Obj x139886476798471 = makeCons(pkg, Nil);
-Obj x139886476798503 = makeCons(symimport, x139886476798471);
-pushCont(co, 35, clofun0, 1, x139886476798503);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = more;
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476147143;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476147143;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476147143;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476147143;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476147143;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x140421011264871 = __arg1;
+Obj name= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011264903 = makeCons(name, x140421011264871);
+Obj x140421011264935 = makeCons(__symbolTable[18], x140421011264903);
+__nargs = 2;
+__arg1 = x140421011264935;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label35:
 {
-Obj x139886476798663 = __arg1;
-Obj x139886476798503= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476798695 = makeCons(x139886476798503, x139886476798663);
-__nargs = 2;
-__arg1 = x139886476798695;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013562695 = makeNative(37, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421011307015 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011307015) {
+Obj x140421011307367 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011307431 = PRIM_ISCONS(x140421011307367);
+if (True == x140421011307431) {
+Obj x140421011307815 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011307911 = PRIM_CAR(x140421011307815);
+Obj x140421011307943 = PRIM_EQ(__symbolTable[21], x140421011307911);
+if (True == x140421011307943) {
+Obj x140421011308263 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011308295 = PRIM_CDR(x140421011308263);
+Obj x140421011308327 = PRIM_ISCONS(x140421011308295);
+if (True == x140421011308327) {
+Obj x140421011275975 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011276007 = PRIM_CDR(x140421011275975);
+Obj x140421011276039 = PRIM_CAR(x140421011276007);
+Obj pkg = x140421011276039;
+Obj x140421011276551 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011276583 = PRIM_CDR(x140421011276551);
+Obj x140421011276615 = PRIM_CDR(x140421011276583);
+Obj x140421011276711 = PRIM_EQ(Nil, x140421011276615);
+if (True == x140421011276711) {
+Obj x140421011276935 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011276935;
+Obj x140421011277191 = makeCons(pkg, Nil);
+Obj x140421011277223 = makeCons(__symbolTable[21], x140421011277191);
+pushCont(co, 36, clofun0, 1, x140421011277223);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[9]);
+__arg1 = more;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013562695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562695;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label36:
 {
-Obj x139886476106407 = makeNative(38, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886477006407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477006407) {
-Obj x139886477006695 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477006759 = PRIM_ISCONS(x139886477006695);
-if (True == x139886477006759) {
-Obj x139886477007111 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477007143 = PRIM_CAR(x139886477007111);
-Obj x139886477007175 = PRIM_EQ(symexport, x139886477007143);
-if (True == x139886477007175) {
-Obj x139886477007463 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477007495 = PRIM_CDR(x139886477007463);
-Obj symbols = x139886477007495;
-Obj x139886477007751 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886477007751;
-Obj x139886477007911 = makeCons(symexport, symbols);
-pushCont(co, 37, clofun0, 1, x139886477007911);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
-__arg1 = more;
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476106407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x140421011279495 = __arg1;
+Obj x140421011277223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011279527 = makeCons(x140421011277223, x140421011279495);
+__nargs = 2;
+__arg1 = x140421011279527;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label37:
 {
-Obj x139886477008135 = __arg1;
-Obj x139886477007911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886477008167 = makeCons(x139886477007911, x139886477008135);
-__nargs = 2;
-__arg1 = x139886477008167;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun0) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label38:
-{
-Obj x139886476080903 = makeNative(40, clofun0, 0, 2, closureRef(co, 1), closureRef(co, 0));
-Obj x139886477004871 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477004871) {
-Obj x139886477005223 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477005287 = PRIM_EQ(symbegin, x139886477005223);
-if (True == x139886477005287) {
-Obj x139886477005479 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886477005479;
-PUSH_CONT_0(co, 39, clofun0);
+Obj x140421013563559 = makeNative(39, clofun0, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421011304871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011304871) {
+Obj x140421011305159 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011305191 = PRIM_ISCONS(x140421011305159);
+if (True == x140421011305191) {
+Obj x140421011305575 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011305607 = PRIM_CAR(x140421011305575);
+Obj x140421011305671 = PRIM_EQ(__symbolTable[20], x140421011305607);
+if (True == x140421011305671) {
+Obj x140421011305927 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011305959 = PRIM_CDR(x140421011305927);
+Obj symbols = x140421011305959;
+Obj x140421011306215 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011306215;
+Obj x140421011306407 = makeCons(__symbolTable[20], symbols);
+pushCont(co, 38, clofun0, 1, x140421011306407);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35extract_45typecheck_45body);
+__arg0 = globalRef(__symbolTable[9]);
 __arg1 = more;
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -1255,7 +1082,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476080903;
+__arg0 = x140421013563559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1264,7 +1091,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476080903;
+__arg0 = x140421013563559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563559;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1273,18 +1109,70 @@ goto *jumpTable[ps.label];
 }
 }
 
-label39:
+label38:
 {
-Obj x139886477005895 = __arg1;
-Obj x139886477005927 = makeCons(symbegin, x139886477005895);
+Obj x140421011306567 = __arg1;
+Obj x140421011306407= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011306599 = makeCons(x140421011306407, x140421011306567);
 __nargs = 2;
-__arg1 = x139886477005927;
+__arg1 = x140421011306599;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
+label39:
+{
+Obj x140421013564103 = makeNative(41, clofun0, 0, 2, closureRef(co, 1), closureRef(co, 0));
+Obj x140421011360871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011360871) {
+Obj x140421011361255 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011361287 = PRIM_EQ(__symbolTable[19], x140421011361255);
+if (True == x140421011361287) {
+Obj x140421011361575 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011361575;
+PUSH_CONT_0(co, 40, clofun0);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[9]);
+__arg1 = more;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013564103;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013564103;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label40:
+{
+Obj x140421011304455 = __arg1;
+Obj x140421011304487 = makeCons(__symbolTable[19], x140421011304455);
+__nargs = 2;
+__arg1 = x140421011304487;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun0) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label41:
 {
 __nargs = 2;
 __arg0 = closureRef(co, 0);
@@ -1296,47 +1184,47 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label41:
+label42:
 {
-Obj x139886476104999 = __arg1;
-Obj x139886476105031 = __arg2;
-Obj x139886476105063 = __arg3;
-Obj x139886476105095 = co->args[4];
-Obj x139886477021479 = PRIM_EQ(Nil, x139886476104999);
-if (True == x139886477021479) {
-pushCont(co, 44, clofun0, 2, x139886476105063, x139886476105095);
+Obj x140421013622823 = __arg1;
+Obj x140421013622855 = __arg2;
+Obj x140421013622951 = __arg3;
+Obj x140421013623367 = co->args[4];
+Obj x140421011441831 = PRIM_EQ(Nil, x140421013622823);
+if (True == x140421011441831) {
+pushCont(co, 45, clofun0, 2, x140421013622951, x140421013623367);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476105031;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013622855;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886476082887 = makeNative(42, clofun0, 0, 4, x139886476104999, x139886476105031, x139886476105063, x139886476105095);
-Obj x139886476722695 = PRIM_ISCONS(x139886476104999);
-if (True == x139886476722695) {
-Obj x139886476722919 = PRIM_CAR(x139886476104999);
-Obj x139886476722951 = PRIM_ISCONS(x139886476722919);
-if (True == x139886476722951) {
-Obj x139886477021287 = PRIM_CAR(x139886476104999);
-Obj x139886477021319 = PRIM_CAR(x139886477021287);
-Obj x139886477021351 = PRIM_EQ(sym_58type, x139886477021319);
-if (True == x139886477021351) {
-Obj x139886477021607 = PRIM_CAR(x139886476104999);
-Obj x139886477021671 = PRIM_CDR(x139886477021607);
-Obj exp = x139886477021671;
-Obj x139886477021863 = PRIM_CDR(x139886476104999);
-Obj more = x139886477021863;
-Obj x139886477022087 = makeCons(symbegin, exp);
-Obj x139886477022119 = makeCons(x139886477022087, x139886476105031);
+Obj x140421013624519 = makeNative(43, clofun0, 0, 4, x140421013622823, x140421013622855, x140421013622951, x140421013623367);
+Obj x140421011357863 = PRIM_ISCONS(x140421013622823);
+if (True == x140421011357863) {
+Obj x140421011358087 = PRIM_CAR(x140421013622823);
+Obj x140421011358119 = PRIM_ISCONS(x140421011358087);
+if (True == x140421011358119) {
+Obj x140421011358439 = PRIM_CAR(x140421013622823);
+Obj x140421011358471 = PRIM_CAR(x140421011358439);
+Obj x140421011358503 = PRIM_EQ(__symbolTable[10], x140421011358471);
+if (True == x140421011358503) {
+Obj x140421011358791 = PRIM_CAR(x140421013622823);
+Obj x140421011358887 = PRIM_CDR(x140421011358791);
+Obj exp = x140421011358887;
+Obj x140421011359047 = PRIM_CDR(x140421013622823);
+Obj more = x140421011359047;
+Obj x140421011359335 = makeCons(__symbolTable[19], exp);
+Obj x140421011359367 = makeCons(x140421011359335, x140421013622855);
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
+__arg0 = globalRef(__symbolTable[17]);
 __arg1 = more;
-__arg2 = x139886477022119;
-__arg3 = x139886476105063;
-co->args[4] = x139886476105095;
+__arg2 = x140421011359367;
+__arg3 = x140421013622951;
+co->args[4] = x140421013623367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1344,16 +1232,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476082887;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476082887;
+__arg0 = x140421013624519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1362,7 +1241,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476082887;
+__arg0 = x140421013624519;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1372,29 +1260,29 @@ goto *jumpTable[ps.label];
 }
 }
 
-label42:
+label43:
 {
-Obj x139886475596263 = makeNative(43, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886477023943 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477023943) {
-Obj x139886477024199 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477024231 = PRIM_ISCONS(x139886477024199);
-if (True == x139886477024231) {
-Obj x139886477024551 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477024583 = PRIM_CAR(x139886477024551);
-Obj x139886477024615 = PRIM_EQ(sym_58declare, x139886477024583);
-if (True == x139886477024615) {
-Obj x139886477024871 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477024903 = PRIM_CDR(x139886477024871);
-Obj exp = x139886477024903;
-Obj x139886477025095 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886477025095;
-Obj x139886476722215 = makeCons(symdeclare, exp);
-Obj x139886476722279 = makeCons(x139886476722215, closureRef(co, 1));
+Obj x140421013625543 = makeNative(44, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421011367719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011367719) {
+Obj x140421011367975 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011368007 = PRIM_ISCONS(x140421011367975);
+if (True == x140421011368007) {
+Obj x140421011368487 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011368519 = PRIM_CAR(x140421011368487);
+Obj x140421011368551 = PRIM_EQ(__symbolTable[12], x140421011368519);
+if (True == x140421011368551) {
+Obj x140421011368999 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011369031 = PRIM_CDR(x140421011368999);
+Obj exp = x140421011369031;
+Obj x140421011369287 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011369287;
+Obj x140421011369511 = makeCons(__symbolTable[11], exp);
+Obj x140421011369671 = makeCons(x140421011369511, closureRef(co, 1));
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
+__arg0 = globalRef(__symbolTable[17]);
 __arg1 = more;
-__arg2 = x139886476722279;
+__arg2 = x140421011369671;
 __arg3 = closureRef(co, 2);
 co->args[4] = closureRef(co, 3);
 co->ctx.frees = __arg0;
@@ -1404,7 +1292,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475596263;
+__arg0 = x140421013625543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1413,7 +1301,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475596263;
+__arg0 = x140421013625543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1422,48 +1310,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475596263;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label43:
-{
-Obj x139886477022183 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477022183) {
-Obj x139886477022375 = PRIM_CAR(closureRef(co, 0));
-Obj exp = x139886477022375;
-Obj x139886477022567 = PRIM_CDR(closureRef(co, 0));
-Obj more = x139886477022567;
-Obj x139886477023111 = makeCons(exp, Nil);
-Obj x139886477023143 = makeCons(symbackquote, x139886477023111);
-Obj x139886477023175 = makeCons(x139886477023143, Nil);
-Obj x139886477023207 = makeCons(symmacroexpand, x139886477023175);
-Obj x139886477023367 = makeCons(symcora_47lib_47infer_35tvar, Nil);
-Obj x139886477023399 = makeCons(x139886477023367, Nil);
-Obj x139886477023431 = makeCons(x139886477023207, x139886477023399);
-Obj x139886477023463 = makeCons(symcora_47lib_47infer_35check_45type_33, x139886477023431);
-Obj x139886477023527 = makeCons(x139886477023463, closureRef(co, 1));
-Obj x139886477023655 = makeCons(exp, closureRef(co, 2));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
-__arg1 = more;
-__arg2 = x139886477023527;
-__arg3 = x139886477023655;
-co->args[4] = closureRef(co, 3);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg0 = x140421013625543;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1474,29 +1321,54 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139886477021639 = __arg1;
-Obj x139886476105063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476105095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 45, clofun0, 2, x139886476105095, x139886477021639);
+Obj x140421011442951 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011442951) {
+Obj x140421011443303 = PRIM_CAR(closureRef(co, 0));
+Obj exp = x140421011443303;
+Obj x140421011443527 = PRIM_CDR(closureRef(co, 0));
+Obj more = x140421011443527;
+Obj x140421011366631 = makeCons(exp, Nil);
+Obj x140421011366663 = makeCons(__symbolTable[14], x140421011366631);
+Obj x140421011366695 = makeCons(x140421011366663, Nil);
+Obj x140421011366759 = makeCons(__symbolTable[15], x140421011366695);
+Obj x140421011366983 = makeCons(__symbolTable[13], Nil);
+Obj x140421011367015 = makeCons(x140421011366983, Nil);
+Obj x140421011367111 = makeCons(x140421011366759, x140421011367015);
+Obj x140421011367143 = makeCons(__symbolTable[16], x140421011367111);
+Obj x140421011367207 = makeCons(x140421011367143, closureRef(co, 1));
+Obj x140421011367367 = makeCons(exp, closureRef(co, 2));
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[17]);
+__arg1 = more;
+__arg2 = x140421011367207;
+__arg3 = x140421011367367;
+co->args[4] = closureRef(co, 3);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476105063;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label45:
 {
-Obj x139886477021735 = __arg1;
-Obj x139886476105095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886477021639= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = x139886476105095;
-__arg1 = x139886477021639;
-__arg2 = x139886477021735;
+Obj x140421011442023 = __arg1;
+Obj x140421013622951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013623367= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun0, 2, x140421013623367, x140421011442023);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013622951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1506,70 +1378,39 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139886476080999 = __arg1;
-Obj x139886476081959 = makeNative(47, clofun0, 0, 1, x139886476080999);
-Obj x139886476798631 = PRIM_ISCONS(x139886476080999);
-if (True == x139886476798631) {
-Obj x139886476798855 = PRIM_CAR(x139886476080999);
-Obj x139886476798887 = PRIM_EQ(sympackage, x139886476798855);
-if (True == x139886476798887) {
-Obj x139886476799111 = PRIM_CDR(x139886476080999);
-Obj x139886476799143 = PRIM_ISCONS(x139886476799111);
-if (True == x139886476799143) {
-Obj x139886476799367 = PRIM_CDR(x139886476080999);
-Obj x139886476799399 = PRIM_CAR(x139886476799367);
-Obj x139886476799623 = PRIM_CDR(x139886476080999);
-Obj x139886476799655 = PRIM_CDR(x139886476799623);
-Obj remain = x139886476799655;
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
-__arg1 = remain;
+Obj x140421011442279 = __arg1;
+Obj x140421013623367= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011442023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = x140421013623367;
+__arg1 = x140421011442023;
+__arg2 = x140421011442279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476081959;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081959;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081959;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label47:
 {
-Obj x139886476186087 = makeNative(48, clofun0, 0, 1, closureRef(co, 0));
-Obj x139886476797799 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476797799) {
-Obj x139886476798055 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476798087 = PRIM_EQ(symbegin, x139886476798055);
-if (True == x139886476798087) {
-Obj x139886476798279 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139886476798279;
+Obj x140421013680391 = __arg1;
+Obj x140421013680583 = makeNative(48, clofun0, 0, 1, x140421013680391);
+Obj x140421011500807 = PRIM_ISCONS(x140421013680391);
+if (True == x140421011500807) {
+Obj x140421011439687 = PRIM_CAR(x140421013680391);
+Obj x140421011439719 = PRIM_EQ(__symbolTable[18], x140421011439687);
+if (True == x140421011439719) {
+Obj x140421011440039 = PRIM_CDR(x140421013680391);
+Obj x140421011440071 = PRIM_ISCONS(x140421011440039);
+if (True == x140421011440071) {
+Obj x140421011440391 = PRIM_CDR(x140421013680391);
+Obj x140421011440423 = PRIM_CAR(x140421011440391);
+Obj x140421011440775 = PRIM_CDR(x140421013680391);
+Obj x140421011440807 = PRIM_CDR(x140421011440775);
+Obj remain = x140421011440807;
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1578,7 +1419,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476186087;
+__arg0 = x140421013680583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1587,7 +1428,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476186087;
+__arg0 = x140421013680583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1598,22 +1448,16 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139886476187879 = makeNative(49, clofun0, 0, 1, closureRef(co, 0));
-Obj x139886476796199 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476796199) {
-Obj x139886476796455 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476796487 = PRIM_ISCONS(x139886476796455);
-if (True == x139886476796487) {
-Obj x139886476796807 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476796839 = PRIM_CAR(x139886476796807);
-Obj x139886476796871 = PRIM_EQ(symexport, x139886476796839);
-if (True == x139886476796871) {
-Obj x139886476797127 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476797159 = PRIM_CDR(x139886476797127);
-Obj x139886476797351 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139886476797351;
+Obj x140421013681735 = makeNative(49, clofun0, 0, 1, closureRef(co, 0));
+Obj x140421011499367 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011499367) {
+Obj x140421011499719 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011499751 = PRIM_EQ(__symbolTable[19], x140421011499719);
+if (True == x140421011499751) {
+Obj x140421011500071 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x140421011500071;
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1622,7 +1466,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476187879;
+__arg0 = x140421013681735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1631,16 +1475,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476187879;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187879;
+__arg0 = x140421013681735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1651,35 +1486,23 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139886476144967 = makeNative(1, clofun1, 0, 0);
-Obj x139886474145639 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474145639) {
-Obj x139886474065383 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474065415 = PRIM_ISCONS(x139886474065383);
-if (True == x139886474065415) {
-Obj x139886474065831 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474065863 = PRIM_CAR(x139886474065831);
-Obj x139886474065895 = PRIM_EQ(symimport, x139886474065863);
-if (True == x139886474065895) {
-Obj x139886474066279 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474066311 = PRIM_CDR(x139886474066279);
-Obj x139886474066343 = PRIM_ISCONS(x139886474066311);
-if (True == x139886474066343) {
-Obj x139886474066695 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474066727 = PRIM_CDR(x139886474066695);
-Obj x139886474066759 = PRIM_CAR(x139886474066727);
-Obj pkg = x139886474066759;
-Obj x139886474067175 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474067207 = PRIM_CDR(x139886474067175);
-Obj x139886474067239 = PRIM_CDR(x139886474067207);
-Obj x139886474067271 = PRIM_EQ(Nil, x139886474067239);
-if (True == x139886474067271) {
-Obj x139886474067527 = PRIM_CDR(closureRef(co, 0));
-Obj remain = x139886474067527;
-pushCont(co, 0, clofun1, 1, remain);
+Obj x140421013682215 = makeNative(0, clofun1, 0, 1, closureRef(co, 0));
+Obj x140421011566535 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011566535) {
+Obj x140421011497255 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011497383 = PRIM_ISCONS(x140421011497255);
+if (True == x140421011497383) {
+Obj x140421011497959 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011497991 = PRIM_CAR(x140421011497959);
+Obj x140421011498023 = PRIM_EQ(__symbolTable[20], x140421011497991);
+if (True == x140421011498023) {
+Obj x140421011498343 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011498439 = PRIM_CDR(x140421011498343);
+Obj x140421011498727 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x140421011498727;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35import);
-__arg1 = pkg;
+__arg0 = globalRef(__symbolTable[22]);
+__arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1687,16 +1510,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476144967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476144967;
+__arg0 = x140421013682215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1705,7 +1519,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476144967;
+__arg0 = x140421013682215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1714,16 +1528,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476144967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476144967;
+__arg0 = x140421013682215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1754,10 +1559,93 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886474067783 = __arg1;
+Obj x140421013682951 = makeNative(2, clofun1, 0, 0);
+Obj x140421011630599 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011630599) {
+Obj x140421011631079 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011631111 = PRIM_ISCONS(x140421011631079);
+if (True == x140421011631111) {
+Obj x140421011631783 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011631815 = PRIM_CAR(x140421011631783);
+Obj x140421011632071 = PRIM_EQ(__symbolTable[21], x140421011631815);
+if (True == x140421011632071) {
+Obj x140421011562919 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011563271 = PRIM_CDR(x140421011562919);
+Obj x140421011563303 = PRIM_ISCONS(x140421011563271);
+if (True == x140421011563303) {
+Obj x140421011564007 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011564039 = PRIM_CDR(x140421011564007);
+Obj x140421011564103 = PRIM_CAR(x140421011564039);
+Obj pkg = x140421011564103;
+Obj x140421011564871 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011565063 = PRIM_CDR(x140421011564871);
+Obj x140421011565095 = PRIM_CDR(x140421011565063);
+Obj x140421011565127 = PRIM_EQ(Nil, x140421011565095);
+if (True == x140421011565127) {
+Obj x140421011565447 = PRIM_CDR(closureRef(co, 0));
+Obj remain = x140421011565447;
+pushCont(co, 1, clofun1, 1, remain);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[135]);
+__arg1 = pkg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013682951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj x140421011565671 = __arg1;
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
+__arg0 = globalRef(__symbolTable[22]);
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1766,7 +1654,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label1:
+label2:
 {
 __nargs = 2;
 __arg1 = Nil;
@@ -1775,14 +1663,14 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label2:
+label3:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
 Obj globals = __arg3;
-pushCont(co, 3, clofun1, 3, bc, globals, to);
+pushCont(co, 4, clofun1, 3, bc, to, globals);
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
+__arg0 = globalRef(__symbolTable[26]);
 __arg1 = Nil;
 __arg2 = MAKE_NUMBER(0);
 __arg3 = Nil;
@@ -1794,36 +1682,17 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
-{
-Obj x139886474142087 = __arg1;
-Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups = x139886474142087;
-pushCont(co, 4, clofun1, 3, globals, to, groups);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35caar);
-__arg1 = bc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label4:
 {
-Obj x139886474142247 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011691175 = __arg1;
+Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj maxid = x139886474142247;
-pushCont(co, 5, clofun1, 4, globals, to, maxid, groups);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("#include \"types.h\"\n");
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj groups = x140421011691175;
+pushCont(co, 5, clofun1, 3, to, globals, groups);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[69]);
+__arg1 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1833,16 +1702,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139886474142439 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 6, clofun1, 4, globals, to, maxid, groups);
+Obj x140421011691623 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj maxid = x140421011691623;
+pushCont(co, 6, clofun1, 4, to, maxid, globals, groups);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("#include \"runtime.h\"\n\n");
+__arg2 = makeCString("#include \"types.h\"\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1852,16 +1721,16 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139886474142599 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421011691847 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 7, clofun1, 4, globals, to, maxid, groups);
+pushCont(co, 7, clofun1, 4, to, maxid, globals, groups);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(12, clofun1, 1, 2, maxid, to);
-__arg2 = groups;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("#include \"runtime.h\"\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1871,16 +1740,16 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139886474143431 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421011692071 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 8, clofun1, 4, globals, to, maxid, groups);
+pushCont(co, 8, clofun1, 4, to, maxid, globals, groups);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("\n\n");
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = makeNative(12, clofun1, 1, 2, maxid, to);
+__arg2 = groups;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1890,15 +1759,16 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886474143687 = __arg1;
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421011693255 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 9, clofun1, 3, to, maxid, groups);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35value);
-__arg1 = globals;
+pushCont(co, 9, clofun1, 4, to, maxid, globals, groups);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1908,15 +1778,16 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139886474143911 = __arg1;
+Obj x140421011628039 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 10, clofun1, 3, to, maxid, groups);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 10, clofun1, 4, to, maxid, globals, groups);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45entry);
+__arg0 = globalRef(__symbolTable[25]);
 __arg1 = to;
-__arg2 = x139886474143911;
+__arg2 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1926,13 +1797,14 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139886474143943 = __arg1;
+Obj x140421011628327 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(11, clofun1, 1, 2, to, maxid);
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = makeNative(11, clofun1, 1, 3, to, maxid, globals);
 __arg2 = groups;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1944,11 +1816,12 @@ goto *jumpTable[ps.label];
 label11:
 {
 Obj group = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45toplevel_45group);
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[27]);
 __arg1 = closureRef(co, 0);
 __arg2 = group;
 __arg3 = closureRef(co, 1);
+co->args[4] = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1961,7 +1834,7 @@ label12:
 Obj group = __arg1;
 PUSH_CONT_0(co, 13, clofun1);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35caar);
+__arg0 = globalRef(__symbolTable[69]);
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1972,12 +1845,12 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139886474143175 = __arg1;
+Obj x140421011692871 = __arg1;
 PUSH_CONT_0(co, 14, clofun1);
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
+__arg0 = globalRef(__symbolTable[46]);
 __arg1 = closureRef(co, 1);
-__arg2 = x139886474143175;
+__arg2 = x140421011692871;
 __arg3 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1988,9 +1861,9 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886474143303 = __arg1;
+Obj x140421011693031 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 1);
 __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
@@ -2006,9 +1879,9 @@ Obj to = __arg1;
 Obj globals = __arg2;
 pushCont(co, 16, clofun1, 2, globals, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(25, clofun1, 1, 1, to);
-__arg2 = globals;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("static __thread Obj* __symbolTable;\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2018,12 +1891,12 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139886474258727 = __arg1;
+Obj x140421011727271 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 17, clofun1, 2, globals, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
 __arg2 = makeCString("void entry(struct Cora *co) {\n");
 co->ctx.frees = __arg0;
@@ -2035,14 +1908,14 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139886474258887 = __arg1;
+Obj x140421011727463 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 18, clofun1, 1, to);
+pushCont(co, 18, clofun1, 2, globals, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(19, clofun1, 1, 1, to);
-__arg2 = globals;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("__symbolTable = (Obj*)malloc(sizeof(Obj) * ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2052,12 +1925,13 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886474260391 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("clofun0(co);\n}\n");
+Obj x140421011727815 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 19, clofun1, 2, globals, to);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2067,12 +1941,14 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj sym = __arg1;
-pushCont(co, 20, clofun1, 1, sym);
+Obj x140421011728103 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 20, clofun1, 2, globals, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 0);
-__arg2 = makeCString("sym");
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = to;
+__arg2 = x140421011728103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2082,13 +1958,14 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139886474259399 = __arg1;
-Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 21, clofun1, 1, sym);
+Obj x140421011728167 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 21, clofun1, 2, globals, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = closureRef(co, 0);
-__arg2 = sym;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2098,13 +1975,15 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139886474259623 = __arg1;
-Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 22, clofun1, 1, sym);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 0);
-__arg2 = makeCString(" = intern(\"");
+Obj x140421011728455 = __arg1;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 22, clofun1, 1, to);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = makeNative(23, clofun1, 2, 1, to);
+__arg2 = MAKE_NUMBER(0);
+__arg3 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2114,12 +1993,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139886474259879 = __arg1;
-Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 23, clofun1);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35symbol_45_62string);
-__arg1 = sym;
+Obj x140421011690503 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("clofun0(co);\n}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2129,12 +2008,13 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139886474260199 = __arg1;
-PUSH_CONT_0(co, 24, clofun1);
+Obj acc = __arg1;
+Obj sym = __arg2;
+pushCont(co, 24, clofun1, 2, sym, acc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 0);
-__arg2 = x139886474260199;
+__arg2 = makeCString("__symbolTable[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2144,11 +2024,14 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139886474260231 = __arg1;
+Obj x140421011729575 = __arg1;
+Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 25, clofun1, 2, sym, acc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[60]);
 __arg1 = closureRef(co, 0);
-__arg2 = makeCString("\");\n");
+__arg2 = acc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2158,12 +2041,14 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj sym = __arg1;
-pushCont(co, 26, clofun1, 1, sym);
+Obj x140421011729799 = __arg1;
+Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 26, clofun1, 2, sym, acc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 0);
-__arg2 = makeCString("static Obj sym");
+__arg2 = makeCString("] = intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2173,13 +2058,13 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x139886474258247 = __arg1;
+Obj x140421011730407 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 27, clofun1);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = closureRef(co, 0);
-__arg2 = sym;
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 27, clofun1, 1, acc);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[24]);
+__arg1 = sym;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2189,11 +2074,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139886474258567 = __arg1;
+Obj x140421011689895 = __arg1;
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 28, clofun1, 1, acc);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 0);
-__arg2 = makeCString(";\n");
+__arg2 = x140421011689895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2203,47 +2090,75 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886476186823 = __arg1;
-Obj x139886476187015 = __arg2;
-Obj x139886476187047 = __arg3;
-Obj x139886476187079 = co->args[4];
-Obj x139886474307687 = PRIM_EQ(Nil, x139886476187079);
-if (True == x139886474307687) {
-pushCont(co, 30, clofun1, 2, x139886476187047, x139886476186823);
+Obj x140421011689991 = __arg1;
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 29, clofun1, 1, acc);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 0);
+__arg2 = makeCString("\");\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj x140421011690215 = __arg1;
+Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011690471 = PRIM_ADD(acc, MAKE_NUMBER(1));
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x139886476187047;
+__arg1 = x140421011690471;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun1) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label30:
+{
+Obj x140421013622983 = __arg1;
+Obj x140421013623015 = __arg2;
+Obj x140421013623047 = __arg3;
+Obj x140421013623335 = co->args[4];
+Obj x140421011767655 = PRIM_EQ(Nil, x140421013623335);
+if (True == x140421011767655) {
+pushCont(co, 32, clofun1, 2, x140421013623047, x140421013622983);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = x140421013623047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886474309063 = PRIM_ISCONS(x139886476187079);
-if (True == x139886474309063) {
-Obj x139886474309415 = PRIM_CAR(x139886476187079);
-Obj bc = x139886474309415;
-Obj x139886474256487 = PRIM_CDR(x139886476187079);
-Obj more = x139886474256487;
-Obj x139886474256679 = PRIM_EQ(x139886476187015, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-if (True == x139886474256679) {
-pushCont(co, 29, clofun1, 3, x139886476186823, bc, more);
+Obj x140421011769127 = PRIM_ISCONS(x140421013623335);
+if (True == x140421011769127) {
+Obj x140421011769639 = PRIM_CAR(x140421013623335);
+Obj bc = x140421011769639;
+Obj x140421011769799 = PRIM_CDR(x140421013623335);
+Obj more = x140421011769799;
+Obj x140421011770311 = PRIM_EQ(x140421013623015, globalRef(__symbolTable[51]));
+if (True == x140421011770311) {
+pushCont(co, 31, clofun1, 3, x140421013622983, bc, more);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476187047;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013623047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886474257383 = PRIM_ADD(x139886476187015, MAKE_NUMBER(1));
-Obj x139886474257479 = makeCons(bc, x139886476187047);
+Obj x140421011771335 = PRIM_ADD(x140421013623015, MAKE_NUMBER(1));
+Obj x140421011726439 = makeCons(bc, x140421013623047);
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = x139886476186823;
-__arg2 = x139886474257383;
-__arg3 = x139886474257479;
+__arg0 = globalRef(__symbolTable[26]);
+__arg1 = x140421013622983;
+__arg2 = x140421011771335;
+__arg3 = x140421011726439;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2253,7 +2168,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2264,63 +2179,20 @@ goto *jumpTable[ps.label];
 }
 }
 
-label29:
-{
-Obj x139886474257095 = __arg1;
-Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886474257127 = makeCons(x139886474257095, x139886476186823);
-Obj x139886474257223 = makeCons(bc, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = x139886474257127;
-__arg2 = MAKE_NUMBER(0);
-__arg3 = Nil;
-co->args[4] = x139886474257223;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj x139886474308199 = __arg1;
-Obj x139886476187047= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886474308231 = primNot(x139886474308199);
-if (True == x139886474308231) {
-pushCont(co, 31, clofun1, 1, x139886476186823);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476187047;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476186823;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
 label31:
 {
-Obj x139886474308775 = __arg1;
-Obj x139886476186823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886474308807 = makeCons(x139886474308775, x139886476186823);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886474308807;
+Obj x140421011770599 = __arg1;
+Obj x140421013622983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421011770631 = makeCons(x140421011770599, x140421013622983);
+Obj x140421011770759 = makeCons(bc, more);
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[26]);
+__arg1 = x140421011770631;
+__arg2 = MAKE_NUMBER(0);
+__arg3 = Nil;
+co->args[4] = x140421011770759;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2330,32 +2202,40 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj to = __arg1;
-Obj group = __arg2;
-Obj maxid = __arg3;
-pushCont(co, 33, clofun1, 3, maxid, group, to);
+Obj x140421011768359 = __arg1;
+Obj x140421013623047= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013622983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011768391 = primNot(x140421011768359);
+if (True == x140421011768391) {
+pushCont(co, 33, clofun1, 1, x140421013622983);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35caar);
-__arg1 = group;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013623047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013622983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label33:
 {
-Obj x139886474552391 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 34, clofun1, 3, maxid, group, to);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
-__arg1 = to;
-__arg2 = x139886474552391;
-__arg3 = maxid;
+Obj x140421011768711 = __arg1;
+Obj x140421013622983= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011768743 = makeCons(x140421011768711, x140421013622983);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421011768743;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2365,15 +2245,14 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139886474552423 = __arg1;
-Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 35, clofun1, 3, maxid, group, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("{\n");
+Obj to = __arg1;
+Obj group = __arg2;
+Obj maxid = __arg3;
+Obj globals = co->args[4];
+pushCont(co, 35, clofun1, 4, maxid, globals, group, to);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[69]);
+__arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2383,15 +2262,17 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139886474552679 = __arg1;
+Obj x140421012076071 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 36, clofun1, 3, maxid, group, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 36, clofun1, 4, maxid, globals, group, to);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[46]);
 __arg1 = to;
-__arg2 = makeCString("int __nargs = co->nargs;\n");
+__arg2 = x140421012076071;
+__arg3 = maxid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2401,15 +2282,16 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139886474552871 = __arg1;
+Obj x140421012076135 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 37, clofun1, 3, maxid, group, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 37, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("Obj __arg0 = co->args[0];\n");
+__arg2 = makeCString("{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2419,15 +2301,16 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139886474553095 = __arg1;
+Obj x140421012076551 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 38, clofun1, 3, maxid, group, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 38, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("Obj __arg1 = co->args[1];\n");
+__arg2 = makeCString("int __nargs = co->nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2437,15 +2320,16 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139886474553255 = __arg1;
+Obj x140421012076711 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 39, clofun1, 3, maxid, group, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 39, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("Obj __arg2 = co->args[2];\n");
+__arg2 = makeCString("Obj __arg0 = co->args[0];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2455,15 +2339,16 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139886474553511 = __arg1;
+Obj x140421012077127 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 40, clofun1, 3, maxid, group, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 40, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
+__arg2 = makeCString("Obj __arg1 = co->args[1];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2473,15 +2358,16 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139886474553735 = __arg1;
+Obj x140421012077415 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 41, clofun1, 3, maxid, group, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 41, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("static void* jumpTable[] = {");
+__arg2 = makeCString("Obj __arg2 = co->args[2];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2491,14 +2377,16 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139886474553895 = __arg1;
+Obj x140421012077735 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 42, clofun1, 3, maxid, group, to);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = group;
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 42, clofun1, 4, maxid, globals, group, to);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2508,16 +2396,16 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139886474554279 = __arg1;
+Obj x140421012078247 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 43, clofun1, 3, maxid, group, to);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 43, clofun1, 4, maxid, globals, group, to);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = MAKE_NUMBER(0);
-__arg3 = x139886474554279;
+__arg2 = makeCString("static void* jumpTable[] = {");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2527,15 +2415,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139886474554311 = __arg1;
+Obj x140421012037927 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 44, clofun1, 3, maxid, group, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("};\n\n");
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 44, clofun1, 4, maxid, globals, group, to);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2545,15 +2433,17 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139886474554631 = __arg1;
+Obj x140421012038343 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 45, clofun1, 3, maxid, group, to);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 45, clofun1, 4, maxid, globals, group, to);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[28]);
 __arg1 = to;
-__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
+__arg2 = MAKE_NUMBER(0);
+__arg3 = x140421012038343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2563,15 +2453,16 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139886474554791 = __arg1;
+Obj x140421012038439 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 46, clofun1, 1, to);
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 46, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(3, clofun2, 1, 2, to, maxid);
-__arg2 = group;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("};\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2581,13 +2472,16 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139886474555367 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 47, clofun1, 1, to);
+Obj x140421012038823 = __arg1;
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 47, clofun1, 4, maxid, globals, group, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("fail:\n");
+__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2597,13 +2491,16 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139886474305767 = __arg1;
-Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012039015 = __arg1;
+Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 48, clofun1, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = to;
-__arg2 = makeCString("co->nargs = __nargs;\n");
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = makeNative(5, clofun2, 1, 3, to, maxid, globals);
+__arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2613,13 +2510,13 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139886474306055 = __arg1;
+Obj x140421012039751 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun1, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("co->args[0] = __arg0;\n");
+__arg2 = makeCString("fail:\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2629,13 +2526,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139886474306215 = __arg1;
+Obj x140421012039911 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 0, clofun2, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("co->args[1] = __arg1;\n");
+__arg2 = makeCString("co->nargs = __nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2665,13 +2562,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886474306503 = __arg1;
+Obj x140421012040199 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 1, clofun2, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("co->args[2] = __arg2;\n");
+__arg2 = makeCString("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2681,13 +2578,13 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139886474306663 = __arg1;
+Obj x140421012040391 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 2, clofun2, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("co->args[3] = __arg3;\n");
+__arg2 = makeCString("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2697,12 +2594,13 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139886474306983 = __arg1;
+Obj x140421012040583 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun2, 1, to);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
-__arg2 = makeCString("\n}\n\n");
+__arg2 = makeCString("co->args[2] = __arg2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2712,12 +2610,13 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45toplevel);
-__arg1 = closureRef(co, 0);
-__arg2 = x;
-__arg3 = closureRef(co, 1);
+Obj x140421012040839 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 4, clofun2, 1, to);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("co->args[3] = __arg3;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2727,14 +2626,45 @@ goto *jumpTable[ps.label];
 
 label4:
 {
+Obj x140421012041255 = __arg1;
+Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = to;
+__arg2 = makeCString("\n}\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj x = __arg1;
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[41]);
+__arg1 = closureRef(co, 0);
+__arg2 = x;
+__arg3 = closureRef(co, 1);
+co->args[4] = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj x139886474583047 = PRIM_EQ(i, MAKE_NUMBER(0));
-if (True == x139886474583047) {
-pushCont(co, 7, clofun2, 2, to, n);
+Obj x140421012097895 = PRIM_EQ(i, MAKE_NUMBER(0));
+if (True == x140421012097895) {
+pushCont(co, 9, clofun2, 2, to, n);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
 __arg2 = makeCString("&&label0");
 co->ctx.frees = __arg0;
@@ -2743,11 +2673,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886474583623 = PRIM_LT(i, n);
-if (True == x139886474583623) {
-pushCont(co, 5, clofun2, 3, i, to, n);
+Obj x140421012098887 = PRIM_LT(i, n);
+if (True == x140421012098887) {
+pushCont(co, 7, clofun2, 3, i, to, n);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = to;
 __arg2 = makeCString(", &&label");
 co->ctx.frees = __arg0;
@@ -2765,15 +2695,15 @@ goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label5:
+label7:
 {
-Obj x139886474583943 = __arg1;
+Obj x140421012099047 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 6, clofun2, 3, i, to, n);
+pushCont(co, 8, clofun2, 3, i, to, n);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg0 = globalRef(__symbolTable[60]);
 __arg1 = to;
 __arg2 = i;
 co->ctx.frees = __arg0;
@@ -2783,17 +2713,17 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label8:
 {
-Obj x139886474551367 = __arg1;
+Obj x140421012074919 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886474551687 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj x140421012075271 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
+__arg0 = globalRef(__symbolTable[28]);
 __arg1 = to;
-__arg2 = x139886474551687;
+__arg2 = x140421012075271;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2802,13 +2732,13 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label9:
 {
-Obj x139886474583239 = __arg1;
+Obj x140421012098279 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
+__arg0 = globalRef(__symbolTable[28]);
 __arg1 = to;
 __arg2 = MAKE_NUMBER(1);
 __arg3 = n;
@@ -2819,27 +2749,27 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label10:
 {
-Obj x139886476147399 = __arg1;
-Obj x139886476147527 = __arg2;
-Obj x139886474581191 = PRIM_EQ(Nil, x139886476147527);
-if (True == x139886474581191) {
+Obj x140421013683111 = __arg1;
+Obj x140421013683143 = __arg2;
+Obj x140421012095815 = PRIM_EQ(Nil, x140421013683143);
+if (True == x140421012095815) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886474581351 = PRIM_ISCONS(x139886476147527);
-if (True == x139886474581351) {
-Obj x139886474581607 = PRIM_CAR(x139886476147527);
-Obj x = x139886474581607;
-Obj x139886474581895 = PRIM_CDR(x139886476147527);
-Obj y = x139886474581895;
-pushCont(co, 9, clofun2, 2, x139886476147399, y);
+Obj x140421012096007 = PRIM_ISCONS(x140421013683143);
+if (True == x140421012096007) {
+Obj x140421012096359 = PRIM_CAR(x140421013683143);
+Obj x = x140421012096359;
+Obj x140421012096743 = PRIM_CDR(x140421013683143);
+Obj y = x140421012096743;
+pushCont(co, 11, clofun2, 2, x140421013683111, y);
 __nargs = 2;
-__arg0 = x139886476147399;
+__arg0 = x140421013683111;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2848,7 +2778,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2859,45 +2789,15 @@ goto *jumpTable[ps.label];
 }
 }
 
-label9:
-{
-Obj x139886474582119 = __arg1;
-Obj x139886476147399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = x139886476147399;
-__arg2 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj globals = __arg1;
-Obj exp = __arg2;
-pushCont(co, 11, clofun2, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35parse_45pass);
-__arg1 = globals;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label11:
 {
-Obj x139886474580391 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 12, clofun2);
-__nargs = 2;
-__arg0 = x139886474580391;
-__arg1 = exp;
+Obj x140421012096967 = __arg1;
+Obj x140421013683111= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = x140421013683111;
+__arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2907,11 +2807,12 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139886474580423 = __arg1;
-PUSH_CONT_0(co, 13, clofun2);
+Obj globals = __arg1;
+Obj exp = __arg2;
+pushCont(co, 13, clofun2, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert_45pass);
-__arg1 = x139886474580423;
+__arg0 = globalRef(__symbolTable[39]);
+__arg1 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2921,11 +2822,12 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139886474580455 = __arg1;
+Obj x140421012123335 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 14, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify_45pass);
-__arg1 = x139886474580455;
+__arg0 = x140421012123335;
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2935,11 +2837,11 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886474580487 = __arg1;
+Obj x140421012123367 = __arg1;
 PUSH_CONT_0(co, 15, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack_45pass);
-__arg1 = x139886474580487;
+__arg0 = globalRef(__symbolTable[38]);
+__arg1 = x140421012123367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2949,10 +2851,11 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139886474580519 = __arg1;
+Obj x140421012123399 = __arg1;
+PUSH_CONT_0(co, 16, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda_45pass);
-__arg1 = x139886474580519;
+__arg0 = globalRef(__symbolTable[37]);
+__arg1 = x140421012123399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2962,11 +2865,11 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj exp = __arg1;
-pushCont(co, 17, clofun2, 1, exp);
+Obj x140421012123431 = __arg1;
+PUSH_CONT_0(co, 17, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35cadr);
-__arg1 = exp;
+__arg0 = globalRef(__symbolTable[36]);
+__arg1 = x140421012123431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2976,13 +2879,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139886474644423 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj obj = x139886474644423;
-pushCont(co, 18, clofun2, 1, obj);
+Obj x140421012123463 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35cddr);
-__arg1 = exp;
+__arg0 = globalRef(__symbolTable[35]);
+__arg1 = x140421012123463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2992,13 +2892,11 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886474644775 = __arg1;
-Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fns = x139886474644775;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = obj;
-__arg2 = fns;
+Obj exp = __arg1;
+pushCont(co, 19, clofun2, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[104]);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3008,27 +2906,59 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139886476186151 = __arg1;
-Obj x139886476186183 = __arg2;
-Obj x139886474642727 = PRIM_EQ(Nil, x139886476186183);
-if (True == x139886474642727) {
+Obj x140421012121223 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj obj = x140421012121223;
+pushCont(co, 20, clofun2, 1, obj);
 __nargs = 2;
-__arg1 = x139886476186151;
+__arg0 = globalRef(__symbolTable[30]);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj x140421012121799 = __arg1;
+Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fns = x140421012121799;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[33]);
+__arg1 = obj;
+__arg2 = fns;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label21:
+{
+Obj x140421013681607 = __arg1;
+Obj x140421013681639 = __arg2;
+Obj x140421012393223 = PRIM_EQ(Nil, x140421013681639);
+if (True == x140421012393223) {
+__nargs = 2;
+__arg1 = x140421013681607;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886474642983 = PRIM_ISCONS(x139886476186183);
-if (True == x139886474642983) {
-Obj x139886474643143 = PRIM_CAR(x139886476186183);
-Obj hd = x139886474643143;
-Obj x139886474643367 = PRIM_CDR(x139886476186183);
-Obj more = x139886474643367;
-Obj x139886474643655 = makeCons(x139886476186151, Nil);
-Obj x139886474643687 = makeCons(hd, x139886474643655);
+Obj x140421012393607 = PRIM_ISCONS(x140421013681639);
+if (True == x140421012393607) {
+Obj x140421012393863 = PRIM_CAR(x140421013681639);
+Obj hd = x140421012393863;
+Obj x140421012119847 = PRIM_CDR(x140421013681639);
+Obj more = x140421012119847;
+Obj x140421012120327 = makeCons(x140421013681607, Nil);
+Obj x140421012120359 = makeCons(hd, x140421012120327);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = x139886474643687;
+__arg0 = globalRef(__symbolTable[33]);
+__arg1 = x140421012120359;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3037,7 +2967,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3048,12 +2978,12 @@ goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label22:
 {
 Obj exp = __arg1;
-pushCont(co, 21, clofun2, 1, exp);
+pushCont(co, 23, clofun2, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35vector);
+__arg0 = globalRef(__symbolTable[34]);
 __arg1 = MAKE_NUMBER(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3062,14 +2992,14 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label21:
+label23:
 {
-Obj x139886474652615 = __arg1;
+Obj x140421012390343 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = x139886474652615;
-pushCont(co, 22, clofun2, 2, exp, v);
+Obj v = x140421012390343;
+pushCont(co, 24, clofun2, 2, exp, v);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
+__arg0 = globalRef(__symbolTable[63]);
 __arg1 = v;
 __arg2 = MAKE_NUMBER(0);
 __arg3 = MAKE_NUMBER(0);
@@ -3080,14 +3010,14 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label22:
+label24:
 {
-Obj x139886474652903 = __arg1;
+Obj x140421012390759 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 23, clofun2, 2, exp, v);
+pushCont(co, 25, clofun2, 2, exp, v);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
+__arg0 = globalRef(__symbolTable[63]);
 __arg1 = v;
 __arg2 = MAKE_NUMBER(1);
 __arg3 = Nil;
@@ -3098,52 +3028,16 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label23:
-{
-Obj x139886474653191 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 24, clofun2, 1, v);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = v;
-__arg2 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label24:
-{
-Obj x139886474653447 = __arg1;
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1 = x139886474653447;
-Obj x139886474641767 = makeCons(e1, Nil);
-Obj x139886474641799 = makeCons(Nil, x139886474641767);
-Obj x139886474641831 = makeCons(Nil, x139886474641799);
-Obj x139886474641863 = makeCons(symlambda, x139886474641831);
-pushCont(co, 25, clofun2, 1, v);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = v;
-__arg2 = x139886474641863;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label25:
 {
-Obj x139886474641927 = __arg1;
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012391175 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 26, clofun2, 1, v);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
+__arg0 = globalRef(__symbolTable[66]);
 __arg1 = v;
-__arg2 = MAKE_NUMBER(1);
+__arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3153,11 +3047,18 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj exp = __arg1;
+Obj x140421012391399 = __arg1;
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj e1 = x140421012391399;
+Obj x140421012392103 = makeCons(e1, Nil);
+Obj x140421012392199 = makeCons(Nil, x140421012392103);
+Obj x140421012392231 = makeCons(Nil, x140421012392199);
+Obj x140421012392327 = makeCons(__symbolTable[94], x140421012392231);
+pushCont(co, 27, clofun2, 1, v);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = Nil;
-__arg2 = exp;
+__arg0 = globalRef(__symbolTable[64]);
+__arg1 = v;
+__arg2 = x140421012392327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3167,11 +3068,12 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj exp = __arg1;
+Obj x140421012392359 = __arg1;
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = exp;
-__arg2 = globalRef(symcora_47lib_47toc_35id);
+__arg0 = globalRef(__symbolTable[65]);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3183,7 +3085,7 @@ label28:
 {
 Obj exp = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
+__arg0 = globalRef(__symbolTable[68]);
 __arg1 = Nil;
 __arg2 = exp;
 co->ctx.frees = __arg0;
@@ -3195,10 +3097,38 @@ goto *jumpTable[ps.label];
 
 label29:
 {
+Obj exp = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = exp;
+__arg2 = globalRef(__symbolTable[75]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label30:
+{
+Obj exp = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = Nil;
+__arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
 Obj globals = __arg1;
 Obj exp = __arg2;
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg0 = globalRef(__symbolTable[102]);
 __arg1 = Nil;
 __arg2 = globals;
 __arg3 = exp;
@@ -3209,80 +3139,81 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label30:
+label32:
 {
-Obj x139886476081543 = __arg1;
-Obj x139886476081575 = __arg2;
-Obj x139886476081607 = __arg3;
-Obj x139886475981511 = makeNative(38, clofun2, 0, 1, x139886476081575);
-Obj x139886475244903 = PRIM_ISCONS(x139886476081575);
-if (True == x139886475244903) {
-Obj x139886475245319 = PRIM_CAR(x139886476081575);
-Obj label = x139886475245319;
-Obj x139886475245927 = PRIM_CDR(x139886476081575);
-Obj x139886475245959 = PRIM_ISCONS(x139886475245927);
-if (True == x139886475245959) {
-Obj x139886475246471 = PRIM_CDR(x139886476081575);
-Obj x139886475246503 = PRIM_CAR(x139886475246471);
-Obj x139886475246631 = PRIM_ISCONS(x139886475246503);
-if (True == x139886475246631) {
-Obj x139886475190375 = PRIM_CDR(x139886476081575);
-Obj x139886475190407 = PRIM_CAR(x139886475190375);
-Obj x139886475190439 = PRIM_CAR(x139886475190407);
-Obj x139886475190471 = PRIM_EQ(symlambda, x139886475190439);
-if (True == x139886475190471) {
-Obj x139886475192007 = PRIM_CDR(x139886476081575);
-Obj x139886475192039 = PRIM_CAR(x139886475192007);
-Obj x139886475192167 = PRIM_CDR(x139886475192039);
-Obj x139886475192199 = PRIM_ISCONS(x139886475192167);
-if (True == x139886475192199) {
-Obj x139886475192775 = PRIM_CDR(x139886476081575);
-Obj x139886475192871 = PRIM_CAR(x139886475192775);
-Obj x139886475192935 = PRIM_CDR(x139886475192871);
-Obj x139886475192999 = PRIM_CAR(x139886475192935);
-Obj params = x139886475192999;
-Obj x139886475193767 = PRIM_CDR(x139886476081575);
-Obj x139886475193799 = PRIM_CAR(x139886475193767);
-Obj x139886475193927 = PRIM_CDR(x139886475193799);
-Obj x139886475193959 = PRIM_CDR(x139886475193927);
-Obj x139886475193991 = PRIM_ISCONS(x139886475193959);
-if (True == x139886475193991) {
-Obj x139886475182599 = PRIM_CDR(x139886476081575);
-Obj x139886475182631 = PRIM_CAR(x139886475182599);
-Obj x139886475182663 = PRIM_CDR(x139886475182631);
-Obj x139886475182791 = PRIM_CDR(x139886475182663);
-Obj x139886475182823 = PRIM_CAR(x139886475182791);
-Obj actives = x139886475182823;
-Obj x139886475183783 = PRIM_CDR(x139886476081575);
-Obj x139886475183815 = PRIM_CAR(x139886475183783);
-Obj x139886475183847 = PRIM_CDR(x139886475183815);
-Obj x139886475183879 = PRIM_CDR(x139886475183847);
-Obj x139886475183943 = PRIM_CDR(x139886475183879);
-Obj x139886475183975 = PRIM_ISCONS(x139886475183943);
-if (True == x139886475183975) {
-Obj x139886475184743 = PRIM_CDR(x139886476081575);
-Obj x139886475184775 = PRIM_CAR(x139886475184743);
-Obj x139886475184839 = PRIM_CDR(x139886475184775);
-Obj x139886475184903 = PRIM_CDR(x139886475184839);
-Obj x139886475184999 = PRIM_CDR(x139886475184903);
-Obj x139886475185031 = PRIM_CAR(x139886475184999);
-Obj body = x139886475185031;
-Obj x139886475185927 = PRIM_CDR(x139886476081575);
-Obj x139886475185991 = PRIM_CAR(x139886475185927);
-Obj x139886475186023 = PRIM_CDR(x139886475185991);
-Obj x139886475186055 = PRIM_CDR(x139886475186023);
-Obj x139886475186087 = PRIM_CDR(x139886475186055);
-Obj x139886475186151 = PRIM_CDR(x139886475186087);
-Obj x139886475124743 = PRIM_EQ(Nil, x139886475186151);
-if (True == x139886475124743) {
-Obj x139886475125319 = PRIM_CDR(x139886476081575);
-Obj x139886475125351 = PRIM_CDR(x139886475125319);
-Obj x139886475125415 = PRIM_EQ(Nil, x139886475125351);
-if (True == x139886475125415) {
-pushCont(co, 31, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
+Obj x140421013623079 = __arg1;
+Obj x140421013623143 = __arg2;
+Obj x140421013623207 = __arg3;
+Obj x140421013623271 = co->args[4];
+Obj x140421013623495 = makeNative(40, clofun2, 0, 1, x140421013623143);
+Obj x140421013271335 = PRIM_ISCONS(x140421013623143);
+if (True == x140421013271335) {
+Obj x140421013271591 = PRIM_CAR(x140421013623143);
+Obj label = x140421013271591;
+Obj x140421013271911 = PRIM_CDR(x140421013623143);
+Obj x140421013271943 = PRIM_ISCONS(x140421013271911);
+if (True == x140421013271943) {
+Obj x140421013272423 = PRIM_CDR(x140421013623143);
+Obj x140421013272455 = PRIM_CAR(x140421013272423);
+Obj x140421013272487 = PRIM_ISCONS(x140421013272455);
+if (True == x140421013272487) {
+Obj x140421013273127 = PRIM_CDR(x140421013623143);
+Obj x140421013273159 = PRIM_CAR(x140421013273127);
+Obj x140421013273191 = PRIM_CAR(x140421013273159);
+Obj x140421013273223 = PRIM_EQ(__symbolTable[94], x140421013273191);
+if (True == x140421013273223) {
+Obj x140421013273703 = PRIM_CDR(x140421013623143);
+Obj x140421013273767 = PRIM_CAR(x140421013273703);
+Obj x140421013273831 = PRIM_CDR(x140421013273767);
+Obj x140421013273863 = PRIM_ISCONS(x140421013273831);
+if (True == x140421013273863) {
+Obj x140421013107143 = PRIM_CDR(x140421013623143);
+Obj x140421013107911 = PRIM_CAR(x140421013107143);
+Obj x140421013107975 = PRIM_CDR(x140421013107911);
+Obj x140421013108199 = PRIM_CAR(x140421013107975);
+Obj params = x140421013108199;
+Obj x140421013110119 = PRIM_CDR(x140421013623143);
+Obj x140421013110183 = PRIM_CAR(x140421013110119);
+Obj x140421013110215 = PRIM_CDR(x140421013110183);
+Obj x140421013110247 = PRIM_CDR(x140421013110215);
+Obj x140421013110343 = PRIM_ISCONS(x140421013110247);
+if (True == x140421013110343) {
+Obj x140421013090759 = PRIM_CDR(x140421013623143);
+Obj x140421013090855 = PRIM_CAR(x140421013090759);
+Obj x140421013090919 = PRIM_CDR(x140421013090855);
+Obj x140421013090951 = PRIM_CDR(x140421013090919);
+Obj x140421013090983 = PRIM_CAR(x140421013090951);
+Obj actives = x140421013090983;
+Obj x140421013092167 = PRIM_CDR(x140421013623143);
+Obj x140421013092199 = PRIM_CAR(x140421013092167);
+Obj x140421013092231 = PRIM_CDR(x140421013092199);
+Obj x140421013092263 = PRIM_CDR(x140421013092231);
+Obj x140421013092295 = PRIM_CDR(x140421013092263);
+Obj x140421013092327 = PRIM_ISCONS(x140421013092295);
+if (True == x140421013092327) {
+Obj x140421013093351 = PRIM_CDR(x140421013623143);
+Obj x140421013093479 = PRIM_CAR(x140421013093351);
+Obj x140421013093511 = PRIM_CDR(x140421013093479);
+Obj x140421013093607 = PRIM_CDR(x140421013093511);
+Obj x140421013093639 = PRIM_CDR(x140421013093607);
+Obj x140421013093671 = PRIM_CAR(x140421013093639);
+Obj body = x140421013093671;
+Obj x140421012992743 = PRIM_CDR(x140421013623143);
+Obj x140421012992807 = PRIM_CAR(x140421012992743);
+Obj x140421012992839 = PRIM_CDR(x140421012992807);
+Obj x140421012992871 = PRIM_CDR(x140421012992839);
+Obj x140421012992903 = PRIM_CDR(x140421012992871);
+Obj x140421012992935 = PRIM_CDR(x140421012992903);
+Obj x140421012993255 = PRIM_EQ(Nil, x140421012992935);
+if (True == x140421012993255) {
+Obj x140421012993767 = PRIM_CDR(x140421013623143);
+Obj x140421012993799 = PRIM_CDR(x140421012993767);
+Obj x140421012993991 = PRIM_EQ(Nil, x140421012993799);
+if (True == x140421012993991) {
+pushCont(co, 33, clofun2, 7, actives, x140421013623207, label, x140421013623271, params, body, x140421013623079);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476081543;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013623079;
 __arg2 = makeCString("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3291,7 +3222,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3300,7 +3231,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3309,7 +3240,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3318,7 +3249,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3327,7 +3258,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3336,7 +3267,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3345,7 +3276,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3354,7 +3285,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3363,72 +3294,31 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475981511;
+__arg0 = x140421013623495;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label31:
-{
-Obj x139886475125767 = __arg1;
-Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj x139886475126055 = PRIM_SUB(x139886476081607, label);
-pushCont(co, 32, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139886475126055;
-__arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label32:
-{
-Obj x139886475126087 = __arg1;
-Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 33, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476081543;
-__arg2 = x139886475126087;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 label33:
 {
-Obj x139886475126279 = __arg1;
+Obj x140421012994311 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 34, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+Obj x140421012994919 = PRIM_SUB(x140421013623207, label);
+pushCont(co, 34, clofun2, 7, actives, x140421013623207, label, x140421013623271, params, body, x140421013623079);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476081543;
-__arg2 = makeCString(":\n{\n");
+__arg0 = globalRef(__symbolTable[52]);
+__arg1 = x140421012994919;
+__arg2 = globalRef(__symbolTable[51]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3438,20 +3328,19 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139886475126663 = __arg1;
+Obj x140421012994951 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 35, clofun2, 6, actives, x139886476081607, label, params, body, x139886476081543);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
-__arg1 = globalRef(symcora_47lib_47toc_35local_45from_45params);
-__arg2 = x139886476081543;
-__arg3 = MAKE_NUMBER(1);
-co->args[4] = params;
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+pushCont(co, 35, clofun2, 7, actives, x140421013623207, label, x140421013623271, params, body, x140421013623079);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013623079;
+__arg2 = x140421012994951;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3461,20 +3350,19 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139886475127047 = __arg1;
+Obj x140421012994983 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-pushCont(co, 36, clofun2, 5, x139886476081607, label, params, body, x139886476081543);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
-__arg1 = globalRef(symcora_47lib_47toc_35local_45from_45cont);
-__arg2 = x139886476081543;
-__arg3 = MAKE_NUMBER(0);
-co->args[4] = actives;
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+pushCont(co, 36, clofun2, 7, actives, x140421013623207, label, x140421013623271, params, body, x140421013623079);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013623079;
+__arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3484,20 +3372,21 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139886475127335 = __arg1;
-Obj x139886476081607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886475127655 = makeCons(x139886476081607, label);
-pushCont(co, 37, clofun2, 1, x139886476081543);
+Obj x140421012995207 = __arg1;
+Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+pushCont(co, 37, clofun2, 7, actives, x140421013623207, label, x140421013623271, params, body, x140421013623079);
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = x139886475127655;
-__arg2 = params;
-__arg3 = x139886476081543;
-co->args[4] = body;
+__arg0 = globalRef(__symbolTable[42]);
+__arg1 = globalRef(__symbolTable[45]);
+__arg2 = x140421013623079;
+__arg3 = MAKE_NUMBER(1);
+co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3507,12 +3396,21 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139886475127687 = __arg1;
-Obj x139886476081543= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476081543;
-__arg2 = makeCString("}\n\n");
+Obj x140421012995559 = __arg1;
+Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+pushCont(co, 38, clofun2, 6, x140421013623207, label, x140421013623271, params, body, x140421013623079);
+__nargs = 5;
+__arg0 = globalRef(__symbolTable[42]);
+__arg1 = globalRef(__symbolTable[43]);
+__arg2 = x140421013623079;
+__arg3 = MAKE_NUMBER(0);
+co->args[4] = actives;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3522,10 +3420,22 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-PUSH_CONT_0(co, 39, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35display);
-__arg1 = makeCString("wrong format of toplevel\n");
+Obj x140421012995943 = __arg1;
+Obj x140421013623207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013623271= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+Obj x140421012513159 = makeCons(x140421013623207, label);
+pushCont(co, 39, clofun2, 1, x140421013623079);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = x140421013623271;
+__arg2 = x140421012513159;
+__arg3 = params;
+co->args[4] = x140421013623079;
+co->args[5] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3535,11 +3445,12 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139886475243943 = __arg1;
-PUSH_CONT_0(co, 40, clofun2);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35display);
-__arg1 = closureRef(co, 0);
+Obj x140421012513191 = __arg1;
+Obj x140421013623079= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013623079;
+__arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3549,10 +3460,10 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj x139886475244455 = __arg1;
+PUSH_CONT_0(co, 41, clofun2);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47io_35display);
-__arg1 = makeCString("\n");
+__arg0 = globalRef(__symbolTable[40]);
+__arg1 = makeCString("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3562,29 +3473,56 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139886476188423 = __arg1;
-Obj x139886476188455 = __arg2;
-Obj x139886476188487 = __arg3;
-Obj x139886476188519 = co->args[4];
-Obj x139886475270055 = PRIM_EQ(Nil, x139886476188519);
-if (True == x139886475270055) {
+Obj x140421013270631 = __arg1;
+PUSH_CONT_0(co, 42, clofun2);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[40]);
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x140421013270919 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[40]);
+__arg1 = makeCString("\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x140421013682599 = __arg1;
+Obj x140421013682631 = __arg2;
+Obj x140421013682663 = __arg3;
+Obj x140421013682727 = co->args[4];
+Obj x140421013390279 = PRIM_EQ(Nil, x140421013682727);
+if (True == x140421013390279) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886475270439 = PRIM_ISCONS(x139886476188519);
-if (True == x139886475270439) {
-Obj x139886475270823 = PRIM_CAR(x139886476188519);
-Obj a = x139886475270823;
-Obj x139886475271111 = PRIM_CDR(x139886476188519);
-Obj b = x139886475271111;
-pushCont(co, 42, clofun2, 4, x139886476188487, x139886476188423, x139886476188455, b);
+Obj x140421013390439 = PRIM_ISCONS(x140421013682727);
+if (True == x140421013390439) {
+Obj x140421013391015 = PRIM_CAR(x140421013682727);
+Obj a = x140421013391015;
+Obj x140421013392071 = PRIM_CDR(x140421013682727);
+Obj b = x140421013392071;
+pushCont(co, 44, clofun2, 4, x140421013682663, x140421013682599, x140421013682631, b);
 __nargs = 4;
-__arg0 = x139886476188423;
-__arg1 = x139886476188455;
-__arg2 = x139886476188487;
+__arg0 = x140421013682599;
+__arg1 = x140421013682631;
+__arg2 = x140421013682663;
 __arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3593,7 +3531,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3604,57 +3542,20 @@ goto *jumpTable[ps.label];
 }
 }
 
-label42:
-{
-Obj x139886475271335 = __arg1;
-Obj x139886476188487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476188423= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476188455= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475271591 = PRIM_ADD(x139886476188487, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
-__arg1 = x139886476188423;
-__arg2 = x139886476188455;
-__arg3 = x139886475271591;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label43:
-{
-Obj w = __arg1;
-Obj i = __arg2;
-Obj var = __arg3;
-pushCont(co, 44, clofun2, 3, var, i, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label44:
 {
-Obj x139886475268231 = __arg1;
-Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 45, clofun2, 2, i, w);
+Obj x140421013392391 = __arg1;
+Obj x140421013682663= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013682599= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013682631= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013392679 = PRIM_ADD(x140421013682663, MAKE_NUMBER(1));
 __nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = symignore;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
+__arg0 = globalRef(__symbolTable[42]);
+__arg1 = x140421013682599;
+__arg2 = x140421013682631;
+__arg3 = x140421013392679;
+co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3664,61 +3565,12 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139886475268711 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun2, 2, i, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-Obj x139886475268967 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 47, clofun2, 1, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
-Obj x139886475269223 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label48:
-{
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 49, clofun2, 3, var, i, w);
+pushCont(co, 46, clofun2, 3, var, i, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
 __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
@@ -3728,19 +3580,69 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label49:
+label46:
 {
-Obj x139886475330887 = __arg1;
+Obj x140421013470087 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 0, clofun3, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = symignore;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
+pushCont(co, 47, clofun2, 2, i, w);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = Nil;
+__arg2 = __symbolTable[44];
+__arg3 = Nil;
+co->args[4] = w;
+co->args[5] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x140421013470439 = __arg1;
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 48, clofun2, 2, i, w);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString("= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x140421013470599 = __arg1;
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 49, clofun2, 1, w);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label49:
+{
+Obj x140421013471111 = __arg1;
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3770,14 +3672,52 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886475331143 = __arg1;
+Obj w = __arg1;
+Obj i = __arg2;
+Obj var = __arg3;
+pushCont(co, 1, clofun3, 3, var, i, w);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj x140421013565095 = __arg1;
+Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun3, 2, i, w);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = Nil;
+__arg2 = __symbolTable[44];
+__arg3 = Nil;
+co->args[4] = w;
+co->args[5] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj x140421013467271 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475331815 = PRIM_LT(i, MAKE_NUMBER(4));
-if (True == x139886475331815) {
-pushCont(co, 3, clofun3, 2, i, w);
+Obj x140421013467463 = PRIM_LT(i, MAKE_NUMBER(4));
+if (True == x140421013467463) {
+pushCont(co, 5, clofun3, 2, i, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
 __arg2 = makeCString(" = __arg");
 co->ctx.frees = __arg0;
@@ -3786,9 +3726,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 1, clofun3, 2, i, w);
+pushCont(co, 3, clofun3, 2, i, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
 __arg2 = makeCString(" = co->args[");
 co->ctx.frees = __arg0;
@@ -3799,46 +3739,14 @@ goto *jumpTable[ps.label];
 }
 }
 
-label1:
-{
-Obj x139886475332839 = __arg1;
-Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 2, clofun3, 1, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x139886475333095 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label3:
 {
-Obj x139886475332071 = __arg1;
+Obj x140421013468775 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 4, clofun3, 1, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg0 = globalRef(__symbolTable[60]);
 __arg1 = w;
 __arg2 = i;
 co->ctx.frees = __arg0;
@@ -3850,12 +3758,12 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139886475332359 = __arg1;
+Obj x140421013469095 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
-__arg2 = makeCString(";\n");
+__arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3865,14 +3773,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj w = __arg1;
-Obj label = __arg2;
-Obj maxid = __arg3;
-pushCont(co, 6, clofun3, 3, label, maxid, w);
+Obj x140421013468007 = __arg1;
+Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 6, clofun3, 1, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[60]);
 __arg1 = w;
-__arg2 = makeCString("static void ");
+__arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3882,13 +3790,45 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139886475386567 = __arg1;
+Obj x140421013468391 = __arg1;
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj w = __arg1;
+Obj label = __arg2;
+Obj maxid = __arg3;
+pushCont(co, 8, clofun3, 3, label, maxid, w);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString("static void ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj x140421013563623 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun3, 1, w);
+pushCont(co, 9, clofun3, 1, w);
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
+__arg0 = globalRef(__symbolTable[54]);
 __arg1 = w;
 __arg2 = label;
 __arg3 = maxid;
@@ -3899,13 +3839,13 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label9:
 {
-Obj x139886475329543 = __arg1;
+Obj x140421013563943 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 8, clofun3, 1, w);
+pushCont(co, 10, clofun3, 1, w);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
 __arg2 = makeCString("(struct Cora* co");
 co->ctx.frees = __arg0;
@@ -3915,50 +3855,14 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
-{
-Obj x139886475329895 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj w = __arg1;
-Obj label = __arg2;
-Obj maxid = __arg3;
-Obj x139886475385319 = PRIM_SUB(maxid, label);
-Obj x139886475385351 = primDiv(x139886475385319, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-Obj gid = x139886475385351;
-pushCont(co, 10, clofun3, 2, w, gid);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("clofun");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
 label10:
 {
-Obj x139886475385735 = __arg1;
+Obj x140421013564263 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = w;
-__arg2 = gid;
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3968,17 +3872,17 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj self = __arg1;
-Obj env = __arg2;
-Obj w = __arg3;
-Obj l = co->args[4];
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list_45h);
-__arg1 = self;
-__arg2 = env;
-__arg3 = globalRef(symcora_47lib_47toc_35generate_45inst);
-co->args[4] = w;
-co->args[5] = l;
+Obj w = __arg1;
+Obj label = __arg2;
+Obj maxid = __arg3;
+Obj x140421013562023 = PRIM_SUB(maxid, label);
+Obj x140421013562183 = primDiv(x140421013562023, globalRef(__symbolTable[51]));
+Obj gid = x140421013562183;
+pushCont(co, 12, clofun3, 2, w, gid);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = w;
+__arg2 = makeCString("clofun");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3988,154 +3892,48 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139886476148199 = __arg1;
-Obj x139886476148231 = __arg2;
-Obj x139886476148263 = __arg3;
-Obj x139886476148295 = co->args[4];
-Obj x139886476148327 = co->args[5];
-Obj x139886475463847 = PRIM_EQ(Nil, x139886476148327);
-if (True == x139886475463847) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun3) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475464103 = PRIM_ISCONS(x139886476148327);
-if (True == x139886475464103) {
-Obj x139886475464359 = PRIM_CAR(x139886476148327);
-Obj a = x139886475464359;
-Obj x139886475464551 = PRIM_CDR(x139886476148327);
-Obj b = x139886475464551;
-pushCont(co, 13, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
-__nargs = 5;
-__arg0 = x139886476148263;
-__arg1 = x139886476148199;
-__arg2 = x139886476148231;
-__arg3 = x139886476148295;
-co->args[4] = a;
+Obj x140421013562407 = __arg1;
+Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = w;
+__arg2 = gid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label13:
 {
-Obj x139886475382855 = __arg1;
-Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 14, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj x139886475383239 = __arg1;
-Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj x139886475383271 = primNot(x139886475383239);
-if (True == x139886475383271) {
-pushCont(co, 15, clofun3, 5, x139886476148199, x139886476148231, x139886476148263, x139886476148295, b);
+Obj x140421013680711 = __arg1;
+Obj x140421013680807 = __arg2;
+Obj x140421013680839 = __arg3;
+Obj x140421013680871 = co->args[4];
+Obj x140421013680903 = co->args[5];
+Obj x140421013681479 = makeNative(36, clofun3, 0, 0);
+Obj x140421011308423 = PRIM_ISCONS(x140421013680903);
+if (True == x140421011308423) {
+Obj x140421011275879 = PRIM_CAR(x140421013680903);
+Obj x140421011275911 = PRIM_EQ(__symbolTable[67], x140421011275879);
+if (True == x140421011275911) {
+Obj x140421011276135 = PRIM_CDR(x140421013680903);
+Obj x140421011276167 = PRIM_ISCONS(x140421011276135);
+if (True == x140421011276167) {
+Obj x140421011276391 = PRIM_CDR(x140421013680903);
+Obj x140421011276423 = PRIM_CAR(x140421011276391);
+Obj label = x140421011276423;
+Obj x140421011276647 = PRIM_CDR(x140421013680903);
+Obj x140421011276679 = PRIM_CDR(x140421011276647);
+Obj stacks = x140421011276679;
+Obj x140421011276903 = PRIM_EQ(stacks, Nil);
+if (True == x140421011276903) {
+pushCont(co, 25, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476148295;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list_45h);
-__arg1 = x139886476148199;
-__arg2 = x139886476148231;
-__arg3 = x139886476148263;
-co->args[4] = x139886476148295;
-co->args[5] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj x139886475383463 = __arg1;
-Obj x139886476148199= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476148231= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476148263= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476148295= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-__nargs = 6;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list_45h);
-__arg1 = x139886476148199;
-__arg2 = x139886476148231;
-__arg3 = x139886476148263;
-co->args[4] = x139886476148295;
-co->args[5] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj x139886476185991 = __arg1;
-Obj x139886476186023 = __arg2;
-Obj x139886476186055 = __arg3;
-Obj x139886476188807 = makeNative(39, clofun3, 0, 0);
-Obj x139886475506503 = PRIM_ISCONS(x139886476186055);
-if (True == x139886475506503) {
-Obj x139886475507143 = PRIM_CAR(x139886476186055);
-Obj x139886475507271 = PRIM_EQ(sym_37continuation, x139886475507143);
-if (True == x139886475507271) {
-Obj x139886475507687 = PRIM_CDR(x139886476186055);
-Obj x139886475507719 = PRIM_ISCONS(x139886475507687);
-if (True == x139886475507719) {
-Obj x139886475508103 = PRIM_CDR(x139886476186055);
-Obj x139886475508135 = PRIM_CAR(x139886475508103);
-Obj label = x139886475508135;
-Obj x139886475508487 = PRIM_CDR(x139886476186055);
-Obj x139886475508583 = PRIM_CDR(x139886475508487);
-Obj stacks = x139886475508583;
-Obj x139886475509031 = PRIM_EQ(stacks, Nil);
-if (True == x139886475509031) {
-pushCont(co, 28, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
 __arg2 = makeCString("PUSH_CONT_0(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4143,10 +3941,10 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 17, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
+pushCont(co, 14, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
 __arg2 = makeCString("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4156,7 +3954,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476188807;
+__arg0 = x140421013681479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4165,7 +3963,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476188807;
+__arg0 = x140421013681479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4174,7 +3972,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476188807;
+__arg0 = x140421013681479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4183,20 +3981,83 @@ goto *jumpTable[ps.label];
 }
 }
 
+label14:
+{
+Obj x140421011279239 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421013681127 = PRIM_CAR(x140421013680807);
+Obj x140421013681543 = PRIM_SUB(x140421013681127, label);
+pushCont(co, 15, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[52]);
+__arg1 = x140421013681543;
+__arg2 = globalRef(__symbolTable[51]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj x140421013681575 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 16, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013680871;
+__arg2 = x140421013681575;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj x140421013681895 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 17, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label17:
 {
-Obj x139886475471815 = __arg1;
+Obj x140421013682183 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475472263 = PRIM_CAR(x139886476185991);
-Obj x139886475472295 = PRIM_SUB(x139886475472263, label);
-pushCont(co, 18, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139886475472295;
-__arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421013683047 = PRIM_CAR(x140421013680807);
+pushCont(co, 18, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = x140421013680871;
+__arg2 = label;
+__arg3 = x140421013683047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4206,35 +4067,48 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886475472327 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013683207 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 19, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013683719 = PRIM_EQ(stacks, Nil);
+if (True == x140421013683719) {
+Nil;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476186023;
-__arg2 = x139886475472327;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(");\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 19, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label19:
 {
-Obj x139886475472615 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013684199 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 20, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(", ");
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 20, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4244,18 +4118,16 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139886475472839 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013623815 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475460871 = PRIM_CAR(x139886476185991);
-pushCont(co, 21, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = x139886476186023;
-__arg2 = label;
-__arg3 = x139886475460871;
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 21, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013680871;
+__arg2 = x140421013623815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4265,46 +4137,31 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139886475460903 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886475461319 = PRIM_EQ(stacks, Nil);
-if (True == x139886475461319) {
-Nil;
+Obj x140421013623911 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 22, clofun3, 1, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(");\n");
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = makeNative(23, clofun3, 1, 3, x140421013680711, x140421013680807, x140421013680871);
+__arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 22, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label22:
 {
-Obj x139886475461671 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 23, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = stacks;
+Obj x140421013625159 = __arg1;
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4314,15 +4171,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139886475462055 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 24, clofun3, 3, x139886476185991, stacks, x139886476186023);
+Obj x = __arg1;
+pushCont(co, 24, clofun3, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476186023;
-__arg2 = x139886475462055;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 2);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4332,15 +4186,15 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139886475462087 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 25, clofun3, 1, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(26, clofun3, 1, 2, x139886476185991, x139886476186023);
-__arg2 = stacks;
+Obj x140421013624647 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+__arg3 = Nil;
+co->args[4] = closureRef(co, 2);
+co->args[5] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4350,12 +4204,19 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139886475462759 = __arg1;
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011276999 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421011277351 = PRIM_CAR(x140421013680807);
+Obj x140421011277383 = PRIM_SUB(x140421011277351, label);
+pushCont(co, 26, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(");\n");
+__arg0 = globalRef(__symbolTable[52]);
+__arg1 = x140421011277383;
+__arg2 = globalRef(__symbolTable[51]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4365,12 +4226,17 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj x = __arg1;
-pushCont(co, 27, clofun3, 1, x);
+Obj x140421011277415 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 27, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 1);
-__arg2 = makeCString(", ");
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013680871;
+__arg2 = x140421011277415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4380,14 +4246,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139886475462503 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 0);
-__arg2 = Nil;
-__arg3 = closureRef(co, 1);
-co->args[4] = x;
+Obj x140421011277447 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 28, clofun3, 5, label, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4397,18 +4266,19 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886475509127 = __arg1;
+Obj x140421011277607 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475509607 = PRIM_CAR(x139886476185991);
-Obj x139886475509639 = PRIM_SUB(x139886475509607, label);
-pushCont(co, 29, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139886475509639;
-__arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421011277831 = PRIM_CAR(x140421013680807);
+pushCont(co, 29, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = x140421013680871;
+__arg2 = label;
+__arg3 = x140421011277831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4418,35 +4288,48 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139886475509671 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011277863 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 30, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421011278087 = PRIM_EQ(stacks, Nil);
+if (True == x140421011278087) {
+Nil;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476186023;
-__arg2 = x139886475509671;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(");\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 30, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label30:
 {
-Obj x139886475509735 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011278311 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 31, clofun3, 4, label, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(", ");
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 31, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4456,18 +4339,16 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139886475469063 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011278535 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475469479 = PRIM_CAR(x139886476185991);
-pushCont(co, 32, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = x139886476186023;
-__arg2 = label;
-__arg3 = x139886475469479;
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 32, clofun3, 4, x140421013680711, x140421013680807, stacks, x140421013680871);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013680871;
+__arg2 = x140421011278535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4477,46 +4358,31 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139886475469511 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886475469895 = PRIM_EQ(stacks, Nil);
-if (True == x139886475469895) {
-Nil;
+Obj x140421011278567 = __arg1;
+Obj x140421013680711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680807= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 33, clofun3, 1, x140421013680871);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(");\n");
+__arg0 = globalRef(__symbolTable[47]);
+__arg1 = makeNative(34, clofun3, 1, 3, x140421013680711, x140421013680807, x140421013680871);
+__arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 33, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label33:
 {
-Obj x139886475470311 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 34, clofun3, 3, x139886476185991, stacks, x139886476186023);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = stacks;
+Obj x140421011279079 = __arg1;
+Obj x140421013680871= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013680871;
+__arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4526,15 +4392,12 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139886475470663 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 35, clofun3, 3, x139886476185991, stacks, x139886476186023);
+Obj x = __arg1;
+pushCont(co, 35, clofun3, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476186023;
-__arg2 = x139886475470663;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 2);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4544,15 +4407,15 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139886475470695 = __arg1;
-Obj x139886476185991= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 36, clofun3, 1, x139886476186023);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35for_45each);
-__arg1 = makeNative(37, clofun3, 1, 2, x139886476185991, x139886476186023);
-__arg2 = stacks;
+Obj x140421011278887 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+__arg3 = Nil;
+co->args[4] = closureRef(co, 2);
+co->args[5] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4562,12 +4425,9 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139886475471559 = __arg1;
-Obj x139886476186023= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476186023;
-__arg2 = makeCString(");\n");
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4577,12 +4437,18 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x = __arg1;
-pushCont(co, 38, clofun3, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 1);
-__arg2 = makeCString(", ");
+Obj globals = __arg1;
+Obj self = __arg2;
+Obj env = __arg3;
+Obj w = co->args[4];
+Obj l = co->args[5];
+Obj x140421011305639 = primGenSym();
+Obj generate_45inst_45list_45h = x140421011305639;
+Obj x140421011307687 = primSet(co, generate_45inst_45list_45h, makeNative(39, clofun3, 1, 5, globals, self, env, w, generate_45inst_45list_45h));
+pushCont(co, 38, clofun3, 1, l);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = generate_45inst_45list_45h;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4592,14 +4458,11 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139886475471271 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 0);
-__arg2 = Nil;
-__arg3 = closureRef(co, 1);
-co->args[4] = x;
+Obj x140421011307847 = __arg1;
+Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = x140421011307847;
+__arg1 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4609,8 +4472,37 @@ goto *jumpTable[ps.label];
 
 label39:
 {
+Obj x = __arg1;
+Obj x140421011305991 = PRIM_EQ(Nil, x);
+if (True == x140421011305991) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421011306151 = PRIM_ISCONS(x);
+if (True == x140421011306151) {
+Obj x140421011306311 = PRIM_CAR(x);
+Obj a = x140421011306311;
+Obj x140421011306471 = PRIM_CDR(x);
+Obj b = x140421011306471;
+pushCont(co, 40, clofun3, 1, b);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+__arg3 = closureRef(co, 2);
+co->args[4] = closureRef(co, 3);
+co->args[5] = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4618,115 +4510,61 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
 label40:
 {
-Obj self = __arg1;
-Obj env = __arg2;
-Obj w = __arg3;
-Obj x1 = co->args[4];
-Obj x139886475184807 = primIsSymbol(x1);
-if (True == x139886475184807) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = w;
-__arg2 = x1;
+Obj x140421011306759 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 41, clofun3, 1, b);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139886476186343 = makeNative(43, clofun3, 0, 4, self, env, x1, w);
-Obj x139886475567943 = PRIM_ISCONS(x1);
-if (True == x139886475567943) {
-Obj x139886475568295 = PRIM_CAR(x1);
-Obj x139886475568327 = PRIM_EQ(sym_37global, x139886475568295);
-if (True == x139886475568327) {
-Obj x139886475568583 = PRIM_CDR(x1);
-Obj x139886475568615 = PRIM_ISCONS(x139886475568583);
-if (True == x139886475568615) {
-Obj x139886475568999 = PRIM_CDR(x1);
-Obj x139886475569031 = PRIM_CAR(x139886475568999);
-Obj x = x139886475569031;
-Obj x139886475569479 = PRIM_CDR(x1);
-Obj x139886475569511 = PRIM_CDR(x139886475569479);
-Obj x139886475569575 = PRIM_EQ(Nil, x139886475569511);
-if (True == x139886475569575) {
-pushCont(co, 41, clofun3, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString("globalRef(sym");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476186343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label41:
 {
-Obj x139886475569799 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 42, clofun3, 1, w);
+Obj x140421011307047 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011307079 = primNot(x140421011307047);
+if (True == x140421011307079) {
+pushCont(co, 43, clofun3, 1, b);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = w;
-__arg2 = x;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
+pushCont(co, 42, clofun3, 1, b);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label42:
 {
-Obj x139886475569991 = __arg1;
-Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = w;
-__arg2 = makeCString(")");
+Obj x140421011307591 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = x140421011307591;
+__arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4736,79 +4574,26 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139886476187911 = makeNative(46, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886475597415 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139886475597415) {
-Obj x139886475597735 = PRIM_CAR(closureRef(co, 2));
-Obj x139886475597767 = PRIM_EQ(sym_37closure_45ref, x139886475597735);
-if (True == x139886475597767) {
-Obj x139886475598375 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475598407 = PRIM_ISCONS(x139886475598375);
-if (True == x139886475598407) {
-Obj x139886475598791 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475598823 = PRIM_CAR(x139886475598791);
-Obj idx = x139886475598823;
-Obj x139886475599335 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475599399 = PRIM_CDR(x139886475599335);
-Obj x139886475599463 = PRIM_EQ(Nil, x139886475599399);
-if (True == x139886475599463) {
-pushCont(co, 44, clofun3, 1, idx);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("closureRef(co, ");
+Obj x140421011307207 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 44, clofun3, 1, b);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476187911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187911;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label44:
 {
-Obj x139886475599751 = __arg1;
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 45, clofun3);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = idx;
+Obj x140421011307399 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = x140421011307399;
+__arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4818,11 +4603,18 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139886475567207 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
+Obj globals = __arg1;
+Obj self = __arg2;
+Obj env1 = __arg3;
+Obj w = co->args[4];
+Obj x1 = co->args[5];
+Obj x140421013392903 = primGenSym();
+Obj generate_45inst_45h = x140421013392903;
+Obj x140421011305095 = primSet(co, generate_45inst_45h, makeNative(47, clofun3, 2, 4, self, generate_45inst_45h, globals, w));
+pushCont(co, 46, clofun3, 2, x1, env1);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = generate_45inst_45h;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4832,93 +4624,110 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139886476188999 = makeNative(49, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886475982695 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139886475982695) {
-Obj x139886475983623 = PRIM_CAR(closureRef(co, 2));
-Obj x139886475983655 = PRIM_EQ(sym_37stack_45ref, x139886475983623);
-if (True == x139886475983655) {
-Obj x139886475984071 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475984103 = PRIM_ISCONS(x139886475984071);
-if (True == x139886475984103) {
-Obj x139886475984423 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475984455 = PRIM_CAR(x139886475984423);
-Obj idx = x139886475984455;
-Obj x139886475595879 = PRIM_CDR(closureRef(co, 2));
-Obj x139886475595911 = PRIM_CDR(x139886475595879);
-Obj x139886475595975 = PRIM_EQ(Nil, x139886475595911);
-if (True == x139886475595975) {
-pushCont(co, 47, clofun3, 1, idx);
+Obj x140421011305255 = __arg1;
+Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj env1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("stackRef(co, ");
+__arg0 = x140421011305255;
+__arg1 = x1;
+__arg2 = env1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476188999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476188999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476188999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476188999;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label47:
 {
-Obj x139886475596295 = __arg1;
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 48, clofun3);
+Obj x2 = __arg1;
+Obj env = __arg2;
+Obj x140421013393351 = primIsSymbol(x2);
+if (True == x140421013393351) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
+__arg0 = globalRef(__symbolTable[55]);
 __arg1 = closureRef(co, 3);
-__arg2 = idx;
+__arg2 = x2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj x140421013683303 = makeNative(1, clofun4, 0, 6, closureRef(co, 0), closureRef(co, 1), env, closureRef(co, 2), x2, closureRef(co, 3));
+Obj x140421011360423 = PRIM_ISCONS(x2);
+if (True == x140421011360423) {
+Obj x140421011360647 = PRIM_CAR(x2);
+Obj x140421011360679 = PRIM_EQ(__symbolTable[98], x140421011360647);
+if (True == x140421011360679) {
+Obj x140421011360903 = PRIM_CDR(x2);
+Obj x140421011360935 = PRIM_ISCONS(x140421011360903);
+if (True == x140421011360935) {
+Obj x140421011361159 = PRIM_CDR(x2);
+Obj x140421011361191 = PRIM_CAR(x140421011361159);
+Obj x = x140421011361191;
+Obj x140421011361479 = PRIM_CDR(x2);
+Obj x140421011361511 = PRIM_CDR(x140421011361479);
+Obj x140421011361543 = PRIM_EQ(Nil, x140421011361511);
+if (True == x140421011361543) {
+pushCont(co, 48, clofun3, 1, x);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("globalRef(__symbolTable[");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013683303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label48:
 {
-Obj x139886475596615 = __arg1;
+Obj x140421011361735 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 49, clofun3);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
+__arg0 = globalRef(__symbolTable[56]);
+__arg1 = x;
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4928,81 +4737,17 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139886476145031 = makeNative(7, clofun4, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139886476105767 = PRIM_ISCONS(closureRef(co, 2));
-if (True == x139886476105767) {
-Obj x139886476106215 = PRIM_CAR(closureRef(co, 2));
-Obj x139886476106247 = PRIM_EQ(sym_37const, x139886476106215);
-if (True == x139886476106247) {
-Obj x139886476106983 = PRIM_CDR(closureRef(co, 2));
-Obj x139886476107015 = PRIM_ISCONS(x139886476106983);
-if (True == x139886476107015) {
-Obj x139886476107367 = PRIM_CDR(closureRef(co, 2));
-Obj x139886476107399 = PRIM_CAR(x139886476107367);
-Obj x = x139886476107399;
-Obj x139886476079335 = PRIM_CDR(closureRef(co, 2));
-Obj x139886476079367 = PRIM_CDR(x139886476079335);
-Obj x139886476079399 = PRIM_EQ(Nil, x139886476079367);
-if (True == x139886476079399) {
-Obj x139886476079559 = primIsSymbol(x);
-if (True == x139886476079559) {
-pushCont(co, 6, clofun4, 1, x);
+Obj x140421011304679 = __arg1;
+PUSH_CONT_0(co, 0, clofun4);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[60]);
 __arg1 = closureRef(co, 3);
-__arg2 = makeCString("sym");
+__arg2 = x140421011304679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 0, clofun4, 1, x);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35number_63);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145031;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145031;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145031;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145031;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 fail:
@@ -5027,13 +4772,298 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886476080551 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886476080551) {
-pushCont(co, 4, clofun4, 1, x);
+Obj x140421011304711 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 3);
+__arg2 = makeCString("])");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj x140421013683655 = makeNative(4, clofun4, 0, 6, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4), closureRef(co, 5));
+Obj x140421011358279 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x140421011358279) {
+Obj x140421011358535 = PRIM_CAR(closureRef(co, 4));
+Obj x140421011358567 = PRIM_EQ(__symbolTable[83], x140421011358535);
+if (True == x140421011358567) {
+Obj x140421011358823 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011358855 = PRIM_ISCONS(x140421011358823);
+if (True == x140421011358855) {
+Obj x140421011359111 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011359143 = PRIM_CAR(x140421011359111);
+Obj idx = x140421011359143;
+Obj x140421011359463 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011359495 = PRIM_CDR(x140421011359463);
+Obj x140421011359527 = PRIM_EQ(Nil, x140421011359495);
+if (True == x140421011359527) {
+pushCont(co, 2, clofun4, 1, idx);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("closureRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013683655;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683655;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683655;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683655;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj x140421011359719 = __arg1;
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 3, clofun4);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = idx;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj x140421011359911 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj x140421013684007 = makeNative(7, clofun4, 0, 6, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 4), closureRef(co, 3), closureRef(co, 5));
+Obj x140421011366727 = PRIM_ISCONS(closureRef(co, 4));
+if (True == x140421011366727) {
+Obj x140421011367047 = PRIM_CAR(closureRef(co, 4));
+Obj x140421011367079 = PRIM_EQ(__symbolTable[48], x140421011367047);
+if (True == x140421011367079) {
+Obj x140421011368935 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011368967 = PRIM_ISCONS(x140421011368935);
+if (True == x140421011368967) {
+Obj x140421011369223 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011369255 = PRIM_CAR(x140421011369223);
+Obj idx = x140421011369255;
+Obj x140421011369575 = PRIM_CDR(closureRef(co, 4));
+Obj x140421011369607 = PRIM_CDR(x140421011369575);
+Obj x140421011369639 = PRIM_EQ(Nil, x140421011369607);
+if (True == x140421011369639) {
+pushCont(co, 5, clofun4, 1, idx);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("stackRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013684007;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684007;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684007;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684007;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj x140421011369831 = __arg1;
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 6, clofun4);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = idx;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj x140421011357735 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj x140421013622887 = makeNative(17, clofun4, 0, 6, closureRef(co, 4), closureRef(co, 0), closureRef(co, 3), closureRef(co, 5), closureRef(co, 1), closureRef(co, 2));
+Obj x140421011499879 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140421011499879) {
+Obj x140421011500135 = PRIM_CAR(closureRef(co, 3));
+Obj x140421011500167 = PRIM_EQ(__symbolTable[101], x140421011500135);
+if (True == x140421011500167) {
+Obj x140421011500551 = PRIM_CDR(closureRef(co, 3));
+Obj x140421011500711 = PRIM_ISCONS(x140421011500551);
+if (True == x140421011500711) {
+Obj x140421011500967 = PRIM_CDR(closureRef(co, 3));
+Obj x140421011500999 = PRIM_CAR(x140421011500967);
+Obj x = x140421011500999;
+Obj x140421011439911 = PRIM_CDR(closureRef(co, 3));
+Obj x140421011439943 = PRIM_CDR(x140421011439911);
+Obj x140421011439975 = PRIM_EQ(Nil, x140421011439943);
+if (True == x140421011439975) {
+Obj x140421011440167 = primIsSymbol(x);
+if (True == x140421011440167) {
+pushCont(co, 14, clofun4, 1, x);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("__symbolTable[");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 8, clofun4, 1, x);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[88]);
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013622887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013622887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013622887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013622887;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label8:
+{
+Obj x140421011441063 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421011441063) {
+pushCont(co, 12, clofun4, 1, x);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
 __arg2 = makeCString("MAKE_NUMBER(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5041,12 +5071,12 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886476081639 = primIsString(x);
-if (True == x139886476081639) {
-pushCont(co, 1, clofun4, 1, x);
+Obj x140421011441927 = primIsString(x);
+if (True == x140421011441927) {
+pushCont(co, 9, clofun4, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
 __arg2 = makeCString("makeCString(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5054,11 +5084,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886476083175 = PRIM_EQ(x, Nil);
-if (True == x139886476083175) {
+Obj x140421011442919 = PRIM_EQ(x, Nil);
+if (True == x140421011442919) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
 __arg2 = makeCString("Nil");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5066,11 +5096,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886475981095 = PRIM_EQ(x, True);
-if (True == x139886475981095) {
+Obj x140421011443335 = PRIM_EQ(x, True);
+if (True == x140421011443335) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
 __arg2 = makeCString("True");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5078,11 +5108,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886475981703 = PRIM_EQ(x, False);
-if (True == x139886475981703) {
+Obj x140421011443591 = PRIM_EQ(x, False);
+if (True == x140421011443591) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
 __arg2 = makeCString("False");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5091,7 +5121,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5105,244 +5135,14 @@ goto *jumpTable[ps.label];
 }
 }
 
-label1:
-{
-Obj x139886476082119 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 2, clofun4);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35escape_45str);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj x139886476082695 = __arg1;
-PUSH_CONT_0(co, 3, clofun4);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = x139886476082695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj x139886476082727 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("\")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj x139886476080871 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 5, clofun4);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj x139886476081255 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x139886476079975 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = closureRef(co, 3);
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj x139886476146343 = makeNative(18, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886477005255 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886477005255) {
-Obj x139886477005511 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477005671 = PRIM_EQ(symlet, x139886477005511);
-if (True == x139886477005671) {
-Obj x139886477005959 = PRIM_CDR(closureRef(co, 0));
-Obj x139886477005991 = PRIM_ISCONS(x139886477005959);
-if (True == x139886477005991) {
-Obj x139886477007655 = PRIM_CDR(closureRef(co, 0));
-Obj x139886477007687 = PRIM_CAR(x139886477007655);
-Obj a = x139886477007687;
-Obj x139886477008007 = PRIM_CDR(closureRef(co, 0));
-Obj x139886477008039 = PRIM_CDR(x139886477008007);
-Obj x139886477008071 = PRIM_ISCONS(x139886477008039);
-if (True == x139886477008071) {
-Obj x139886477008391 = PRIM_CDR(closureRef(co, 0));
-Obj x139886477008423 = PRIM_CDR(x139886477008391);
-Obj x139886477008455 = PRIM_CAR(x139886477008423);
-Obj b = x139886477008455;
-Obj x139886477008839 = PRIM_CDR(closureRef(co, 0));
-Obj x139886477008871 = PRIM_CDR(x139886477008839);
-Obj x139886476186119 = PRIM_CDR(x139886477008871);
-Obj x139886476186215 = PRIM_ISCONS(x139886476186119);
-if (True == x139886476186215) {
-Obj x139886476187367 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476187399 = PRIM_CDR(x139886476187367);
-Obj x139886476187431 = PRIM_CDR(x139886476187399);
-Obj x139886476187783 = PRIM_CAR(x139886476187431);
-Obj c = x139886476187783;
-Obj x139886476188775 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476188839 = PRIM_CDR(x139886476188775);
-Obj x139886476189063 = PRIM_CDR(x139886476188839);
-Obj x139886476189127 = PRIM_CDR(x139886476189063);
-Obj x139886476189159 = PRIM_EQ(Nil, x139886476189127);
-if (True == x139886476189159) {
-pushCont(co, 8, clofun4, 3, b, a, c);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35index);
-__arg1 = a;
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj x139886476189351 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj idx = x139886476189351;
-Obj x139886476144807 = PRIM_LT(idx, MAKE_NUMBER(0));
-if (True == x139886476144807) {
-pushCont(co, 13, clofun4, 3, b, a, c);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-pushCont(co, 9, clofun4, 3, b, a, c);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = closureRef(co, 3);
-__arg2 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
 label9:
 {
-Obj x139886476147367 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 10, clofun4, 3, b, a, c);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(" = ");
+Obj x140421011442247 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 10, clofun4);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[49]);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5352,17 +5152,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139886476147783 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 11, clofun4, 2, a, c);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = b;
+Obj x140421011442503 = __arg1;
+PUSH_CONT_0(co, 11, clofun4);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421011442503;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5372,14 +5167,11 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139886476148167 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 12, clofun4, 2, a, c);
+Obj x140421011442535 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(";\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5389,16 +5181,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj x139886476148711 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476104391 = makeCons(a, closureRef(co, 2));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = x139886476104391;
-__arg3 = closureRef(co, 3);
-co->args[4] = c;
+Obj x140421011441351 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 13, clofun4);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5408,15 +5197,11 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139886476144999 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 14, clofun4, 3, b, a, c);
+Obj x140421011441543 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
-__arg1 = closureRef(co, 3);
-__arg2 = a;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5426,15 +5211,13 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886476145543 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 15, clofun4, 3, b, a, c);
+Obj x140421011440359 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 15, clofun4);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(" = ");
+__arg0 = globalRef(__symbolTable[56]);
+__arg1 = x;
+__arg2 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5444,17 +5227,12 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139886476145735 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 16, clofun4, 2, a, c);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = b;
+Obj x140421011440679 = __arg1;
+PUSH_CONT_0(co, 16, clofun4);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421011440679;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5464,14 +5242,11 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139886476146247 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 17, clofun4, 2, a, c);
+Obj x140421011440743 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(";\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5481,98 +5256,134 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139886476146567 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476147111 = makeCons(a, closureRef(co, 2));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = x139886476147111;
-__arg3 = closureRef(co, 3);
-co->args[4] = c;
+Obj x140421013623239 = makeNative(32, clofun4, 0, 6, closureRef(co, 4), closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 5), closureRef(co, 3));
+Obj x140421011629319 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140421011629319) {
+Obj x140421011629735 = PRIM_CAR(closureRef(co, 2));
+Obj x140421011629767 = PRIM_EQ(__symbolTable[91], x140421011629735);
+if (True == x140421011629767) {
+Obj x140421011630279 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011630311 = PRIM_ISCONS(x140421011630279);
+if (True == x140421011630311) {
+Obj x140421011630695 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011630759 = PRIM_CAR(x140421011630695);
+Obj a = x140421011630759;
+Obj x140421011631399 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011631431 = PRIM_CDR(x140421011631399);
+Obj x140421011631463 = PRIM_ISCONS(x140421011631431);
+if (True == x140421011631463) {
+Obj x140421011631847 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011631879 = PRIM_CDR(x140421011631847);
+Obj x140421011632007 = PRIM_CAR(x140421011631879);
+Obj b = x140421011632007;
+Obj x140421011562951 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011562983 = PRIM_CDR(x140421011562951);
+Obj x140421011563015 = PRIM_CDR(x140421011562983);
+Obj x140421011563239 = PRIM_ISCONS(x140421011563015);
+if (True == x140421011563239) {
+Obj x140421011563783 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011563815 = PRIM_CDR(x140421011563783);
+Obj x140421011563847 = PRIM_CDR(x140421011563815);
+Obj x140421011563879 = PRIM_CAR(x140421011563847);
+Obj c = x140421011563879;
+Obj x140421011564679 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011564711 = PRIM_CDR(x140421011564679);
+Obj x140421011564743 = PRIM_CDR(x140421011564711);
+Obj x140421011564775 = PRIM_CDR(x140421011564743);
+Obj x140421011564807 = PRIM_EQ(Nil, x140421011564775);
+if (True == x140421011564807) {
+pushCont(co, 18, clofun4, 3, b, a, c);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[129]);
+__arg1 = a;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label18:
 {
-Obj x139886476104807 = makeNative(25, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886474067079 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474067079) {
-Obj x139886474067335 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474067367 = PRIM_ISCONS(x139886474067335);
-if (True == x139886474067367) {
-Obj x139886474067687 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474067719 = PRIM_CAR(x139886474067687);
-Obj x139886474067751 = PRIM_EQ(sym_37builtin, x139886474067719);
-if (True == x139886474067751) {
-Obj x139886474038215 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474038407 = PRIM_CDR(x139886474038215);
-Obj x139886474038663 = PRIM_ISCONS(x139886474038407);
-if (True == x139886474038663) {
-Obj x139886477005095 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477005127 = PRIM_CDR(x139886477005095);
-Obj x139886477005159 = PRIM_CAR(x139886477005127);
-Obj f = x139886477005159;
-Obj x139886477005543 = PRIM_CAR(closureRef(co, 0));
-Obj x139886477005575 = PRIM_CDR(x139886477005543);
-Obj x139886477005607 = PRIM_CDR(x139886477005575);
-Obj x139886477005639 = PRIM_EQ(Nil, x139886477005607);
-if (True == x139886477005639) {
-Obj x139886477005831 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886477005831;
-pushCont(co, 19, clofun4, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62name);
-__arg1 = f;
+Obj x140421011565159 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj idx = x140421011565159;
+Obj x140421011565479 = PRIM_LT(idx, MAKE_NUMBER(0));
+if (True == x140421011565479) {
+pushCont(co, 25, clofun4, 3, b, a, c);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139886476104807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476104807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476104807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476104807;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476104807;
+Nil;
+pushCont(co, 19, clofun4, 3, b, a, c);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[55]);
+__arg1 = closureRef(co, 3);
+__arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5583,14 +5394,15 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj x139886477006087 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 20, clofun4, 2, f, args);
+Obj x140421011497671 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 20, clofun4, 3, b, a, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 3);
-__arg2 = x139886477006087;
+__arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5600,46 +5412,32 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139886477006119 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886477006343 = PRIM_EQ(f, symset);
-if (True == x139886477006343) {
-pushCont(co, 23, clofun4, 1, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("(co, ");
+Obj x140421011498055 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 21, clofun4, 3, b, a, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 21, clofun4, 1, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("(");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label21:
 {
-Obj x139886477006951 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 22, clofun4);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = args;
+Obj x140421011498311 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 22, clofun4, 2, a, c);
+__nargs = 3;
+__arg0 = x140421011498311;
+__arg1 = b;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5649,11 +5447,14 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139886477007207 = __arg1;
+Obj x140421011498407 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 23, clofun4, 2, a, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5663,15 +5464,13 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139886477006471 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 24, clofun4);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = args;
+Obj x140421011498663 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 24, clofun4, 2, a, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5681,11 +5480,14 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139886477006727 = __arg1;
+Obj x140421011498919 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011499047 = makeCons(a, closureRef(co, 5));
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
+__arg0 = x140421011498919;
+__arg1 = c;
+__arg2 = x140421011499047;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5695,121 +5497,33 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139886476106695 = makeNative(32, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886474142407 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474142407) {
-Obj x139886474142663 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474142695 = PRIM_EQ(symif, x139886474142663);
-if (True == x139886474142695) {
-Obj x139886474142951 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474142983 = PRIM_ISCONS(x139886474142951);
-if (True == x139886474142983) {
-Obj x139886474143239 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474143271 = PRIM_CAR(x139886474143239);
-Obj a = x139886474143271;
-Obj x139886474143591 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474143623 = PRIM_CDR(x139886474143591);
-Obj x139886474143655 = PRIM_ISCONS(x139886474143623);
-if (True == x139886474143655) {
-Obj x139886474143975 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474144007 = PRIM_CDR(x139886474143975);
-Obj x139886474144039 = PRIM_CAR(x139886474144007);
-Obj b = x139886474144039;
-Obj x139886474144423 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474144455 = PRIM_CDR(x139886474144423);
-Obj x139886474144487 = PRIM_CDR(x139886474144455);
-Obj x139886474144519 = PRIM_ISCONS(x139886474144487);
-if (True == x139886474144519) {
-Obj x139886474144903 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474144935 = PRIM_CDR(x139886474144903);
-Obj x139886474144967 = PRIM_CDR(x139886474144935);
-Obj x139886474144999 = PRIM_CAR(x139886474144967);
-Obj c = x139886474144999;
-Obj x139886474145447 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474145479 = PRIM_CDR(x139886474145447);
-Obj x139886474145511 = PRIM_CDR(x139886474145479);
-Obj x139886474145543 = PRIM_CDR(x139886474145511);
-Obj x139886474145575 = PRIM_EQ(Nil, x139886474145543);
-if (True == x139886474145575) {
-pushCont(co, 26, clofun4, 3, a, b, c);
+Obj x140421011565607 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 26, clofun4, 3, b, a, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[55]);
 __arg1 = closureRef(co, 3);
-__arg2 = makeCString("if (True == ");
+__arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106695;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label26:
 {
-Obj x139886474145767 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011565799 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 27, clofun4, 2, b, c);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = a;
+pushCont(co, 27, clofun4, 3, b, a, c);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5819,14 +5533,14 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139886474065479 = __arg1;
+Obj x140421011566023 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 28, clofun4, 2, b, c);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(") {\n");
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 28, clofun4, 3, b, a, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5836,16 +5550,15 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886474065703 = __arg1;
+Obj x140421011566343 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 29, clofun4, 1, c);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = b;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 29, clofun4, 2, a, c);
+__nargs = 3;
+__arg0 = x140421011566343;
+__arg1 = b;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5855,13 +5568,14 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj x139886474065959 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 30, clofun4, 1, c);
+Obj x140421011566471 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 30, clofun4, 2, a, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+__arg0 = globalRef(__symbolTable[61]);
 __arg1 = closureRef(co, 3);
-__arg2 = makeCString("} else {\n");
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5871,15 +5585,13 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139886474066151 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 31, clofun4);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = c;
+Obj x140421011497095 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 31, clofun4, 2, a, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5889,11 +5601,14 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj x139886474066407 = __arg1;
+Obj x140421011497351 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011497479 = makeCons(a, closureRef(co, 5));
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("}\n");
+__arg0 = x140421011497351;
+__arg1 = c;
+__arg2 = x140421011497479;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5903,35 +5618,35 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139886476081127 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886474306695 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474306695) {
-Obj x139886474307079 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474307111 = PRIM_EQ(sym_37closure, x139886474307079);
-if (True == x139886474307111) {
-Obj x139886474307495 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474307527 = PRIM_ISCONS(x139886474307495);
-if (True == x139886474307527) {
-Obj x139886474307783 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474307815 = PRIM_CAR(x139886474307783);
-Obj label = x139886474307815;
-Obj x139886474308423 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474308455 = PRIM_CDR(x139886474308423);
-Obj x139886474308487 = PRIM_ISCONS(x139886474308455);
-if (True == x139886474308487) {
-Obj x139886474308967 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474308999 = PRIM_CDR(x139886474308967);
-Obj x139886474309031 = PRIM_CAR(x139886474308999);
-Obj nargs = x139886474309031;
-Obj x139886474309543 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474309575 = PRIM_CDR(x139886474309543);
-Obj x139886474256423 = PRIM_CDR(x139886474309575);
-Obj frees = x139886474256423;
-pushCont(co, 33, clofun4, 3, label, nargs, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("makeNative(");
+Obj x140421013623943 = makeNative(39, clofun4, 0, 6, closureRef(co, 2), closureRef(co, 3), closureRef(co, 1), closureRef(co, 0), closureRef(co, 4), closureRef(co, 5));
+Obj x140421011729703 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421011729703) {
+Obj x140421011730023 = PRIM_CAR(closureRef(co, 1));
+Obj x140421011730311 = PRIM_ISCONS(x140421011730023);
+if (True == x140421011730311) {
+Obj x140421011689799 = PRIM_CAR(closureRef(co, 1));
+Obj x140421011689831 = PRIM_CAR(x140421011689799);
+Obj x140421011689863 = PRIM_EQ(__symbolTable[95], x140421011689831);
+if (True == x140421011689863) {
+Obj x140421011690311 = PRIM_CAR(closureRef(co, 1));
+Obj x140421011690343 = PRIM_CDR(x140421011690311);
+Obj x140421011690375 = PRIM_ISCONS(x140421011690343);
+if (True == x140421011690375) {
+Obj x140421011690727 = PRIM_CAR(closureRef(co, 1));
+Obj x140421011690759 = PRIM_CDR(x140421011690727);
+Obj x140421011690855 = PRIM_CAR(x140421011690759);
+Obj f = x140421011690855;
+Obj x140421011691335 = PRIM_CAR(closureRef(co, 1));
+Obj x140421011691399 = PRIM_CDR(x140421011691335);
+Obj x140421011691495 = PRIM_CDR(x140421011691399);
+Obj x140421011691527 = PRIM_EQ(Nil, x140421011691495);
+if (True == x140421011691527) {
+Obj x140421011691783 = PRIM_CDR(closureRef(co, 1));
+Obj args = x140421011691783;
+pushCont(co, 33, clofun4, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[107]);
+__arg1 = f;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5939,16 +5654,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476081127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081127;
+__arg0 = x140421013623943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5957,7 +5663,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476081127;
+__arg0 = x140421013623943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5966,7 +5672,25 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476081127;
+__arg0 = x140421013623943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5977,17 +5701,14 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139886474256615 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886474258375 = PRIM_CAR(closureRef(co, 1));
-Obj x139886474258407 = PRIM_SUB(x139886474258375, label);
-pushCont(co, 34, clofun4, 3, label, nargs, frees);
+Obj x140421011692103 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 34, clofun4, 2, f, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = x139886474258407;
-__arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421011692103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5997,33 +5718,47 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj x139886474258439 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 35, clofun4, 3, label, nargs, frees);
+Obj x140421011692135 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011692455 = PRIM_EQ(f, __symbolTable[126]);
+if (True == x140421011692455) {
+pushCont(co, 37, clofun4, 1, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = x139886474258439;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 35, clofun4, 1, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label35:
 {
-Obj x139886474258471 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 36, clofun4, 3, label, nargs, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
+Obj x140421011693479 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 36, clofun4);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[50]);
+__arg1 = closureRef(co, 2);
+__arg2 = closureRef(co, 3);
+__arg3 = closureRef(co, 4);
+co->args[4] = closureRef(co, 5);
+co->args[5] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6033,17 +5768,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139886474258663 = __arg1;
-Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886474258951 = PRIM_CAR(closureRef(co, 1));
-pushCont(co, 37, clofun4, 2, nargs, frees);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = closureRef(co, 3);
-__arg2 = label;
-__arg3 = x139886474258951;
+Obj x140421011628487 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6053,14 +5782,16 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139886474258983 = __arg1;
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 38, clofun4, 2, nargs, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
+Obj x140421011692679 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 38, clofun4);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[50]);
+__arg1 = closureRef(co, 2);
+__arg2 = closureRef(co, 3);
+__arg3 = closureRef(co, 4);
+co->args[4] = closureRef(co, 5);
+co->args[5] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6070,14 +5801,11 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x139886474259175 = __arg1;
-Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 39, clofun4, 1, frees);
+Obj x140421011693127 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = nargs;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6087,28 +5815,118 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139886474259367 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 40, clofun4, 1, frees);
+Obj x140421013624391 = makeNative(49, clofun4, 0, 6, closureRef(co, 3), closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 4), closureRef(co, 5));
+Obj x140421012040519 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140421012040519) {
+Obj x140421012040871 = PRIM_CAR(closureRef(co, 2));
+Obj x140421012040967 = PRIM_EQ(__symbolTable[92], x140421012040871);
+if (True == x140421012040967) {
+Obj x140421012041351 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012041383 = PRIM_ISCONS(x140421012041351);
+if (True == x140421012041383) {
+Obj x140421011767431 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011767463 = PRIM_CAR(x140421011767431);
+Obj a = x140421011767463;
+Obj x140421011767975 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011768007 = PRIM_CDR(x140421011767975);
+Obj x140421011768039 = PRIM_ISCONS(x140421011768007);
+if (True == x140421011768039) {
+Obj x140421011768583 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011768615 = PRIM_CDR(x140421011768583);
+Obj x140421011768647 = PRIM_CAR(x140421011768615);
+Obj b = x140421011768647;
+Obj x140421011769255 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011769287 = PRIM_CDR(x140421011769255);
+Obj x140421011769351 = PRIM_CDR(x140421011769287);
+Obj x140421011769511 = PRIM_ISCONS(x140421011769351);
+if (True == x140421011769511) {
+Obj x140421011769991 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011770183 = PRIM_CDR(x140421011769991);
+Obj x140421011770215 = PRIM_CDR(x140421011770183);
+Obj x140421011770247 = PRIM_CAR(x140421011770215);
+Obj c = x140421011770247;
+Obj x140421011770823 = PRIM_CDR(closureRef(co, 2));
+Obj x140421011770855 = PRIM_CDR(x140421011770823);
+Obj x140421011770983 = PRIM_CDR(x140421011770855);
+Obj x140421011771015 = PRIM_CDR(x140421011770983);
+Obj x140421011771207 = PRIM_EQ(Nil, x140421011771015);
+if (True == x140421011771207) {
+pushCont(co, 40, clofun4, 3, a, b, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("if (True == ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624391;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label40:
 {
-Obj x139886474259559 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 41, clofun4, 1, frees);
+Obj x140421011726375 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 41, clofun4, 3, a, b, c);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = frees;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6118,13 +5936,15 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139886474259815 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 42, clofun4, 1, frees);
+Obj x140421011726695 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 42, clofun4, 2, b, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 3);
-__arg2 = x139886474259815;
+__arg0 = x140421011726695;
+__arg1 = a;
+__arg2 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6134,12 +5954,14 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139886474259847 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 43, clofun4, 1, frees);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = frees;
+Obj x140421011726759 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 43, clofun4, 2, b, c);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6149,45 +5971,30 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139886474260135 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886474260167 = primNot(x139886474260135);
-if (True == x139886474260167) {
-pushCont(co, 44, clofun4, 1, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
+Obj x140421011727111 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 44, clofun4, 2, b, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
 __arg1 = closureRef(co, 3);
-__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label44:
 {
-Obj x139886474260359 = __arg1;
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 45, clofun4);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst_45list);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = frees;
+Obj x140421011727431 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun4, 1, c);
+__nargs = 3;
+__arg0 = x140421011727431;
+__arg1 = b;
+__arg2 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6197,11 +6004,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj x139886474141767 = __arg1;
+Obj x140421011727623 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 46, clofun4, 1, c);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(")");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6211,99 +6020,28 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj x139886475981127 = makeNative(49, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139886474552775 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474552775) {
-Obj x139886474553031 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474553063 = PRIM_EQ(symdo, x139886474553031);
-if (True == x139886474553063) {
-Obj x139886474553351 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474553383 = PRIM_ISCONS(x139886474553351);
-if (True == x139886474553383) {
-Obj x139886474553639 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474553671 = PRIM_CAR(x139886474553639);
-Obj a = x139886474553671;
-Obj x139886474553991 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474554055 = PRIM_CDR(x139886474553991);
-Obj x139886474554087 = PRIM_ISCONS(x139886474554055);
-if (True == x139886474554087) {
-Obj x139886474554471 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474554503 = PRIM_CDR(x139886474554471);
-Obj x139886474554535 = PRIM_CAR(x139886474554503);
-Obj b = x139886474554535;
-Obj x139886474554983 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474555015 = PRIM_CDR(x139886474554983);
-Obj x139886474555047 = PRIM_CDR(x139886474555015);
-Obj x139886474555079 = PRIM_EQ(Nil, x139886474555047);
-if (True == x139886474555079) {
-pushCont(co, 47, clofun4, 1, b);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = a;
+Obj x140421011727847 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 47, clofun4, 1, c);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475981127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label47:
 {
-Obj x139886474305607 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 48, clofun4, 1, b);
+Obj x140421011728135 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 48, clofun4);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(";\n");
+__arg0 = x140421011728135;
+__arg1 = c;
+__arg2 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6313,14 +6051,11 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139886474305799 = __arg1;
-Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = b;
+Obj x140421011728199 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("}\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6330,27 +6065,35 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj x139886475983271 = makeNative(8, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj x139886474580679 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474580679) {
-Obj x139886474581095 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474581127 = PRIM_EQ(symreturn, x139886474581095);
-if (True == x139886474581127) {
-Obj x139886474581383 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474581415 = PRIM_ISCONS(x139886474581383);
-if (True == x139886474581415) {
-Obj x139886474581767 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474581799 = PRIM_CAR(x139886474581767);
-Obj x = x139886474581799;
-Obj x139886474582247 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474582279 = PRIM_CDR(x139886474582247);
-Obj x139886474582311 = PRIM_EQ(Nil, x139886474582279);
-if (True == x139886474582311) {
-pushCont(co, 0, clofun5, 1, x);
+Obj x140421013625031 = makeNative(13, clofun5, 0, 6, closureRef(co, 2), closureRef(co, 3), closureRef(co, 1), closureRef(co, 5), closureRef(co, 0), closureRef(co, 4));
+Obj x140421012097095 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421012097095) {
+Obj x140421012097511 = PRIM_CAR(closureRef(co, 1));
+Obj x140421012097543 = PRIM_EQ(__symbolTable[77], x140421012097511);
+if (True == x140421012097543) {
+Obj x140421012097959 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012097991 = PRIM_ISCONS(x140421012097959);
+if (True == x140421012097991) {
+Obj x140421012098503 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012098535 = PRIM_CAR(x140421012098503);
+Obj label = x140421012098535;
+Obj x140421012074503 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012074535 = PRIM_CDR(x140421012074503);
+Obj x140421012074567 = PRIM_ISCONS(x140421012074535);
+if (True == x140421012074567) {
+Obj x140421012075111 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012075143 = PRIM_CDR(x140421012075111);
+Obj x140421012075175 = PRIM_CAR(x140421012075143);
+Obj nargs = x140421012075175;
+Obj x140421012075751 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012075783 = PRIM_CDR(x140421012075751);
+Obj x140421012075815 = PRIM_CDR(x140421012075783);
+Obj frees = x140421012075815;
+pushCont(co, 0, clofun5, 3, label, nargs, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("__nargs = 2;\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("makeNative(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6358,16 +6101,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475983271;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983271;
+__arg0 = x140421013625031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6376,7 +6110,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475983271;
+__arg0 = x140421013625031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6385,7 +6119,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475983271;
+__arg0 = x140421013625031;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6416,13 +6159,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886474582599 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 1, clofun5, 1, x);
+Obj x140421012076039 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421012076775 = PRIM_CAR(closureRef(co, 3));
+Obj x140421012076807 = PRIM_SUB(x140421012076775, label);
+pushCont(co, 1, clofun5, 3, label, nargs, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("__arg1 = ");
+__arg0 = globalRef(__symbolTable[52]);
+__arg1 = x140421012076807;
+__arg2 = globalRef(__symbolTable[51]);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6432,15 +6179,15 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj x139886474582791 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 2, clofun5);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 2);
-__arg2 = closureRef(co, 1);
-__arg3 = closureRef(co, 3);
-co->args[4] = x;
+Obj x140421012076839 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun5, 3, label, nargs, frees);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421012076839;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6450,12 +6197,15 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139886474583143 = __arg1;
-PUSH_CONT_0(co, 3, clofun5);
+Obj x140421012076871 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun5, 3, label, nargs, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(";\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6465,12 +6215,17 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139886474583463 = __arg1;
-PUSH_CONT_0(co, 4, clofun5);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
+Obj x140421012077159 = __arg1;
+Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421012077575 = PRIM_CAR(closureRef(co, 3));
+pushCont(co, 4, clofun5, 2, nargs, frees);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = closureRef(co, 5);
+__arg2 = label;
+__arg3 = x140421012077575;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6480,12 +6235,14 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139886474583655 = __arg1;
-PUSH_CONT_0(co, 5, clofun5);
+Obj x140421012077607 = __arg1;
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 5, clofun5, 2, nargs, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("if (co->ctx.pc.func != ");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6495,15 +6252,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139886474583975 = __arg1;
-Obj x139886474551623 = PRIM_CDR(closureRef(co, 2));
-Obj x139886474551879 = PRIM_CAR(closureRef(co, 2));
-PUSH_CONT_0(co, 6, clofun5);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
-__arg1 = closureRef(co, 3);
-__arg2 = x139886474551623;
-__arg3 = x139886474551879;
+Obj x140421012078023 = __arg1;
+Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 6, clofun5, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6513,12 +6269,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj x139886474551911 = __arg1;
-PUSH_CONT_0(co, 7, clofun5);
+Obj x140421012037863 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 7, clofun5, 1, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString(") { goto fail; }\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6528,11 +6285,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj x139886474552103 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 3);
-__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
+Obj x140421012038215 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 8, clofun5, 1, frees);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6542,195 +6300,57 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886475984551 = makeNative(9, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj x139886474643719 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474643719) {
-Obj x139886474644071 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474644103 = PRIM_EQ(symtailcall, x139886474644071);
-if (True == x139886474644103) {
-Obj x139886474644455 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474644487 = PRIM_ISCONS(x139886474644455);
-if (True == x139886474644487) {
-Obj x139886474644871 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474644903 = PRIM_CAR(x139886474644871);
-Obj exp = x139886474644903;
-Obj x139886474645351 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474645383 = PRIM_CDR(x139886474645351);
-Obj x139886474645415 = PRIM_EQ(Nil, x139886474645383);
-if (True == x139886474645415) {
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = exp;
+Obj x140421012038535 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 9, clofun5, 1, frees);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421012038535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475984551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label9:
 {
-Obj x139886475596551 = makeNative(11, clofun5, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj x139886474652327 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474652327) {
-Obj x139886474652647 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474652679 = PRIM_EQ(symcall, x139886474652647);
-if (True == x139886474652679) {
-Obj x139886474652999 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474653031 = PRIM_ISCONS(x139886474652999);
-if (True == x139886474653031) {
-Obj x139886474653383 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474653415 = PRIM_CAR(x139886474653383);
-Obj exp = x139886474653415;
-Obj x139886474641511 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474641543 = PRIM_CDR(x139886474641511);
-Obj x139886474641575 = PRIM_ISCONS(x139886474641543);
-if (True == x139886474641575) {
-Obj x139886474641959 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474641991 = PRIM_CDR(x139886474641959);
-Obj x139886474642023 = PRIM_CAR(x139886474641991);
-Obj cont = x139886474642023;
-Obj x139886474642503 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474642535 = PRIM_CDR(x139886474642503);
-Obj x139886474642567 = PRIM_CDR(x139886474642535);
-Obj x139886474642599 = PRIM_EQ(Nil, x139886474642567);
-if (True == x139886474642599) {
-pushCont(co, 10, clofun5, 1, exp);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45cont);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 3);
-__arg3 = cont;
+Obj x140421012038695 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 10, clofun5, 1, frees);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475596551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475596551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475596551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475596551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475596551;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label10:
 {
-Obj x139886474642855 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = closureRef(co, 3);
-co->args[4] = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x139886475126503 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475126503) {
-Obj x139886475126727 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139886475126727;
-Obj x139886475127111 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886475127111;
-pushCont(co, 12, clofun5, 2, f, args);
+Obj x140421012039047 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012039079 = primNot(x140421012039047);
+if (True == x140421012039079) {
+pushCont(co, 11, clofun5, 1, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("__nargs = ");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Nil;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6739,15 +6359,32 @@ goto *jumpTable[ps.label];
 }
 }
 
+label11:
+{
+Obj x140421012039463 = __arg1;
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+PUSH_CONT_0(co, 12, clofun5);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[50]);
+__arg1 = closureRef(co, 2);
+__arg2 = closureRef(co, 3);
+__arg3 = closureRef(co, 4);
+co->args[4] = closureRef(co, 5);
+co->args[5] = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label12:
 {
-Obj x139886475127399 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 13, clofun5, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = args;
+Obj x140421012039719 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6757,32 +6394,97 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj x139886475127815 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475127911 = PRIM_ADD(MAKE_NUMBER(1), x139886475127815);
-pushCont(co, 14, clofun5, 2, f, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = closureRef(co, 2);
-__arg2 = x139886475127911;
+Obj x140421013625511 = makeNative(18, clofun5, 0, 6, closureRef(co, 0), closureRef(co, 2), closureRef(co, 4), closureRef(co, 5), closureRef(co, 1), closureRef(co, 3));
+Obj x140421012120007 = PRIM_ISCONS(closureRef(co, 2));
+if (True == x140421012120007) {
+Obj x140421012120551 = PRIM_CAR(closureRef(co, 2));
+Obj x140421012120583 = PRIM_EQ(__symbolTable[90], x140421012120551);
+if (True == x140421012120583) {
+Obj x140421012121063 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012121095 = PRIM_ISCONS(x140421012121063);
+if (True == x140421012121095) {
+Obj x140421012121383 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012121415 = PRIM_CAR(x140421012121383);
+Obj a = x140421012121415;
+Obj x140421012122279 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012122311 = PRIM_CDR(x140421012122279);
+Obj x140421012122343 = PRIM_ISCONS(x140421012122311);
+if (True == x140421012122343) {
+Obj x140421012122887 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012123047 = PRIM_CDR(x140421012122887);
+Obj x140421012123079 = PRIM_CAR(x140421012123047);
+Obj b = x140421012123079;
+Obj x140421012123591 = PRIM_CDR(closureRef(co, 2));
+Obj x140421012123623 = PRIM_CDR(x140421012123591);
+Obj x140421012095175 = PRIM_CDR(x140421012123623);
+Obj x140421012095303 = PRIM_EQ(Nil, x140421012095175);
+if (True == x140421012095303) {
+pushCont(co, 14, clofun5, 2, a, b);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013625511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013625511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label14:
 {
-Obj x139886475127943 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 15, clofun5, 2, f, args);
+Obj x140421012095559 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 15, clofun5, 1, b);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString(";\n");
+__arg0 = x140421012095559;
+__arg1 = a;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6792,17 +6494,13 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139886475128295 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886474649607 = makeCons(f, args);
-PUSH_CONT_0(co, 16, clofun5);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = MAKE_NUMBER(0);
-co->args[4] = x139886474649607;
+Obj x140421012095719 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 16, clofun5, 1, b);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6812,12 +6510,12 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139886474649639 = __arg1;
-PUSH_CONT_0(co, 17, clofun5);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("co->ctx.frees = __arg0;\n");
+Obj x140421012095911 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 17, clofun5, 1, b);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6827,12 +6525,12 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj x139886474650023 = __arg1;
-PUSH_CONT_0(co, 18, clofun5);
+Obj x140421012096263 = __arg1;
+Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n");
+__arg0 = x140421012096263;
+__arg1 = b;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6842,27 +6540,79 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886474650311 = __arg1;
-PUSH_CONT_0(co, 19, clofun5);
+Obj x140421013625959 = makeNative(28, clofun5, 0, 6, closureRef(co, 0), closureRef(co, 4), closureRef(co, 5), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421012515815 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421012515815) {
+Obj x140421012516135 = PRIM_CAR(closureRef(co, 1));
+Obj x140421012516167 = PRIM_EQ(__symbolTable[78], x140421012516135);
+if (True == x140421012516167) {
+Obj x140421012516487 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012516551 = PRIM_ISCONS(x140421012516487);
+if (True == x140421012516551) {
+Obj x140421012389927 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012389959 = PRIM_CAR(x140421012389927);
+Obj x = x140421012389959;
+Obj x140421012390375 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012390407 = PRIM_CDR(x140421012390375);
+Obj x140421012390567 = PRIM_EQ(Nil, x140421012390407);
+if (True == x140421012390567) {
+pushCont(co, 19, clofun5, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("__nargs = 2;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013625959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013625959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label19:
 {
-Obj x139886474650631 = __arg1;
-PUSH_CONT_0(co, 20, clofun5);
+Obj x140421012390855 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 20, clofun5, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("if (ps.func != ");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("__arg1 = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6872,15 +6622,12 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj x139886474650951 = __arg1;
-Obj x139886474651271 = PRIM_CDR(closureRef(co, 1));
-Obj x139886474651399 = PRIM_CAR(closureRef(co, 1));
-PUSH_CONT_0(co, 21, clofun5);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
+Obj x140421012391207 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 21, clofun5, 1, x);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
 __arg1 = closureRef(co, 2);
-__arg2 = x139886474651271;
-__arg3 = x139886474651399;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6890,12 +6637,13 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj x139886474651495 = __arg1;
+Obj x140421012391495 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 22, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
+__arg0 = x140421012391495;
+__arg1 = x;
+__arg2 = closureRef(co, 3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6905,11 +6653,12 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139886474651687 = __arg1;
+Obj x140421012391559 = __arg1;
+PUSH_CONT_0(co, 23, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = closureRef(co, 2);
-__arg2 = makeCString("goto *jumpTable[ps.label];\n");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6919,12 +6668,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj sym = __arg1;
-Obj globals = __arg2;
-pushCont(co, 24, clofun5, 2, sym, globals);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35value);
-__arg1 = globals;
+Obj x140421012391815 = __arg1;
+PUSH_CONT_0(co, 24, clofun5);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6934,15 +6683,12 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x139886475183911 = __arg1;
-Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val = x139886475183911;
-pushCont(co, 25, clofun5, 3, sym, val, globals);
+Obj x140421012392167 = __arg1;
+PUSH_CONT_0(co, 25, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = sym;
-__arg2 = val;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("if (co->ctx.pc.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6952,98 +6698,44 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139886475184103 = __arg1;
-Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139886475184103) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475184263 = makeCons(sym, val);
-Obj x139886475184295 = primSet(co, globals, x139886475184263);
-__nargs = 2;
-__arg1 = x139886475184295;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
+Obj x140421012392519 = __arg1;
+Obj x140421012392935 = PRIM_CDR(closureRef(co, 4));
+Obj x140421012393127 = PRIM_CAR(closureRef(co, 4));
+PUSH_CONT_0(co, 26, clofun5);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = closureRef(co, 5);
+__arg2 = x140421012392935;
+__arg3 = x140421012393127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label26:
 {
-Obj x139886476106727 = __arg1;
-Obj x139886476106759 = __arg2;
-Obj x139886476106791 = __arg3;
-Obj x139886476106855 = co->args[4];
-Obj x139886475190503 = PRIM_EQ(Nil, x139886476106855);
-if (True == x139886475190503) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475190919 = PRIM_ISCONS(x139886476106855);
-if (True == x139886475190919) {
-Obj x139886475191207 = PRIM_CAR(x139886476106855);
-Obj x = x139886475191207;
-Obj x139886475192135 = PRIM_CDR(x139886476106855);
-Obj more = x139886475192135;
-Obj x139886475192551 = PRIM_GT(x139886476106791, MAKE_NUMBER(3));
-Obj x139886475192583 = primNot(x139886475192551);
-if (True == x139886475192583) {
-pushCont(co, 33, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+Obj x140421012393159 = __arg1;
+PUSH_CONT_0(co, 27, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString("__arg");
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString(") { goto fail; }\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 27, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString("co->args[");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label27:
 {
-Obj x139886475194087 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 28, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+Obj x140421012393543 = __arg1;
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476106759;
-__arg2 = x139886476106791;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 5);
+__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7053,37 +6745,77 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886475182183 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 29, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString("]");
+Obj x140421013626311 = makeNative(30, clofun5, 0, 6, closureRef(co, 3), closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 4), closureRef(co, 5));
+Obj x140421012995655 = PRIM_ISCONS(closureRef(co, 3));
+if (True == x140421012995655) {
+Obj x140421012512775 = PRIM_CAR(closureRef(co, 3));
+Obj x140421012512807 = PRIM_EQ(__symbolTable[80], x140421012512775);
+if (True == x140421012512807) {
+Obj x140421012513319 = PRIM_CDR(closureRef(co, 3));
+Obj x140421012513479 = PRIM_ISCONS(x140421012513319);
+if (True == x140421012513479) {
+Obj x140421012513863 = PRIM_CDR(closureRef(co, 3));
+Obj x140421012514055 = PRIM_CAR(x140421012513863);
+Obj exp = x140421012514055;
+Obj x140421012514855 = PRIM_CDR(closureRef(co, 3));
+Obj x140421012514887 = PRIM_CDR(x140421012514855);
+Obj x140421012514919 = PRIM_EQ(Nil, x140421012514887);
+if (True == x140421012514919) {
+pushCont(co, 29, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013626311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626311;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label29:
 {
-Obj x139886475182279 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 30, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+Obj x140421012515111 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString(" = ");
+__arg0 = x140421012515111;
+__arg1 = exp;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7093,38 +6825,99 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj x139886475182535 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 31, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = x139886476106727;
-__arg2 = Nil;
-__arg3 = x139886476106759;
-co->args[4] = x;
+Obj x140421013626663 = makeNative(33, clofun5, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj x140421013092647 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013092647) {
+Obj x140421013092967 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013092999 = PRIM_EQ(__symbolTable[79], x140421013092967);
+if (True == x140421013092999) {
+Obj x140421013093543 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093575 = PRIM_ISCONS(x140421013093543);
+if (True == x140421013093575) {
+Obj x140421013094183 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013094215 = PRIM_CAR(x140421013094183);
+Obj exp = x140421013094215;
+Obj x140421012992487 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012992551 = PRIM_CDR(x140421012992487);
+Obj x140421012992615 = PRIM_ISCONS(x140421012992551);
+if (True == x140421012992615) {
+Obj x140421012993159 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012993191 = PRIM_CDR(x140421012993159);
+Obj x140421012993223 = PRIM_CAR(x140421012993191);
+Obj cont = x140421012993223;
+Obj x140421012993831 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012993863 = PRIM_CDR(x140421012993831);
+Obj x140421012993927 = PRIM_CDR(x140421012993863);
+Obj x140421012993959 = PRIM_EQ(Nil, x140421012993927);
+if (True == x140421012993959) {
+pushCont(co, 31, clofun5, 1, exp);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[53]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 5);
+co->args[4] = closureRef(co, 3);
+co->args[5] = cont;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626663;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013626663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626663;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label31:
 {
-Obj x139886475182759 = __arg1;
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 32, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString(";\n");
+Obj x140421012994407 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 32, clofun5, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = closureRef(co, 4);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7134,18 +6927,12 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj x139886475182919 = __arg1;
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475183239 = PRIM_ADD(x139886476106791, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
-__arg1 = x139886476106727;
-__arg2 = x139886476106759;
-__arg3 = x139886475183239;
-co->args[4] = more;
+Obj x140421012994791 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = x140421012994791;
+__arg1 = exp;
+__arg2 = closureRef(co, 5);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7155,37 +6942,43 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139886475192743 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 34, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
+Obj x140421013273319 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013273319) {
+Obj x140421013273511 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140421013273511;
+Obj x140421013273735 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421013273735;
+pushCont(co, 34, clofun5, 2, f, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
-__arg1 = x139886476106759;
-__arg2 = x139886476106791;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("__nargs = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label34:
 {
-Obj x139886475192903 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 35, clofun5, 5, x, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
-__arg2 = makeCString(" = ");
+Obj x140421013273991 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 35, clofun5, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7195,19 +6988,15 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139886475193127 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 36, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = x139886476106727;
-__arg2 = Nil;
-__arg3 = x139886476106759;
-co->args[4] = x;
+Obj x140421013107367 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013107591 = PRIM_ADD(MAKE_NUMBER(1), x140421013107367);
+pushCont(co, 36, clofun5, 2, f, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = closureRef(co, 3);
+__arg2 = x140421013107591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7217,15 +7006,13 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj x139886475193351 = __arg1;
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 37, clofun5, 4, x139886476106791, x139886476106727, x139886476106759, more);
+Obj x140421013107623 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 37, clofun5, 2, f, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
-__arg1 = x139886476106759;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
 __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7236,18 +7023,18 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139886475193639 = __arg1;
-Obj x139886476106791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476106727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476106759= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x139886475193895 = PRIM_ADD(x139886476106791, MAKE_NUMBER(1));
-__nargs = 5;
-__arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
-__arg1 = x139886476106727;
-__arg2 = x139886476106759;
-__arg3 = x139886475193895;
-co->args[4] = more;
+Obj x140421013108615 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013109255 = makeCons(f, args);
+PUSH_CONT_0(co, 38, clofun5);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[62]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = closureRef(co, 3);
+co->args[4] = MAKE_NUMBER(0);
+co->args[5] = x140421013109255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7257,14 +7044,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj x = __arg1;
-Obj k = __arg2;
-Obj x139886475246343 = primGenSym();
-Obj tmp = x139886475246343;
-pushCont(co, 39, clofun5, 2, x, tmp);
-__nargs = 2;
-__arg0 = k;
-__arg1 = tmp;
+Obj x140421013110023 = __arg1;
+PUSH_CONT_0(co, 39, clofun5);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("co->ctx.frees = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7274,29 +7059,27 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139886475247015 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475247047 = makeCons(x139886475247015, Nil);
-Obj x139886475247079 = makeCons(x, x139886475247047);
-Obj x139886475247111 = makeCons(tmp, x139886475247079);
-Obj x139886475247143 = makeCons(symlet, x139886475247111);
-__nargs = 2;
-__arg1 = x139886475247143;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013110279 = __arg1;
+PUSH_CONT_0(co, 40, clofun5);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label40:
 {
-Obj v = __arg1;
-Obj val = __arg2;
-pushCont(co, 41, clofun5, 2, val, v);
+Obj x140421013110663 = __arg1;
+PUSH_CONT_0(co, 41, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7306,15 +7089,12 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139886475244103 = __arg1;
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj idx = x139886475244103;
-pushCont(co, 42, clofun5, 3, val, idx, v);
+Obj x140421013090535 = __arg1;
+PUSH_CONT_0(co, 42, clofun5);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(1);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("if (ps.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7324,22 +7104,15 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139886475244327 = __arg1;
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cur = x139886475244327;
-Obj x139886475244935 = makeCons(val, Nil);
-Obj x139886475244967 = makeCons(idx, x139886475244935);
-Obj x139886475244999 = makeCons(x139886475244967, cur);
-Obj cur1 = x139886475244999;
-Obj x139886475245383 = PRIM_ADD(idx, MAKE_NUMBER(1));
-pushCont(co, 43, clofun5, 2, v, cur1);
+Obj x140421013090887 = __arg1;
+Obj x140421013091399 = PRIM_CDR(closureRef(co, 2));
+Obj x140421013091591 = PRIM_CAR(closureRef(co, 2));
+PUSH_CONT_0(co, 43, clofun5);
 __nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(0);
-__arg3 = x139886475245383;
+__arg0 = globalRef(__symbolTable[54]);
+__arg1 = closureRef(co, 3);
+__arg2 = x140421013091399;
+__arg3 = x140421013091591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7349,14 +7122,12 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj x139886475245415 = __arg1;
-Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 4;
-__arg0 = globalRef(symcora_47init_35vector_45set_33);
-__arg1 = v;
-__arg2 = MAKE_NUMBER(1);
-__arg3 = cur1;
+Obj x140421013091623 = __arg1;
+PUSH_CONT_0(co, 44, clofun5);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7366,189 +7137,43 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj x139886476185831 = __arg1;
-Obj x139886476185863 = __arg2;
-Obj x139886476187719 = makeNative(1, clofun6, 0, 2, x139886476185831, x139886476185863);
-Obj x139886475383495 = PRIM_ISCONS(x139886476185863);
-if (True == x139886475383495) {
-Obj x139886475383655 = PRIM_CAR(x139886476185863);
-Obj clo_45or_45cont = x139886475383655;
-Obj x139886475384039 = PRIM_CDR(x139886476185863);
-Obj x139886475384071 = PRIM_ISCONS(x139886475384039);
-if (True == x139886475384071) {
-Obj x139886475384455 = PRIM_CDR(x139886476185863);
-Obj x139886475384487 = PRIM_CAR(x139886475384455);
-Obj x139886475384519 = PRIM_ISCONS(x139886475384487);
-if (True == x139886475384519) {
-Obj x139886475385031 = PRIM_CDR(x139886476185863);
-Obj x139886475385063 = PRIM_CAR(x139886475385031);
-Obj x139886475385095 = PRIM_CAR(x139886475385063);
-Obj x139886475385127 = PRIM_EQ(symlambda, x139886475385095);
-if (True == x139886475385127) {
-Obj x139886475385511 = PRIM_CDR(x139886476185863);
-Obj x139886475385543 = PRIM_CAR(x139886475385511);
-Obj x139886475385575 = PRIM_CDR(x139886475385543);
-Obj x139886475385607 = PRIM_ISCONS(x139886475385575);
-if (True == x139886475385607) {
-Obj x139886475386151 = PRIM_CDR(x139886476185863);
-Obj x139886475386183 = PRIM_CAR(x139886475386151);
-Obj x139886475386247 = PRIM_CDR(x139886475386183);
-Obj x139886475386279 = PRIM_CAR(x139886475386247);
-Obj params = x139886475386279;
-Obj x139886475329607 = PRIM_CDR(x139886476185863);
-Obj x139886475329639 = PRIM_CAR(x139886475329607);
-Obj x139886475329671 = PRIM_CDR(x139886475329639);
-Obj x139886475329703 = PRIM_CDR(x139886475329671);
-Obj x139886475329767 = PRIM_ISCONS(x139886475329703);
-if (True == x139886475329767) {
-Obj x139886475330343 = PRIM_CDR(x139886476185863);
-Obj x139886475330375 = PRIM_CAR(x139886475330343);
-Obj x139886475330471 = PRIM_CDR(x139886475330375);
-Obj x139886475330535 = PRIM_CDR(x139886475330471);
-Obj x139886475330567 = PRIM_CAR(x139886475330535);
-Obj body = x139886475330567;
-Obj x139886475331399 = PRIM_CDR(x139886476185863);
-Obj x139886475331431 = PRIM_CAR(x139886475331399);
-Obj x139886475331495 = PRIM_CDR(x139886475331431);
-Obj x139886475331527 = PRIM_CDR(x139886475331495);
-Obj x139886475331559 = PRIM_CDR(x139886475331527);
-Obj x139886475331591 = PRIM_EQ(Nil, x139886475331559);
-if (True == x139886475331591) {
-Obj x139886475332007 = PRIM_CDR(x139886476185863);
-Obj x139886475332039 = PRIM_CDR(x139886475332007);
-Obj fvs = x139886475332039;
-Obj x139886476185895 = makeNative(45, clofun5, 1, 6, body, x139886476185831, params, clo_45or_45cont, fvs, x139886476187719);
-Obj x139886475271175 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == x139886475271175) {
-__nargs = 2;
-__arg0 = x139886476185895;
-__arg1 = True;
+Obj x140421013091911 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = closureRef(co, 3);
+__arg2 = makeCString("goto *jumpTable[ps.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139886475271431 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
-if (True == x139886475271431) {
-__nargs = 2;
-__arg0 = x139886476185895;
-__arg1 = True;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = x139886476185895;
-__arg1 = False;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476187719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label45:
 {
-Obj x139886476185927 = __arg1;
-if (True == x139886476185927) {
-PUSH_CONT_0(co, 46, clofun5);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 0);
+Obj sym = __arg1;
+Obj globals = __arg2;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[57]);
+__arg1 = MAKE_NUMBER(0);
+__arg2 = sym;
+__arg3 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = closureRef(co, 5);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label46:
 {
-Obj x139886475332807 = __arg1;
-Obj body1 = x139886475332807;
-pushCont(co, 47, clofun5, 1, body1);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35vector_45ref);
-__arg1 = closureRef(co, 1);
-__arg2 = MAKE_NUMBER(0);
+Obj idx = __arg1;
+Obj sym = __arg2;
+Obj globals = __arg3;
+pushCont(co, 47, clofun5, 3, idx, globals, sym);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = globals;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7558,64 +7183,68 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj x139886475333063 = __arg1;
-Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cur = x139886475333063;
-Obj x139886475333383 = PRIM_EQ(closureRef(co, 3), sym_37closure);
-if (True == x139886475333383) {
-Obj x139886475268455 = makeCons(body1, Nil);
-Obj x139886475268487 = makeCons(Nil, x139886475268455);
-Obj x139886475268519 = makeCons(closureRef(co, 2), x139886475268487);
-Obj x139886475268647 = makeCons(symlambda, x139886475268519);
-pushCont(co, 49, clofun5, 1, cur);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = closureRef(co, 1);
-__arg2 = x139886475268647;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421013390247 = __arg1;
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140421013390247) {
+__nargs = 2;
+__arg1 = MAKE_NUMBER(-1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886475270119 = makeCons(body1, Nil);
-Obj x139886475270151 = makeCons(closureRef(co, 4), x139886475270119);
-Obj x139886475270183 = makeCons(closureRef(co, 2), x139886475270151);
-Obj x139886475270215 = makeCons(symlambda, x139886475270183);
-pushCont(co, 48, clofun5, 1, cur);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35append_45result);
-__arg1 = closureRef(co, 1);
-__arg2 = x139886475270215;
+Obj x140421013390471 = PRIM_CAR(globals);
+Obj x140421013390727 = PRIM_EQ(sym, x140421013390471);
+if (True == x140421013390727) {
+__nargs = 2;
+__arg1 = idx;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013390983 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj x140421013391079 = PRIM_CDR(globals);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[57]);
+__arg1 = x140421013390983;
+__arg2 = sym;
+__arg3 = x140421013391079;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 }
 
 label48:
 {
-Obj x139886475270247 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475270567 = makeCons(cur, closureRef(co, 4));
-Obj x139886475270599 = makeCons(closureRef(co, 3), x139886475270567);
+Obj sym = __arg1;
+Obj globals = __arg2;
+pushCont(co, 49, clofun5, 2, sym, globals);
 __nargs = 2;
-__arg1 = x139886475270599;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun5) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(__symbolTable[58]);
+__arg1 = globals;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label49:
 {
-Obj x139886475268679 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 0, clofun6, 1, cur);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = closureRef(co, 2);
+Obj x140421013470823 = __arg1;
+Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj val = x140421013470823;
+pushCont(co, 0, clofun6, 3, sym, val, globals);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[100]);
+__arg1 = sym;
+__arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7645,47 +7274,100 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886475269159 = __arg1;
-Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475269319 = makeCons(x139886475269159, closureRef(co, 4));
-Obj x139886475269383 = makeCons(cur, x139886475269319);
-Obj x139886475269415 = makeCons(closureRef(co, 3), x139886475269383);
+Obj x140421013470983 = __arg1;
+Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140421013470983) {
 __nargs = 2;
-__arg1 = x139886475269415;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013389415 = makeCons(sym, val);
+Obj x140421013389543 = primSet(co, globals, x140421013389415);
+__nargs = 2;
+__arg1 = x140421013389543;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
+}
 
 label1:
 {
-Obj x139886475382887 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139886475382887) {
+Obj x140421013681063 = __arg1;
+Obj x140421013681095 = __arg2;
+Obj x140421013681191 = __arg3;
+Obj x140421013681223 = co->args[4];
+Obj x140421013681287 = co->args[5];
+Obj x140421013563655 = PRIM_EQ(Nil, x140421013681287);
+if (True == x140421013563655) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013563911 = PRIM_ISCONS(x140421013681287);
+if (True == x140421013563911) {
+Obj x140421013564135 = PRIM_CAR(x140421013681287);
+Obj x = x140421013564135;
+Obj x140421013564359 = PRIM_CDR(x140421013681287);
+Obj more = x140421013564359;
+Obj x140421013564807 = PRIM_GT(x140421013681223, MAKE_NUMBER(3));
+Obj x140421013564839 = primNot(x140421013564807);
+if (True == x140421013564839) {
+pushCont(co, 8, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = makeNative(2, clofun6, 1, 1, closureRef(co, 0));
-__arg2 = closureRef(co, 1);
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
+pushCont(co, 2, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString("co->args[");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
 __nargs = 2;
-__arg1 = closureRef(co, 1);
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label2:
 {
-Obj e = __arg1;
+Obj x140421013468487 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 3, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda);
-__arg1 = closureRef(co, 0);
-__arg2 = e;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013681191;
+__arg2 = x140421013681223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7695,12 +7377,18 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj x139886475983879 = __arg1;
-Obj x139886475983911 = __arg2;
-pushCont(co, 4, clofun6, 2, x139886475983911, x139886475983879);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x139886475983911;
+Obj x140421013468743 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 4, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7710,215 +7398,85 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj x139886475567879 = __arg1;
-Obj x139886475983911= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475983879= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886475567879) {
-__nargs = 2;
-__arg1 = x139886475983911;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475568071 = primIsSymbol(x139886475983911);
-if (True == x139886475568071) {
-__nargs = 2;
-__arg1 = x139886475983911;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475460679 = makeNative(6, clofun6, 0, 2, x139886475983911, x139886475983879);
-Obj x139886475460935 = PRIM_ISCONS(x139886475983911);
-if (True == x139886475460935) {
-Obj x139886475461255 = PRIM_CAR(x139886475983911);
-Obj x139886475461287 = PRIM_EQ(symlambda, x139886475461255);
-if (True == x139886475461287) {
-Obj x139886475461575 = PRIM_CDR(x139886475983911);
-Obj x139886475461607 = PRIM_ISCONS(x139886475461575);
-if (True == x139886475461607) {
-Obj x139886475461863 = PRIM_CDR(x139886475983911);
-Obj x139886475461927 = PRIM_CAR(x139886475461863);
-Obj args = x139886475461927;
-Obj x139886475462247 = PRIM_CDR(x139886475983911);
-Obj x139886475462279 = PRIM_CDR(x139886475462247);
-Obj x139886475462311 = PRIM_ISCONS(x139886475462279);
-if (True == x139886475462311) {
-Obj x139886475462599 = PRIM_CDR(x139886475983911);
-Obj x139886475462631 = PRIM_CDR(x139886475462599);
-Obj x139886475462663 = PRIM_CAR(x139886475462631);
-Obj body = x139886475462663;
-Obj x139886475463015 = PRIM_CDR(x139886475983911);
-Obj x139886475463047 = PRIM_CDR(x139886475463015);
-Obj x139886475463079 = PRIM_CDR(x139886475463047);
-Obj x139886475463111 = PRIM_EQ(Nil, x139886475463079);
-if (True == x139886475463111) {
-pushCont(co, 5, clofun6, 1, args);
+Obj x140421013468839 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 5, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = x139886475983879;
-__arg2 = body;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475460679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475460679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475460679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475460679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475460679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
 }
 
 label5:
 {
-Obj x139886475463495 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475463559 = makeCons(x139886475463495, Nil);
-Obj x139886475463591 = makeCons(args, x139886475463559);
-Obj x139886475463655 = makeCons(symlambda, x139886475463591);
-__nargs = 2;
-__arg1 = x139886475463655;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013469127 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 6, clofun6, 5, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = x140421013681063;
+__arg2 = x140421013681095;
+__arg3 = Nil;
+co->args[4] = x140421013681191;
+co->args[5] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj x139886475383943 = makeNative(12, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886475509479 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475509479) {
-Obj x139886475468807 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475468839 = PRIM_EQ(symcontinuation, x139886475468807);
-if (True == x139886475468839) {
-Obj x139886475469159 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475469223 = PRIM_ISCONS(x139886475469159);
-if (True == x139886475469223) {
-Obj x139886475469575 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475469607 = PRIM_CAR(x139886475469575);
-Obj val = x139886475469607;
-Obj x139886475470119 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475470151 = PRIM_CDR(x139886475470119);
-Obj x139886475470183 = PRIM_ISCONS(x139886475470151);
-if (True == x139886475470183) {
-Obj x139886475470503 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475470567 = PRIM_CDR(x139886475470503);
-Obj x139886475470599 = PRIM_CAR(x139886475470567);
-Obj body = x139886475470599;
-Obj x139886475471047 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475471143 = PRIM_CDR(x139886475471047);
-Obj x139886475471175 = PRIM_CDR(x139886475471143);
-Obj x139886475471207 = PRIM_EQ(Nil, x139886475471175);
-if (True == x139886475471207) {
-pushCont(co, 7, clofun6, 2, body, val);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = body;
+Obj x140421013469383 = __arg1;
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 7, clofun6, 5, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475383943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475383943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475383943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475383943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475383943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label7:
 {
-Obj x139886475471495 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 8, clofun6, 2, body, val);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139886475471495;
-__arg2 = val;
+Obj x140421013469703 = __arg1;
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421013469927 = PRIM_ADD(x140421013681223, MAKE_NUMBER(1));
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[62]);
+__arg1 = x140421013681063;
+__arg2 = x140421013681095;
+__arg3 = x140421013681191;
+co->args[4] = x140421013469927;
+co->args[5] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7928,14 +7486,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886475471527 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs1 = x139886475471527;
-pushCont(co, 9, clofun6, 3, fvs1, body, val);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = closureRef(co, 1);
+Obj x140421013565191 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 9, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[60]);
+__arg1 = x140421013681191;
+__arg2 = x140421013681223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7945,15 +7507,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj x139886475471879 = __arg1;
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 10, clofun6, 3, fvs1, body, val);
+Obj x140421013565287 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 10, clofun6, 6, x, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886475471879;
-__arg2 = fvs1;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7963,16 +7528,21 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj x139886475471911 = __arg1;
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs2 = x139886475471911;
-pushCont(co, 11, clofun6, 2, val, fvs2);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = fvs1;
-__arg2 = body;
+Obj x140421013467335 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
+pushCont(co, 11, clofun6, 5, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[59]);
+__arg1 = x140421013681063;
+__arg2 = x140421013681095;
+__arg3 = Nil;
+co->args[4] = x140421013681191;
+co->args[5] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7982,114 +7552,57 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj x139886475472359 = __arg1;
-Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475472391 = makeCons(x139886475472359, Nil);
-Obj x139886475472487 = makeCons(val, x139886475472391);
-Obj x139886475472519 = makeCons(symlambda, x139886475472487);
-Obj x139886475472551 = makeCons(x139886475472519, fvs2);
-Obj x139886475472583 = makeCons(sym_37continuation, x139886475472551);
-__nargs = 2;
-__arg1 = x139886475472583;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013467591 = __arg1;
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+pushCont(co, 12, clofun6, 5, x140421013681223, x140421013681063, x140421013681095, x140421013681191, more);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[61]);
+__arg1 = x140421013681191;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj x139886475331079 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886475569927 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475569927) {
-Obj x139886475570183 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475570215 = PRIM_EQ(symcall, x139886475570183);
-if (True == x139886475570215) {
-Obj x139886475570503 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475570535 = PRIM_ISCONS(x139886475570503);
-if (True == x139886475570535) {
-Obj x139886475571047 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475505991 = PRIM_CAR(x139886475571047);
-Obj exp = x139886475505991;
-Obj x139886475506695 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475506759 = PRIM_CDR(x139886475506695);
-Obj x139886475506791 = PRIM_ISCONS(x139886475506759);
-if (True == x139886475506791) {
-Obj x139886475507335 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475507367 = PRIM_CDR(x139886475507335);
-Obj x139886475507399 = PRIM_CAR(x139886475507367);
-Obj cont = x139886475507399;
-Obj x139886475507879 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475507911 = PRIM_CDR(x139886475507879);
-Obj x139886475507943 = PRIM_CDR(x139886475507911);
-Obj x139886475508007 = PRIM_EQ(Nil, x139886475507943);
-if (True == x139886475508007) {
-pushCont(co, 13, clofun6, 2, exp, cont);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = closureRef(co, 1);
+Obj x140421013467975 = __arg1;
+Obj x140421013681223= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013681063= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013681095= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421013681191= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
+Obj x140421013468135 = PRIM_ADD(x140421013681223, MAKE_NUMBER(1));
+__nargs = 6;
+__arg0 = globalRef(__symbolTable[62]);
+__arg1 = x140421013681063;
+__arg2 = x140421013681095;
+__arg3 = x140421013681191;
+co->args[4] = x140421013468135;
+co->args[5] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475331079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475331079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475331079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475331079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475331079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label13:
 {
-Obj x139886475508391 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 14, clofun6, 1, cont);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886475508391;
-__arg2 = exp;
+Obj x = __arg1;
+Obj k = __arg2;
+Obj x140421013562055 = primGenSym();
+Obj tmp = x140421013562055;
+pushCont(co, 14, clofun6, 2, x, tmp);
+__nargs = 2;
+__arg0 = k;
+__arg1 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8099,73 +7612,72 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886475508423 = __arg1;
-Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 15, clofun6, 1, x139886475508423);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = closureRef(co, 1);
-__arg2 = cont;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj x139886475508679 = __arg1;
-Obj x139886475508423= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475508711 = makeCons(x139886475508679, Nil);
-Obj x139886475508743 = makeCons(x139886475508423, x139886475508711);
-Obj x139886475508775 = makeCons(symcall, x139886475508743);
+Obj x140421013562727 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013562823 = makeCons(x140421013562727, Nil);
+Obj x140421013562855 = makeCons(x, x140421013562823);
+Obj x140421013562887 = makeCons(tmp, x140421013562855);
+Obj x140421013562951 = makeCons(__symbolTable[91], x140421013562887);
 __nargs = 2;
-__arg1 = x139886475508775;
+__arg1 = x140421013562951;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label15:
 {
-Obj x139886475568839 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475568839) {
-Obj x139886475569063 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139886475569063;
-Obj x139886475569319 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886475569319;
-pushCont(co, 17, clofun6, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
-__arg1 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+Obj v = __arg1;
+Obj val = __arg2;
+pushCont(co, 16, clofun6, 2, val, v);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[65]);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+
+label16:
+{
+Obj x140421013624999 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj idx = x140421013624999;
+pushCont(co, 17, clofun6, 3, val, idx, v);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[65]);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj x139886475569543 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475569671 = makeCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886475569543;
-__arg2 = x139886475569671;
+Obj x140421013625255 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj cur = x140421013625255;
+Obj x140421013625895 = makeCons(val, Nil);
+Obj x140421013625991 = makeCons(idx, x140421013625895);
+Obj x140421013626023 = makeCons(x140421013625991, cur);
+Obj cur1 = x140421013626023;
+Obj x140421013626599 = PRIM_ADD(idx, MAKE_NUMBER(1));
+pushCont(co, 18, clofun6, 2, v, cur1);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[63]);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(0);
+__arg3 = x140421013626599;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8175,118 +7687,90 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj x139886476187527 = __arg1;
-Obj x139886476187559 = __arg2;
-Obj x139886476187687 = __arg3;
-Obj x139886475595943 = PRIM_EQ(Nil, x139886476187527);
-if (True == x139886475595943) {
-pushCont(co, 20, clofun6, 1, x139886476187687);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = x139886476187559;
+Obj x140421013626631 = __arg1;
+Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[63]);
+__arg1 = v;
+__arg2 = MAKE_NUMBER(1);
+__arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139886475599239 = PRIM_ISCONS(x139886476187527);
-if (True == x139886475599239) {
-Obj x139886475599431 = PRIM_CAR(x139886476187527);
-Obj hd = x139886475599431;
-Obj x139886475599623 = PRIM_CDR(x139886476187527);
-Obj tl = x139886475599623;
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = hd;
-__arg2 = makeNative(19, clofun6, 1, 3, tl, x139886476187559, x139886476187687);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label19:
 {
-Obj hd1 = __arg1;
-Obj x139886475567303 = makeCons(hd1, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = closureRef(co, 0);
-__arg2 = x139886475567303;
-__arg3 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj x139886475596167 = __arg1;
-Obj x139886476187687= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp = x139886475596167;
-Obj x139886476185735 = makeNative(23, clofun6, 1, 2, exp, x139886476187687);
-Obj x139886475598663 = PRIM_CAR(exp);
-pushCont(co, 21, clofun6, 2, exp, x139886476185735);
+Obj x140421013563047 = __arg1;
+Obj x140421013563079 = __arg2;
+Obj x140421013563271 = makeNative(26, clofun6, 0, 2, x140421013563047, x140421013563079);
+Obj x140421011440551 = PRIM_ISCONS(x140421013563079);
+if (True == x140421011440551) {
+Obj x140421011440711 = PRIM_CAR(x140421013563079);
+Obj clo_45or_45cont = x140421011440711;
+Obj x140421011440935 = PRIM_CDR(x140421013563079);
+Obj x140421011440967 = PRIM_ISCONS(x140421011440935);
+if (True == x140421011440967) {
+Obj x140421011441255 = PRIM_CDR(x140421013563079);
+Obj x140421011441287 = PRIM_CAR(x140421011441255);
+Obj x140421011441319 = PRIM_ISCONS(x140421011441287);
+if (True == x140421011441319) {
+Obj x140421011441671 = PRIM_CDR(x140421013563079);
+Obj x140421011441703 = PRIM_CAR(x140421011441671);
+Obj x140421011441735 = PRIM_CAR(x140421011441703);
+Obj x140421011441767 = PRIM_EQ(__symbolTable[94], x140421011441735);
+if (True == x140421011441767) {
+Obj x140421011442119 = PRIM_CDR(x140421013563079);
+Obj x140421011442151 = PRIM_CAR(x140421011442119);
+Obj x140421011442183 = PRIM_CDR(x140421011442151);
+Obj x140421011442215 = PRIM_ISCONS(x140421011442183);
+if (True == x140421011442215) {
+Obj x140421011442567 = PRIM_CDR(x140421013563079);
+Obj x140421011442599 = PRIM_CAR(x140421011442567);
+Obj x140421011442631 = PRIM_CDR(x140421011442599);
+Obj x140421011442663 = PRIM_CAR(x140421011442631);
+Obj params = x140421011442663;
+Obj x140421011443079 = PRIM_CDR(x140421013563079);
+Obj x140421011443111 = PRIM_CAR(x140421011443079);
+Obj x140421011443143 = PRIM_CDR(x140421011443111);
+Obj x140421011443175 = PRIM_CDR(x140421011443143);
+Obj x140421011443207 = PRIM_ISCONS(x140421011443175);
+if (True == x140421011443207) {
+Obj x140421011443623 = PRIM_CDR(x140421013563079);
+Obj x140421011443655 = PRIM_CAR(x140421011443623);
+Obj x140421011443687 = PRIM_CDR(x140421011443655);
+Obj x140421011365895 = PRIM_CDR(x140421011443687);
+Obj x140421011365927 = PRIM_CAR(x140421011365895);
+Obj body = x140421011365927;
+Obj x140421011366407 = PRIM_CDR(x140421013563079);
+Obj x140421011366439 = PRIM_CAR(x140421011366407);
+Obj x140421011366471 = PRIM_CDR(x140421011366439);
+Obj x140421011366503 = PRIM_CDR(x140421011366471);
+Obj x140421011366535 = PRIM_CDR(x140421011366503);
+Obj x140421011366567 = PRIM_EQ(Nil, x140421011366535);
+if (True == x140421011366567) {
+Obj x140421011366791 = PRIM_CDR(x140421013563079);
+Obj x140421011366823 = PRIM_CDR(x140421011366791);
+Obj fvs = x140421011366823;
+Obj x140421013680935 = makeNative(20, clofun6, 1, 6, body, x140421013563047, params, clo_45or_45cont, fvs, x140421013563271);
+Obj x140421013683751 = PRIM_EQ(clo_45or_45cont, __symbolTable[77]);
+if (True == x140421013683751) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = x139886475598663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label21:
-{
-Obj x139886475598695 = __arg1;
-Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476185735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886475598695) {
-pushCont(co, 22, clofun6, 1, x139886476185735);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35caar);
-__arg1 = exp;
+__arg0 = x140421013680935;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
+Obj x140421013683911 = PRIM_EQ(clo_45or_45cont, __symbolTable[67]);
+if (True == x140421013683911) {
 __nargs = 2;
-__arg0 = x139886476185735;
-__arg1 = False;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label22:
-{
-Obj x139886475598983 = __arg1;
-Obj x139886476185735= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475599015 = PRIM_EQ(x139886475598983, sym_37builtin);
-if (True == x139886475599015) {
-__nargs = 2;
-__arg0 = x139886476185735;
+__arg0 = x140421013680935;
 __arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8295,8 +7779,152 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = x139886476185735;
+__arg0 = x140421013680935;
 __arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj x140421013681031 = __arg1;
+if (True == x140421013681031) {
+PUSH_CONT_0(co, 21, clofun6);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[66]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = closureRef(co, 5);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label21:
+{
+Obj x140421011367239 = __arg1;
+Obj body1 = x140421011367239;
+pushCont(co, 22, clofun6, 1, body1);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[65]);
+__arg1 = closureRef(co, 1);
+__arg2 = MAKE_NUMBER(0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label22:
+{
+Obj x140421011367431 = __arg1;
+Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cur = x140421011367431;
+Obj x140421011367623 = PRIM_EQ(closureRef(co, 3), __symbolTable[77]);
+if (True == x140421011367623) {
+Obj x140421011368103 = makeCons(body1, Nil);
+Obj x140421011368135 = makeCons(Nil, x140421011368103);
+Obj x140421011368167 = makeCons(closureRef(co, 2), x140421011368135);
+Obj x140421011368199 = makeCons(__symbolTable[94], x140421011368167);
+pushCont(co, 24, clofun6, 1, cur);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[64]);
+__arg1 = closureRef(co, 1);
+__arg2 = x140421011368199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140421013682311 = makeCons(body1, Nil);
+Obj x140421013682343 = makeCons(closureRef(co, 4), x140421013682311);
+Obj x140421013682407 = makeCons(closureRef(co, 2), x140421013682343);
+Obj x140421013682471 = makeCons(__symbolTable[94], x140421013682407);
+pushCont(co, 23, clofun6, 1, cur);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[64]);
+__arg1 = closureRef(co, 1);
+__arg2 = x140421013682471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8307,10 +7935,700 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj x139886476185767 = __arg1;
-if (True == x139886476185767) {
+Obj x140421013682503 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013682983 = makeCons(cur, closureRef(co, 4));
+Obj x140421013683015 = makeCons(closureRef(co, 3), x140421013682983);
+__nargs = 2;
+__arg1 = x140421013683015;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label24:
+{
+Obj x140421011368231 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 25, clofun6, 1, cur);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label25:
+{
+Obj x140421011368583 = __arg1;
+Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011368647 = makeCons(x140421011368583, closureRef(co, 4));
+Obj x140421011368679 = makeCons(cur, x140421011368647);
+Obj x140421011368711 = makeCons(closureRef(co, 3), x140421011368679);
+__nargs = 2;
+__arg1 = x140421011368711;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label26:
+{
+Obj x140421011440103 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421011440103) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = makeNative(27, clofun6, 1, 1, closureRef(co, 0));
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = closureRef(co, 1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label27:
+{
+Obj e = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[66]);
+__arg1 = closureRef(co, 0);
+__arg2 = e;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label28:
+{
+Obj x140421013624935 = __arg1;
+Obj x140421013624967 = __arg2;
+pushCont(co, 29, clofun6, 2, x140421013624967, x140421013624935);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[84]);
+__arg1 = x140421013624967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label29:
+{
+Obj x140421011691367 = __arg1;
+Obj x140421013624967= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013624935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421011691367) {
+__nargs = 2;
+__arg1 = x140421013624967;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421011691591 = primIsSymbol(x140421013624967);
+if (True == x140421011691591) {
+__nargs = 2;
+__arg1 = x140421013624967;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013625767 = makeNative(31, clofun6, 0, 2, x140421013624967, x140421013624935);
+Obj x140421011498375 = PRIM_ISCONS(x140421013624967);
+if (True == x140421011498375) {
+Obj x140421011498599 = PRIM_CAR(x140421013624967);
+Obj x140421011498631 = PRIM_EQ(__symbolTable[94], x140421011498599);
+if (True == x140421011498631) {
+Obj x140421011498855 = PRIM_CDR(x140421013624967);
+Obj x140421011498887 = PRIM_ISCONS(x140421011498855);
+if (True == x140421011498887) {
+Obj x140421011499111 = PRIM_CDR(x140421013624967);
+Obj x140421011499143 = PRIM_CAR(x140421011499111);
+Obj args = x140421011499143;
+Obj x140421011499431 = PRIM_CDR(x140421013624967);
+Obj x140421011499463 = PRIM_CDR(x140421011499431);
+Obj x140421011499495 = PRIM_ISCONS(x140421011499463);
+if (True == x140421011499495) {
+Obj x140421011499783 = PRIM_CDR(x140421013624967);
+Obj x140421011499815 = PRIM_CDR(x140421011499783);
+Obj x140421011499847 = PRIM_CAR(x140421011499815);
+Obj body = x140421011499847;
+Obj x140421011500199 = PRIM_CDR(x140421013624967);
+Obj x140421011500231 = PRIM_CDR(x140421011500199);
+Obj x140421011500263 = PRIM_CDR(x140421011500231);
+Obj x140421011500295 = PRIM_EQ(Nil, x140421011500263);
+if (True == x140421011500295) {
+pushCont(co, 30, clofun6, 1, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = x140421013624935;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013625767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label30:
+{
+Obj x140421011500583 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011500615 = makeCons(x140421011500583, Nil);
+Obj x140421011500647 = makeCons(args, x140421011500615);
+Obj x140421011500679 = makeCons(__symbolTable[94], x140421011500647);
+__nargs = 2;
+__arg1 = x140421011500679;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label31:
+{
+Obj x140421013626439 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421011632039 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011632039) {
+Obj x140421011562759 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011562791 = PRIM_EQ(__symbolTable[81], x140421011562759);
+if (True == x140421011562791) {
+Obj x140421011563047 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011563079 = PRIM_ISCONS(x140421011563047);
+if (True == x140421011563079) {
+Obj x140421011563463 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011563591 = PRIM_CAR(x140421011563463);
+Obj val = x140421011563591;
+Obj x140421011563911 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011563943 = PRIM_CDR(x140421011563911);
+Obj x140421011563975 = PRIM_ISCONS(x140421011563943);
+if (True == x140421011563975) {
+Obj x140421011564391 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011564423 = PRIM_CDR(x140421011564391);
+Obj x140421011564455 = PRIM_CAR(x140421011564423);
+Obj body = x140421011564455;
+Obj x140421011564967 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011564999 = PRIM_CDR(x140421011564967);
+Obj x140421011565031 = PRIM_CDR(x140421011564999);
+Obj x140421011566407 = PRIM_EQ(Nil, x140421011565031);
+if (True == x140421011566407) {
+pushCont(co, 32, clofun6, 2, body, val);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label32:
+{
+Obj x140421011496999 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 33, clofun6, 2, body, val);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = x140421011496999;
+__arg2 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label33:
+{
+Obj x140421011497031 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fvs1 = x140421011497031;
+pushCont(co, 34, clofun6, 3, fvs1, body, val);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label34:
+{
+Obj x140421011497287 = __arg1;
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+pushCont(co, 35, clofun6, 3, fvs1, body, val);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421011497287;
+__arg2 = fvs1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label35:
+{
+Obj x140421011497319 = __arg1;
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj fvs2 = x140421011497319;
+pushCont(co, 36, clofun6, 2, val, fvs2);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = fvs1;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x140421011497735 = __arg1;
+Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011497767 = makeCons(x140421011497735, Nil);
+Obj x140421011497799 = makeCons(val, x140421011497767);
+Obj x140421011497831 = makeCons(__symbolTable[94], x140421011497799);
+Obj x140421011497863 = makeCons(x140421011497831, fvs2);
+Obj x140421011497895 = makeCons(__symbolTable[67], x140421011497863);
+__nargs = 2;
+__arg1 = x140421011497895;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label37:
+{
+Obj x140421013561767 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421011693511 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011693511) {
+Obj x140421011628359 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011628391 = PRIM_EQ(__symbolTable[79], x140421011628359);
+if (True == x140421011628391) {
+Obj x140421011628679 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011628711 = PRIM_ISCONS(x140421011628679);
+if (True == x140421011628711) {
+Obj x140421011628999 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011629031 = PRIM_CAR(x140421011628999);
+Obj exp = x140421011629031;
+Obj x140421011629415 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011629447 = PRIM_CDR(x140421011629415);
+Obj x140421011629479 = PRIM_ISCONS(x140421011629447);
+if (True == x140421011629479) {
+Obj x140421011629927 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011629959 = PRIM_CDR(x140421011629927);
+Obj x140421011629991 = PRIM_CAR(x140421011629959);
+Obj cont = x140421011629991;
+Obj x140421011630471 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011630503 = PRIM_CDR(x140421011630471);
+Obj x140421011630535 = PRIM_CDR(x140421011630503);
+Obj x140421011630567 = PRIM_EQ(Nil, x140421011630535);
+if (True == x140421011630567) {
+pushCont(co, 38, clofun6, 2, exp, cont);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013561767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013561767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013561767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013561767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013561767;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label38:
+{
+Obj x140421011630919 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 39, clofun6, 1, cont);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421011630919;
+__arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label39:
+{
+Obj x140421011630951 = __arg1;
+Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 40, clofun6, 1, x140421011630951);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = closureRef(co, 1);
+__arg2 = cont;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x140421011631207 = __arg1;
+Obj x140421011630951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011631239 = makeCons(x140421011631207, Nil);
+Obj x140421011631335 = makeCons(x140421011630951, x140421011631239);
+Obj x140421011631367 = makeCons(__symbolTable[79], x140421011631335);
+__nargs = 2;
+__arg1 = x140421011631367;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label41:
+{
+Obj x140421011692327 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011692327) {
+Obj x140421011692519 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140421011692519;
+Obj x140421011692775 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421011692775;
+pushCont(co, 42, clofun6, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[68]);
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label42:
+{
+Obj x140421011693063 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011693159 = makeCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421011693063;
+__arg2 = x140421011693159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x140421013623591 = __arg1;
+Obj x140421013623623 = __arg2;
+Obj x140421013623655 = __arg3;
+Obj x140421011727495 = PRIM_EQ(Nil, x140421013623591);
+if (True == x140421011727495) {
+pushCont(co, 45, clofun6, 1, x140421013623655);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[72]);
+__arg1 = x140421013623623;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140421011690119 = PRIM_ISCONS(x140421013623591);
+if (True == x140421011690119) {
+Obj x140421011690279 = PRIM_CAR(x140421013623591);
+Obj hd = x140421011690279;
+Obj x140421011690439 = PRIM_CDR(x140421013623591);
+Obj tl = x140421011690439;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = hd;
+__arg2 = makeNative(44, clofun6, 1, 3, tl, x140421013623623, x140421013623655);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label44:
+{
+Obj hd1 = __arg1;
+Obj x140421011690791 = makeCons(hd1, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[73]);
+__arg1 = closureRef(co, 0);
+__arg2 = x140421011690791;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label45:
+{
+Obj x140421011727751 = __arg1;
+Obj x140421013623655= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj exp = x140421011727751;
+Obj x140421013680647 = makeNative(48, clofun6, 1, 2, exp, x140421013623655);
+Obj x140421011689671 = PRIM_CAR(exp);
+pushCont(co, 46, clofun6, 2, exp, x140421013680647);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[70]);
+__arg1 = x140421011689671;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label46:
+{
+Obj x140421011689703 = __arg1;
+Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013680647= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421011689703) {
+pushCont(co, 47, clofun6, 1, x140421013680647);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[69]);
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x140421013680647;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label47:
+{
+Obj x140421011689927 = __arg1;
+Obj x140421013680647= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011689959 = PRIM_EQ(x140421011689927, __symbolTable[95]);
+if (True == x140421011689959) {
+__nargs = 2;
+__arg0 = x140421013680647;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x140421013680647;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label48:
+{
+Obj x140421013680679 = __arg1;
+if (True == x140421013680679) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[71]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -8319,20 +8637,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj x139886475596935 = PRIM_EQ(closureRef(co, 1), globalRef(symcora_47lib_47toc_35id));
-if (True == x139886475596935) {
-Obj x139886475597127 = makeCons(closureRef(co, 0), Nil);
-Obj x139886475597159 = makeCons(symtailcall, x139886475597127);
+Obj x140421011728359 = PRIM_EQ(closureRef(co, 1), globalRef(__symbolTable[75]));
+if (True == x140421011728359) {
+Obj x140421011728615 = makeCons(closureRef(co, 0), Nil);
+Obj x140421011728647 = makeCons(__symbolTable[80], x140421011728615);
 __nargs = 2;
-__arg1 = x139886475597159;
+__arg1 = x140421011728647;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886475597319 = primGenSym();
-Obj val = x139886475597319;
-Obj x139886475597927 = makeCons(val, Nil);
-pushCont(co, 24, clofun6, 1, x139886475597927);
+Obj x140421011729287 = primGenSym();
+Obj val = x140421011729287;
+Obj x140421011729863 = makeCons(val, Nil);
+pushCont(co, 49, clofun6, 1, x140421011729863);
 __nargs = 2;
 __arg0 = closureRef(co, 1);
 __arg1 = val;
@@ -8345,1031 +8663,21 @@ goto *jumpTable[ps.label];
 }
 }
 
-label24:
-{
-Obj x139886475598119 = __arg1;
-Obj x139886475597927= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475598151 = makeCons(x139886475598119, Nil);
-Obj x139886475598183 = makeCons(x139886475597927, x139886475598151);
-Obj x139886475598247 = makeCons(symcontinuation, x139886475598183);
-Obj x139886475598279 = makeCons(x139886475598247, Nil);
-Obj x139886475598311 = makeCons(closureRef(co, 0), x139886475598279);
-Obj x139886475598343 = makeCons(symcall, x139886475598311);
-__nargs = 2;
-__arg1 = x139886475598343;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label25:
-{
-Obj x139886475463463 = __arg1;
-Obj x139886475463527 = __arg2;
-Obj x139886476185607 = makeNative(27, clofun6, 1, 2, x139886475463463, x139886475463527);
-Obj x139886475984359 = primIsSymbol(x139886475463463);
-if (True == x139886475984359) {
-__nargs = 2;
-__arg0 = x139886476185607;
-__arg1 = True;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 26, clofun6, 1, x139886476185607);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x139886475463463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label26:
-{
-Obj x139886475984615 = __arg1;
-Obj x139886476185607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886475984615) {
-__nargs = 2;
-__arg0 = x139886476185607;
-__arg1 = True;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = x139886476185607;
-__arg1 = False;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label27:
-{
-Obj x139886476185703 = __arg1;
-if (True == x139886476185703) {
-__nargs = 2;
-__arg0 = closureRef(co, 1);
-__arg1 = closureRef(co, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-PUSH_CONT_0(co, 28, clofun6);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = closureRef(co, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label28:
-{
-Obj x139886474553287 = __arg1;
-if (True == x139886474553287) {
-__nargs = 2;
-__arg1 = closureRef(co, 0);
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886476145799 = makeNative(32, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886476079879 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476079879) {
-Obj x139886476080359 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476080391 = PRIM_EQ(symif, x139886476080359);
-if (True == x139886476080391) {
-Obj x139886476080743 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476080775 = PRIM_ISCONS(x139886476080743);
-if (True == x139886476080775) {
-Obj x139886476081191 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476081223 = PRIM_CAR(x139886476081191);
-Obj a = x139886476081223;
-Obj x139886476081671 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476081703 = PRIM_CDR(x139886476081671);
-Obj x139886476081735 = PRIM_ISCONS(x139886476081703);
-if (True == x139886476081735) {
-Obj x139886476082247 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476082503 = PRIM_CDR(x139886476082247);
-Obj x139886476082535 = PRIM_CAR(x139886476082503);
-Obj b = x139886476082535;
-Obj x139886476082951 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476082983 = PRIM_CDR(x139886476082951);
-Obj x139886476083047 = PRIM_CDR(x139886476082983);
-Obj x139886476083079 = PRIM_ISCONS(x139886476083047);
-if (True == x139886476083079) {
-Obj x139886475981159 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475981255 = PRIM_CDR(x139886475981159);
-Obj x139886475981287 = PRIM_CDR(x139886475981255);
-Obj x139886475981319 = PRIM_CAR(x139886475981287);
-Obj c = x139886475981319;
-Obj x139886475981991 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475982023 = PRIM_CDR(x139886475981991);
-Obj x139886475982055 = PRIM_CDR(x139886475982023);
-Obj x139886475982087 = PRIM_CDR(x139886475982055);
-Obj x139886475982119 = PRIM_EQ(Nil, x139886475982087);
-if (True == x139886475982119) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = a;
-__arg2 = makeNative(29, clofun6, 1, 3, b, c, closureRef(co, 1));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label29:
-{
-Obj ra = __arg1;
-pushCont(co, 30, clofun6, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label30:
-{
-Obj x139886475982727 = __arg1;
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 31, clofun6, 2, x139886475982727, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label31:
-{
-Obj x139886475983207 = __arg1;
-Obj x139886475982727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475983239 = makeCons(x139886475983207, Nil);
-Obj x139886475983303 = makeCons(x139886475982727, x139886475983239);
-Obj x139886475983367 = makeCons(ra, x139886475983303);
-Obj x139886475983399 = makeCons(symif, x139886475983367);
-__nargs = 2;
-__arg1 = x139886475983399;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label32:
-{
-Obj x139886476081063 = makeNative(35, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886476147847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476147847) {
-Obj x139886476148359 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476148391 = PRIM_EQ(symdo, x139886476148359);
-if (True == x139886476148391) {
-Obj x139886476103719 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476103751 = PRIM_ISCONS(x139886476103719);
-if (True == x139886476103751) {
-Obj x139886476104455 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476104935 = PRIM_CAR(x139886476104455);
-Obj a = x139886476104935;
-Obj x139886476105383 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476105415 = PRIM_CDR(x139886476105383);
-Obj x139886476105447 = PRIM_ISCONS(x139886476105415);
-if (True == x139886476105447) {
-Obj x139886476105863 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476105895 = PRIM_CDR(x139886476105863);
-Obj x139886476105927 = PRIM_CAR(x139886476105895);
-Obj b = x139886476105927;
-Obj x139886476106471 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476106503 = PRIM_CDR(x139886476106471);
-Obj x139886476106535 = PRIM_CDR(x139886476106503);
-Obj x139886476106567 = PRIM_EQ(Nil, x139886476106535);
-if (True == x139886476106567) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = a;
-__arg2 = makeNative(33, clofun6, 1, 2, b, closureRef(co, 1));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476081063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476081063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label33:
-{
-Obj ra = __arg1;
-Obj x139886476107079 = primIsSymbol(ra);
-if (True == x139886476107079) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 34, clofun6, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label34:
-{
-Obj x139886476107687 = __arg1;
-Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476107719 = makeCons(x139886476107687, Nil);
-Obj x139886476107751 = makeCons(ra, x139886476107719);
-Obj x139886476079111 = makeCons(symdo, x139886476107751);
-__nargs = 2;
-__arg1 = x139886476079111;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label35:
-{
-Obj x139886475984039 = makeNative(38, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886474257767 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474257767) {
-Obj x139886474258023 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474258055 = PRIM_EQ(symlet, x139886474258023);
-if (True == x139886474258055) {
-Obj x139886476186439 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476186471 = PRIM_ISCONS(x139886476186439);
-if (True == x139886476186471) {
-Obj x139886476187239 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476187303 = PRIM_CAR(x139886476187239);
-Obj a = x139886476187303;
-Obj x139886476188039 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476188071 = PRIM_CDR(x139886476188039);
-Obj x139886476188103 = PRIM_ISCONS(x139886476188071);
-if (True == x139886476188103) {
-Obj x139886476188679 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476188711 = PRIM_CDR(x139886476188679);
-Obj x139886476188743 = PRIM_CAR(x139886476188711);
-Obj b = x139886476188743;
-Obj x139886476189383 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476189415 = PRIM_CDR(x139886476189383);
-Obj x139886476189447 = PRIM_CDR(x139886476189415);
-Obj x139886476189479 = PRIM_ISCONS(x139886476189447);
-if (True == x139886476189479) {
-Obj x139886476145063 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476145095 = PRIM_CDR(x139886476145063);
-Obj x139886476145127 = PRIM_CDR(x139886476145095);
-Obj x139886476145159 = PRIM_CAR(x139886476145127);
-Obj c = x139886476145159;
-Obj x139886476145831 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476145863 = PRIM_CDR(x139886476145831);
-Obj x139886476145927 = PRIM_CDR(x139886476145863);
-Obj x139886476145959 = PRIM_CDR(x139886476145927);
-Obj x139886476145991 = PRIM_EQ(Nil, x139886476145959);
-if (True == x139886476145991) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = b;
-__arg2 = makeNative(36, clofun6, 1, 3, a, c, closureRef(co, 1));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475984039;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label36:
-{
-Obj rb = __arg1;
-pushCont(co, 37, clofun6, 1, rb);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label37:
-{
-Obj x139886476146791 = __arg1;
-Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476146823 = makeCons(x139886476146791, Nil);
-Obj x139886476146855 = makeCons(rb, x139886476146823);
-Obj x139886476146887 = makeCons(closureRef(co, 0), x139886476146855);
-Obj x139886476146919 = makeCons(symlet, x139886476146887);
-__nargs = 2;
-__arg1 = x139886476146919;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label38:
-{
-Obj x139886475469287 = makeNative(40, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886474554855 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474554855) {
-Obj x139886474555111 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474555143 = PRIM_EQ(sym_37closure, x139886474555111);
-if (True == x139886474555143) {
-Obj x139886474305543 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474305575 = PRIM_ISCONS(x139886474305543);
-if (True == x139886474305575) {
-Obj x139886474305895 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474305927 = PRIM_CAR(x139886474305895);
-Obj x139886474305959 = PRIM_ISCONS(x139886474305927);
-if (True == x139886474305959) {
-Obj x139886474306343 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474306375 = PRIM_CAR(x139886474306343);
-Obj x139886474306407 = PRIM_CAR(x139886474306375);
-Obj x139886474306439 = PRIM_EQ(symlambda, x139886474306407);
-if (True == x139886474306439) {
-Obj x139886474306823 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474306855 = PRIM_CAR(x139886474306823);
-Obj x139886474306887 = PRIM_CDR(x139886474306855);
-Obj x139886474306919 = PRIM_ISCONS(x139886474306887);
-if (True == x139886474306919) {
-Obj x139886474307303 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474307335 = PRIM_CAR(x139886474307303);
-Obj x139886474307367 = PRIM_CDR(x139886474307335);
-Obj x139886474307399 = PRIM_CAR(x139886474307367);
-Obj args = x139886474307399;
-Obj x139886474307847 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474307879 = PRIM_CAR(x139886474307847);
-Obj x139886474307911 = PRIM_CDR(x139886474307879);
-Obj x139886474307943 = PRIM_CDR(x139886474307911);
-Obj x139886474307975 = PRIM_ISCONS(x139886474307943);
-if (True == x139886474307975) {
-Obj x139886474308551 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474308583 = PRIM_CAR(x139886474308551);
-Obj x139886474308615 = PRIM_CDR(x139886474308583);
-Obj x139886474308647 = PRIM_CDR(x139886474308615);
-Obj x139886474308679 = PRIM_CAR(x139886474308647);
-Obj body = x139886474308679;
-Obj x139886474309191 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474309223 = PRIM_CAR(x139886474309191);
-Obj x139886474309255 = PRIM_CDR(x139886474309223);
-Obj x139886474309287 = PRIM_CDR(x139886474309255);
-Obj x139886474309319 = PRIM_CDR(x139886474309287);
-Obj x139886474309351 = PRIM_EQ(Nil, x139886474309319);
-if (True == x139886474309351) {
-Obj x139886474309607 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474256391 = PRIM_CDR(x139886474309607);
-Obj frees = x139886474256391;
-pushCont(co, 39, clofun6, 2, args, frees);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify);
-__arg1 = body;
-__arg2 = globalRef(symcora_47lib_47toc_35id);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469287;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label39:
-{
-Obj x139886474256903 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886474256935 = makeCons(x139886474256903, Nil);
-Obj x139886474256967 = makeCons(args, x139886474256935);
-Obj x139886474256999 = makeCons(symlambda, x139886474256967);
-Obj x139886474257031 = makeCons(x139886474256999, frees);
-Obj x139886474257063 = makeCons(sym_37closure, x139886474257031);
-__nargs = 2;
-__arg0 = closureRef(co, 1);
-__arg1 = x139886474257063;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label40:
-{
-Obj x139886474554023 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474554023) {
-Obj x139886474554215 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139886474554215;
-Obj x139886474554407 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886474554407;
-Obj x139886474554567 = makeCons(f, args);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = x139886474554567;
-__arg2 = Nil;
-__arg3 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label41:
-{
-Obj x = __arg1;
-Obj x139886474552519 = makeCons(x, Nil);
-Obj x139886474552551 = makeCons(symreturn, x139886474552519);
-__nargs = 2;
-__arg1 = x139886474552551;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label42:
-{
-Obj x139886476187751 = __arg1;
-Obj x139886476187815 = __arg2;
-pushCont(co, 43, clofun6, 2, x139886476187815, x139886476187751);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x139886476187815;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label43:
-{
-Obj x139886474652039 = __arg1;
-Obj x139886476187815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886474652039) {
-__nargs = 2;
-__arg1 = x139886476187815;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886474652199 = primIsSymbol(x139886476187815);
-if (True == x139886474652199) {
-pushCont(co, 3, clofun7, 1, x139886476187815);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35index);
-__arg1 = x139886476187815;
-__arg2 = x139886476187751;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139886476079943 = makeNative(48, clofun6, 0, 2, x139886476187815, x139886476187751);
-Obj x139886474581447 = PRIM_ISCONS(x139886476187815);
-if (True == x139886474581447) {
-Obj x139886474581671 = PRIM_CAR(x139886476187815);
-Obj x139886474581703 = PRIM_EQ(symlambda, x139886474581671);
-if (True == x139886474581703) {
-Obj x139886474581927 = PRIM_CDR(x139886476187815);
-Obj x139886474581959 = PRIM_ISCONS(x139886474581927);
-if (True == x139886474581959) {
-Obj x139886474582183 = PRIM_CDR(x139886476187815);
-Obj x139886474582215 = PRIM_CAR(x139886474582183);
-Obj args = x139886474582215;
-Obj x139886474582503 = PRIM_CDR(x139886476187815);
-Obj x139886474582535 = PRIM_CDR(x139886474582503);
-Obj x139886474582567 = PRIM_ISCONS(x139886474582535);
-if (True == x139886474582567) {
-Obj x139886474582855 = PRIM_CDR(x139886476187815);
-Obj x139886474582887 = PRIM_CDR(x139886474582855);
-Obj x139886474582919 = PRIM_CAR(x139886474582887);
-Obj body = x139886474582919;
-Obj x139886474583271 = PRIM_CDR(x139886476187815);
-Obj x139886474583303 = PRIM_CDR(x139886474583271);
-Obj x139886474583335 = PRIM_CDR(x139886474583303);
-Obj x139886474583367 = PRIM_EQ(Nil, x139886474583335);
-if (True == x139886474583367) {
-Obj x139886474583719 = makeCons(body, Nil);
-Obj x139886474583751 = makeCons(args, x139886474583719);
-Obj x139886474583783 = makeCons(symlambda, x139886474583751);
-pushCont(co, 44, clofun6, 3, body, args, x139886476187751);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139886474583783;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476079943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-
-label44:
-{
-Obj x139886474583815 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = x139886474583815;
-pushCont(co, 45, clofun6, 3, args, x139886476187751, fvs1);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = fvs1;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label45:
-{
-Obj x139886474551463 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476187751= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj x139886474551495 = makeCons(x139886474551463, Nil);
-Obj x139886474551527 = makeCons(args, x139886474551495);
-Obj x139886474551559 = makeCons(symlambda, x139886474551527);
-pushCont(co, 46, clofun6, 2, fvs1, x139886474551559);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = x139886476187751;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label46:
-{
-Obj x139886474551719 = __arg1;
-Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886474551559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 47, clofun6, 1, x139886474551559);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886474551719;
-__arg2 = fvs1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label47:
-{
-Obj x139886474551751 = __arg1;
-Obj x139886474551559= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886474551783 = makeCons(x139886474551559, x139886474551751);
-Obj x139886474551815 = makeCons(sym_37closure, x139886474551783);
-__nargs = 2;
-__arg1 = x139886474551815;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun6) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label48:
-{
-Obj x139886475983335 = makeNative(1, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x139886474642631 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474642631) {
-Obj x139886474642887 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474642919 = PRIM_EQ(symlet, x139886474642887);
-if (True == x139886474642919) {
-Obj x139886474643175 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474643207 = PRIM_ISCONS(x139886474643175);
-if (True == x139886474643207) {
-Obj x139886474643463 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474643495 = PRIM_CAR(x139886474643463);
-Obj a = x139886474643495;
-Obj x139886474643815 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474643847 = PRIM_CDR(x139886474643815);
-Obj x139886474643879 = PRIM_ISCONS(x139886474643847);
-if (True == x139886474643879) {
-Obj x139886474644199 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474644231 = PRIM_CDR(x139886474644199);
-Obj x139886474644263 = PRIM_CAR(x139886474644231);
-Obj b = x139886474644263;
-Obj x139886474644647 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474644679 = PRIM_CDR(x139886474644647);
-Obj x139886474644711 = PRIM_CDR(x139886474644679);
-Obj x139886474644743 = PRIM_ISCONS(x139886474644711);
-if (True == x139886474644743) {
-Obj x139886474645127 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474645159 = PRIM_CDR(x139886474645127);
-Obj x139886474645191 = PRIM_CDR(x139886474645159);
-Obj x139886474645223 = PRIM_CAR(x139886474645191);
-Obj c = x139886474645223;
-Obj x139886474580135 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474580167 = PRIM_CDR(x139886474580135);
-Obj x139886474580199 = PRIM_CDR(x139886474580167);
-Obj x139886474580231 = PRIM_CDR(x139886474580199);
-Obj x139886474580263 = PRIM_EQ(Nil, x139886474580231);
-if (True == x139886474580263) {
-pushCont(co, 49, clofun6, 2, c, a);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = closureRef(co, 1);
-__arg2 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
 label49:
 {
-Obj x139886474580583 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 0, clofun7, 2, x139886474580583, a);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = closureRef(co, 1);
-__arg2 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421011730055 = __arg1;
+Obj x140421011729863= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421011730087 = makeCons(x140421011730055, Nil);
+Obj x140421011730119 = makeCons(x140421011729863, x140421011730087);
+Obj x140421011730151 = makeCons(__symbolTable[81], x140421011730119);
+Obj x140421011730215 = makeCons(x140421011730151, Nil);
+Obj x140421011730247 = makeCons(closureRef(co, 0), x140421011730215);
+Obj x140421011730279 = makeCons(__symbolTable[79], x140421011730247);
+__nargs = 2;
+__arg1 = x140421011730279;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:
@@ -9394,32 +8702,40 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886474580775 = __arg1;
-Obj x139886474580583= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886474580807 = makeCons(x139886474580775, Nil);
-Obj x139886474580839 = makeCons(x139886474580583, x139886474580807);
-Obj x139886474580871 = makeCons(a, x139886474580839);
-Obj x139886474580903 = makeCons(symlet, x139886474580871);
+Obj x140421013680199 = __arg1;
+Obj x140421013680263 = __arg2;
+Obj x140421013680487 = makeNative(2, clofun7, 1, 2, x140421013680199, x140421013680263);
+Obj x140421011726823 = primIsSymbol(x140421013680199);
+if (True == x140421011726823) {
 __nargs = 2;
-__arg1 = x139886474580903;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = x140421013680487;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 1, clofun7, 1, x140421013680487);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[84]);
+__arg1 = x140421013680199;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj x139886474641703 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474641703) {
-Obj x139886474641895 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139886474641895;
-Obj x139886474642087 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886474642087;
-pushCont(co, 2, clofun7, 2, f, args);
+Obj x140421011727047 = __arg1;
+Obj x140421013680487= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421011727047) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
-__arg1 = closureRef(co, 1);
+__arg0 = x140421013680487;
+__arg1 = True;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9427,8 +8743,8 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg0 = x140421013680487;
+__arg1 = False;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9439,51 +8755,149 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139886474642279 = __arg1;
-Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886474642375 = makeCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886474642279;
-__arg2 = x139886474642375;
+Obj x140421013680519 = __arg1;
+if (True == x140421013680519) {
+__nargs = 2;
+__arg0 = closureRef(co, 1);
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+PUSH_CONT_0(co, 3, clofun7);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[84]);
+__arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
 label3:
 {
-Obj x139886474652359 = __arg1;
-Obj x139886476187815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pos = x139886474652359;
-Obj x139886474653351 = PRIM_EQ(MAKE_NUMBER(-1), pos);
-if (True == x139886474653351) {
+Obj x140421012516519 = __arg1;
+if (True == x140421012516519) {
 __nargs = 2;
-__arg1 = x139886476187815;
+__arg1 = closureRef(co, 0);
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886474653511 = makeCons(pos, Nil);
-Obj x139886474653543 = makeCons(sym_37closure_45ref, x139886474653511);
-__nargs = 2;
-__arg1 = x139886474653543;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013681159 = makeNative(7, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421012040743 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012040743) {
+Obj x140421012041063 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012041095 = PRIM_EQ(__symbolTable[92], x140421012041063);
+if (True == x140421012041095) {
+Obj x140421012041415 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012041447 = PRIM_ISCONS(x140421012041415);
+if (True == x140421012041447) {
+Obj x140421011767367 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011767399 = PRIM_CAR(x140421011767367);
+Obj a = x140421011767399;
+Obj x140421011767751 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011767783 = PRIM_CDR(x140421011767751);
+Obj x140421011767815 = PRIM_ISCONS(x140421011767783);
+if (True == x140421011767815) {
+Obj x140421011768263 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011768295 = PRIM_CDR(x140421011768263);
+Obj x140421011768327 = PRIM_CAR(x140421011768295);
+Obj b = x140421011768327;
+Obj x140421011768775 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011768903 = PRIM_CDR(x140421011768775);
+Obj x140421011768935 = PRIM_CDR(x140421011768903);
+Obj x140421011768967 = PRIM_ISCONS(x140421011768935);
+if (True == x140421011768967) {
+Obj x140421011769383 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011769415 = PRIM_CDR(x140421011769383);
+Obj x140421011769447 = PRIM_CDR(x140421011769415);
+Obj x140421011769479 = PRIM_CAR(x140421011769447);
+Obj c = x140421011769479;
+Obj x140421011770023 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011770055 = PRIM_CDR(x140421011770023);
+Obj x140421011770087 = PRIM_CDR(x140421011770055);
+Obj x140421011770119 = PRIM_CDR(x140421011770087);
+Obj x140421011770151 = PRIM_EQ(Nil, x140421011770119);
+if (True == x140421011770151) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = a;
+__arg2 = makeNative(4, clofun7, 1, 3, b, c, closureRef(co, 1));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681159;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 
 label4:
 {
-Obj x139886475383815 = __arg1;
-pushCont(co, 5, clofun7, 1, x139886475383815);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
-__arg1 = x139886475383815;
+Obj ra = __arg1;
+pushCont(co, 5, clofun7, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9493,168 +8907,67 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj x139886475461735 = __arg1;
-Obj x139886475383815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886475461735) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475461895 = primIsSymbol(x139886475383815);
-if (True == x139886475461895) {
-Obj x139886475461991 = makeCons(x139886475383815, Nil);
-__nargs = 2;
-__arg1 = x139886475461991;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475330055 = makeNative(7, clofun7, 0, 1, x139886475383815);
-Obj x139886475127719 = PRIM_ISCONS(x139886475383815);
-if (True == x139886475127719) {
-Obj x139886475128007 = PRIM_CAR(x139886475383815);
-Obj x139886475128039 = PRIM_EQ(symlambda, x139886475128007);
-if (True == x139886475128039) {
-Obj x139886475128359 = PRIM_CDR(x139886475383815);
-Obj x139886475128391 = PRIM_ISCONS(x139886475128359);
-if (True == x139886475128391) {
-Obj x139886475128615 = PRIM_CDR(x139886475383815);
-Obj x139886475128775 = PRIM_CAR(x139886475128615);
-Obj args = x139886475128775;
-Obj x139886474649927 = PRIM_CDR(x139886475383815);
-Obj x139886474649959 = PRIM_CDR(x139886474649927);
-Obj x139886474649991 = PRIM_ISCONS(x139886474649959);
-if (True == x139886474649991) {
-Obj x139886474650375 = PRIM_CDR(x139886475383815);
-Obj x139886474650407 = PRIM_CDR(x139886474650375);
-Obj x139886474650471 = PRIM_CAR(x139886474650407);
-Obj body = x139886474650471;
-Obj x139886474650823 = PRIM_CDR(x139886475383815);
-Obj x139886474650855 = PRIM_CDR(x139886474650823);
-Obj x139886474650887 = PRIM_CDR(x139886474650855);
-Obj x139886474650919 = PRIM_EQ(Nil, x139886474650887);
-if (True == x139886474650919) {
-pushCont(co, 6, clofun7, 1, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = body;
+Obj x140421011770727 = __arg1;
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 6, clofun7, 2, x140421011770727, ra);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475330055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475330055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475330055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475330055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475330055;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
 }
 
 label6:
 {
-Obj x139886474651079 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139886474651079;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421011771047 = __arg1;
+Obj x140421011770727= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421011771079 = makeCons(x140421011771047, Nil);
+Obj x140421011771111 = makeCons(x140421011770727, x140421011771079);
+Obj x140421011771143 = makeCons(ra, x140421011771111);
+Obj x140421011771175 = makeCons(__symbolTable[92], x140421011771143);
+__nargs = 2;
+__arg1 = x140421011771175;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label7:
 {
-Obj x139886475333127 = makeNative(9, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475184071 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475184071) {
-Obj x139886475184327 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475184359 = PRIM_EQ(symif, x139886475184327);
-if (True == x139886475184359) {
-Obj x139886475184615 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475184647 = PRIM_ISCONS(x139886475184615);
-if (True == x139886475184647) {
-Obj x139886475184935 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475184967 = PRIM_CAR(x139886475184935);
-Obj x = x139886475184967;
-Obj x139886475185351 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475185383 = PRIM_CDR(x139886475185351);
-Obj x139886475185415 = PRIM_ISCONS(x139886475185383);
-if (True == x139886475185415) {
-Obj x139886475185831 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475185863 = PRIM_CDR(x139886475185831);
-Obj x139886475185895 = PRIM_CAR(x139886475185863);
-Obj y = x139886475185895;
-Obj x139886475124967 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475124999 = PRIM_CDR(x139886475124967);
-Obj x139886475125031 = PRIM_CDR(x139886475124999);
-Obj x139886475125063 = PRIM_ISCONS(x139886475125031);
-if (True == x139886475125063) {
-Obj x139886475125575 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475125671 = PRIM_CDR(x139886475125575);
-Obj x139886475125703 = PRIM_CDR(x139886475125671);
-Obj x139886475125735 = PRIM_CAR(x139886475125703);
-Obj z = x139886475125735;
-Obj x139886475126343 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475126375 = PRIM_CDR(x139886475126343);
-Obj x139886475126407 = PRIM_CDR(x139886475126375);
-Obj x139886475126439 = PRIM_CDR(x139886475126407);
-Obj x139886475126471 = PRIM_EQ(Nil, x139886475126439);
-if (True == x139886475126471) {
-Obj x139886475126855 = makeCons(z, Nil);
-Obj x139886475126951 = makeCons(y, x139886475126855);
-Obj x139886475126983 = makeCons(x, x139886475126951);
-PUSH_CONT_0(co, 8, clofun7);
+Obj x140421013682087 = makeNative(10, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421012077031 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012077031) {
+Obj x140421012077351 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012077383 = PRIM_EQ(__symbolTable[90], x140421012077351);
+if (True == x140421012077383) {
+Obj x140421012077671 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012077703 = PRIM_ISCONS(x140421012077671);
+if (True == x140421012077703) {
+Obj x140421012078279 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012078535 = PRIM_CAR(x140421012078279);
+Obj a = x140421012078535;
+Obj x140421012038087 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012038119 = PRIM_CDR(x140421012038087);
+Obj x140421012038151 = PRIM_ISCONS(x140421012038119);
+if (True == x140421012038151) {
+Obj x140421012038567 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012038599 = PRIM_CDR(x140421012038567);
+Obj x140421012038663 = PRIM_CAR(x140421012038599);
+Obj b = x140421012038663;
+Obj x140421012039143 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012039175 = PRIM_CDR(x140421012039143);
+Obj x140421012039207 = PRIM_CDR(x140421012039175);
+Obj x140421012039239 = PRIM_EQ(Nil, x140421012039207);
+if (True == x140421012039239) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139886475126983;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = a;
+__arg2 = makeNative(8, clofun7, 1, 2, b, closureRef(co, 1));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9662,16 +8975,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475333127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475333127;
+__arg0 = x140421013682087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9680,7 +8984,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475333127;
+__arg0 = x140421013682087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9689,7 +8993,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475333127;
+__arg0 = x140421013682087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9698,7 +9002,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475333127;
+__arg0 = x140421013682087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9707,7 +9011,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475333127;
+__arg0 = x140421013682087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9718,265 +9022,328 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886475127015 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139886475127015;
+Obj ra = __arg1;
+Obj x140421012039559 = primIsSymbol(ra);
+if (True == x140421012039559) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+pushCont(co, 9, clofun7, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label9:
 {
-Obj x139886476186663 = makeNative(11, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475192839 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475192839) {
-Obj x139886475193159 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475193191 = PRIM_EQ(symdo, x139886475193159);
-if (True == x139886475193191) {
-Obj x139886475193479 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475193511 = PRIM_ISCONS(x139886475193479);
-if (True == x139886475193511) {
-Obj x139886475193831 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475193863 = PRIM_CAR(x139886475193831);
-Obj x = x139886475193863;
-Obj x139886475194247 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475194279 = PRIM_CDR(x139886475194247);
-Obj x139886475194311 = PRIM_ISCONS(x139886475194279);
-if (True == x139886475194311) {
-Obj x139886475182439 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475182471 = PRIM_CDR(x139886475182439);
-Obj x139886475182503 = PRIM_CAR(x139886475182471);
-Obj y = x139886475182503;
-Obj x139886475182951 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475182983 = PRIM_CDR(x139886475182951);
-Obj x139886475183015 = PRIM_CDR(x139886475182983);
-Obj x139886475183079 = PRIM_EQ(Nil, x139886475183015);
-if (True == x139886475183079) {
-Obj x139886475183399 = makeCons(y, Nil);
-Obj x139886475183431 = makeCons(x, x139886475183399);
-PUSH_CONT_0(co, 10, clofun7);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139886475183431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476186663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476186663;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj x140421012040039 = __arg1;
+Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012040071 = makeCons(x140421012040039, Nil);
+Obj x140421012040103 = makeCons(ra, x140421012040071);
+Obj x140421012040135 = makeCons(__symbolTable[90], x140421012040103);
+__nargs = 2;
+__arg1 = x140421012040135;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label10:
 {
-Obj x139886475183463 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139886475183463;
+Obj x140421013682791 = makeNative(13, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421012096167 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012096167) {
+Obj x140421012096423 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012096455 = PRIM_EQ(__symbolTable[91], x140421012096423);
+if (True == x140421012096455) {
+Obj x140421012096871 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012096903 = PRIM_ISCONS(x140421012096871);
+if (True == x140421012096903) {
+Obj x140421012097159 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012097223 = PRIM_CAR(x140421012097159);
+Obj a = x140421012097223;
+Obj x140421012097607 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012097639 = PRIM_CDR(x140421012097607);
+Obj x140421012097671 = PRIM_ISCONS(x140421012097639);
+if (True == x140421012097671) {
+Obj x140421012098119 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012098151 = PRIM_CDR(x140421012098119);
+Obj x140421012098183 = PRIM_CAR(x140421012098151);
+Obj b = x140421012098183;
+Obj x140421012098695 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012098727 = PRIM_CDR(x140421012098695);
+Obj x140421012098759 = PRIM_CDR(x140421012098727);
+Obj x140421012098855 = PRIM_ISCONS(x140421012098759);
+if (True == x140421012098855) {
+Obj x140421012074663 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012074695 = PRIM_CDR(x140421012074663);
+Obj x140421012074759 = PRIM_CDR(x140421012074695);
+Obj x140421012074791 = PRIM_CAR(x140421012074759);
+Obj c = x140421012074791;
+Obj x140421012075367 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012075399 = PRIM_CDR(x140421012075367);
+Obj x140421012075431 = PRIM_CDR(x140421012075399);
+Obj x140421012075463 = PRIM_CDR(x140421012075431);
+Obj x140421012075495 = PRIM_EQ(Nil, x140421012075463);
+if (True == x140421012075495) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = b;
+__arg2 = makeNative(11, clofun7, 1, 3, a, c, closureRef(co, 1));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label11:
 {
-Obj x139886476146535 = makeNative(15, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475243847 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475243847) {
-Obj x139886475244199 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475244231 = PRIM_EQ(symlet, x139886475244199);
-if (True == x139886475244231) {
-Obj x139886475244583 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475244615 = PRIM_ISCONS(x139886475244583);
-if (True == x139886475244615) {
-Obj x139886475245031 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475245063 = PRIM_CAR(x139886475245031);
-Obj a = x139886475245063;
-Obj x139886475245575 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475245607 = PRIM_CDR(x139886475245575);
-Obj x139886475245639 = PRIM_ISCONS(x139886475245607);
-if (True == x139886475245639) {
-Obj x139886475246055 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475246087 = PRIM_CDR(x139886475246055);
-Obj x139886475246119 = PRIM_CAR(x139886475246087);
-Obj b = x139886475246119;
-Obj x139886475246695 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475246727 = PRIM_CDR(x139886475246695);
-Obj x139886475246759 = PRIM_CDR(x139886475246727);
-Obj x139886475246791 = PRIM_ISCONS(x139886475246759);
-if (True == x139886475246791) {
-Obj x139886475247367 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475247399 = PRIM_CDR(x139886475247367);
-Obj x139886475247431 = PRIM_CDR(x139886475247399);
-Obj x139886475247463 = PRIM_CAR(x139886475247431);
-Obj c = x139886475247463;
-Obj x139886475190759 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475190791 = PRIM_CDR(x139886475190759);
-Obj x139886475190823 = PRIM_CDR(x139886475190791);
-Obj x139886475190855 = PRIM_CDR(x139886475190823);
-Obj x139886475190887 = PRIM_EQ(Nil, x139886475190855);
-if (True == x139886475190887) {
-pushCont(co, 12, clofun7, 2, c, a);
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = b;
+Obj rb = __arg1;
+pushCont(co, 12, clofun7, 1, rb);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476146535;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label12:
 {
-Obj x139886475191143 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 13, clofun7, 2, a, x139886475191143);
+Obj x140421012076167 = __arg1;
+Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012076199 = makeCons(x140421012076167, Nil);
+Obj x140421012076231 = makeCons(rb, x140421012076199);
+Obj x140421012076263 = makeCons(closureRef(co, 0), x140421012076231);
+Obj x140421012076327 = makeCons(__symbolTable[91], x140421012076263);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140421012076327;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj x139886475191975 = __arg1;
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475191143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475192071 = makeCons(a, Nil);
-pushCont(co, 14, clofun7, 1, x139886475191143);
+Obj x140421013683687 = makeNative(15, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421012391591 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012391591) {
+Obj x140421012391879 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012391975 = PRIM_EQ(__symbolTable[77], x140421012391879);
+if (True == x140421012391975) {
+Obj x140421012392263 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012392295 = PRIM_ISCONS(x140421012392263);
+if (True == x140421012392295) {
+Obj x140421012392711 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012392743 = PRIM_CAR(x140421012392711);
+Obj x140421012392775 = PRIM_ISCONS(x140421012392743);
+if (True == x140421012392775) {
+Obj x140421012393255 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012393287 = PRIM_CAR(x140421012393255);
+Obj x140421012393319 = PRIM_CAR(x140421012393287);
+Obj x140421012393415 = PRIM_EQ(__symbolTable[94], x140421012393319);
+if (True == x140421012393415) {
+Obj x140421012393895 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012393927 = PRIM_CAR(x140421012393895);
+Obj x140421012393959 = PRIM_CDR(x140421012393927);
+Obj x140421012119559 = PRIM_ISCONS(x140421012393959);
+if (True == x140421012119559) {
+Obj x140421012120071 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012120103 = PRIM_CAR(x140421012120071);
+Obj x140421012120231 = PRIM_CDR(x140421012120103);
+Obj x140421012120263 = PRIM_CAR(x140421012120231);
+Obj args = x140421012120263;
+Obj x140421012120839 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012120871 = PRIM_CAR(x140421012120839);
+Obj x140421012120903 = PRIM_CDR(x140421012120871);
+Obj x140421012120935 = PRIM_CDR(x140421012120903);
+Obj x140421012120967 = PRIM_ISCONS(x140421012120935);
+if (True == x140421012120967) {
+Obj x140421012121447 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012121479 = PRIM_CAR(x140421012121447);
+Obj x140421012121511 = PRIM_CDR(x140421012121479);
+Obj x140421012121543 = PRIM_CDR(x140421012121511);
+Obj x140421012121735 = PRIM_CAR(x140421012121543);
+Obj body = x140421012121735;
+Obj x140421012122471 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012122503 = PRIM_CAR(x140421012122471);
+Obj x140421012122535 = PRIM_CDR(x140421012122503);
+Obj x140421012122567 = PRIM_CDR(x140421012122535);
+Obj x140421012122599 = PRIM_CDR(x140421012122567);
+Obj x140421012122631 = PRIM_EQ(Nil, x140421012122599);
+if (True == x140421012122631) {
+Obj x140421012122919 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012123015 = PRIM_CDR(x140421012122919);
+Obj frees = x140421012123015;
+pushCont(co, 14, clofun7, 2, args, frees);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139886475191975;
-__arg2 = x139886475192071;
+__arg0 = globalRef(__symbolTable[74]);
+__arg1 = body;
+__arg2 = globalRef(__symbolTable[75]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683687;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label14:
 {
-Obj x139886475192103 = __arg1;
-Obj x139886475191143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = x139886475191143;
-__arg2 = x139886475192103;
+Obj x140421012094983 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421012095015 = makeCons(x140421012094983, Nil);
+Obj x140421012095047 = makeCons(args, x140421012095015);
+Obj x140421012095079 = makeCons(__symbolTable[94], x140421012095047);
+Obj x140421012095111 = makeCons(x140421012095079, frees);
+Obj x140421012095143 = makeCons(__symbolTable[77], x140421012095111);
+__nargs = 2;
+__arg0 = closureRef(co, 1);
+__arg1 = x140421012095143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9986,51 +9353,27 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj x139886476079623 = makeNative(16, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475270343 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475270343) {
-Obj x139886475270663 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475270695 = PRIM_EQ(sym_37closure, x139886475270663);
-if (True == x139886475270695) {
-Obj x139886475270983 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475271079 = PRIM_ISCONS(x139886475270983);
-if (True == x139886475271079) {
-Obj x139886475271367 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475271399 = PRIM_CAR(x139886475271367);
-Obj lam = x139886475271399;
-Obj x139886475271751 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475271783 = PRIM_CDR(x139886475271751);
-Obj more = x139886475271783;
-Obj x139886475271943 = makeCons(lam, more);
+Obj x140421012390599 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012390599) {
+Obj x140421012390791 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140421012390791;
+Obj x140421012391015 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421012391015;
+Obj x140421012391303 = makeCons(f, args);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[73]);
+__arg1 = x140421012391303;
+__arg2 = Nil;
+__arg3 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x139886475271943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476079623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079623;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476079623;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10041,324 +9384,191 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj x139886475981351 = makeNative(17, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475268263 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475268263) {
-Obj x139886475268551 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475268615 = PRIM_EQ(symreturn, x139886475268551);
-if (True == x139886475268615) {
-Obj x139886475268903 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475268935 = PRIM_ISCONS(x139886475268903);
-if (True == x139886475268935) {
-Obj x139886475269255 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475269287 = PRIM_CAR(x139886475269255);
-Obj x = x139886475269287;
-Obj x139886475269703 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475269735 = PRIM_CDR(x139886475269703);
-Obj x139886475269767 = PRIM_EQ(Nil, x139886475269735);
-if (True == x139886475269767) {
+Obj x = __arg1;
+Obj x140421012515559 = makeCons(x, Nil);
+Obj x140421012515591 = makeCons(__symbolTable[78], x140421012515559);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475981351;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981351;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981351;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475981351;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x140421012515591;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label17:
 {
-Obj x139886475983719 = makeNative(19, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475330087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475330087) {
-Obj x139886475330407 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475330439 = PRIM_EQ(symcall, x139886475330407);
-if (True == x139886475330439) {
-Obj x139886475330791 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475330823 = PRIM_ISCONS(x139886475330791);
-if (True == x139886475330823) {
-Obj x139886475331175 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475331207 = PRIM_CAR(x139886475331175);
-Obj exp = x139886475331207;
-Obj x139886475331655 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475331687 = PRIM_CDR(x139886475331655);
-Obj x139886475331751 = PRIM_ISCONS(x139886475331687);
-if (True == x139886475331751) {
-Obj x139886475332103 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475332135 = PRIM_CDR(x139886475332103);
-Obj x139886475332167 = PRIM_CAR(x139886475332135);
-Obj cont = x139886475332167;
-Obj x139886475332647 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475332679 = PRIM_CDR(x139886475332647);
-Obj x139886475332711 = PRIM_CDR(x139886475332679);
-Obj x139886475332743 = PRIM_EQ(Nil, x139886475332711);
-if (True == x139886475332743) {
-Obj x139886475333159 = makeCons(cont, Nil);
-Obj x139886475333191 = makeCons(exp, x139886475333159);
-PUSH_CONT_0(co, 18, clofun7);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139886475333191;
+Obj x140421013561607 = __arg1;
+Obj x140421013561671 = __arg2;
+pushCont(co, 18, clofun7, 2, x140421013561671, x140421013561607);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[84]);
+__arg1 = x140421013561671;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475983719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983719;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label18:
 {
-Obj x139886475333223 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139886475333223;
+Obj x140421013273639 = __arg1;
+Obj x140421013561671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013561607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421013273639) {
+__nargs = 2;
+__arg1 = x140421013561671;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013273799 = primIsSymbol(x140421013561671);
+if (True == x140421013273799) {
+pushCont(co, 28, clofun7, 1, x140421013561671);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[129]);
+__arg1 = x140421013561671;
+__arg2 = x140421013561607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj x140421013562439 = makeNative(23, clofun7, 0, 2, x140421013561671, x140421013561607);
+Obj x140421012993895 = PRIM_ISCONS(x140421013561671);
+if (True == x140421012993895) {
+Obj x140421012994151 = PRIM_CAR(x140421013561671);
+Obj x140421012994183 = PRIM_EQ(__symbolTable[94], x140421012994151);
+if (True == x140421012994183) {
+Obj x140421012994535 = PRIM_CDR(x140421013561671);
+Obj x140421012994567 = PRIM_ISCONS(x140421012994535);
+if (True == x140421012994567) {
+Obj x140421012994855 = PRIM_CDR(x140421013561671);
+Obj x140421012994887 = PRIM_CAR(x140421012994855);
+Obj args = x140421012994887;
+Obj x140421012995239 = PRIM_CDR(x140421013561671);
+Obj x140421012995271 = PRIM_CDR(x140421012995239);
+Obj x140421012995303 = PRIM_ISCONS(x140421012995271);
+if (True == x140421012995303) {
+Obj x140421012995687 = PRIM_CDR(x140421013561671);
+Obj x140421012995719 = PRIM_CDR(x140421012995687);
+Obj x140421012995847 = PRIM_CAR(x140421012995719);
+Obj body = x140421012995847;
+Obj x140421012512999 = PRIM_CDR(x140421013561671);
+Obj x140421012513031 = PRIM_CDR(x140421012512999);
+Obj x140421012513063 = PRIM_CDR(x140421012513031);
+Obj x140421012513095 = PRIM_EQ(Nil, x140421012513063);
+if (True == x140421012513095) {
+Obj x140421012513575 = makeCons(body, Nil);
+Obj x140421012513607 = makeCons(args, x140421012513575);
+Obj x140421012513639 = makeCons(__symbolTable[94], x140421012513607);
+pushCont(co, 19, clofun7, 3, body, args, x140421013561607);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = x140421012513639;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013562439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013562439;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
 }
 
 label19:
 {
-Obj x139886475568679 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475385383 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475385383) {
-Obj x139886475385639 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475385671 = PRIM_EQ(symtailcall, x139886475385639);
-if (True == x139886475385671) {
-Obj x139886475385959 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475385991 = PRIM_ISCONS(x139886475385959);
-if (True == x139886475385991) {
-Obj x139886475386311 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475386343 = PRIM_CAR(x139886475386311);
-Obj exp = x139886475386343;
-Obj x139886475386727 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475386791 = PRIM_CDR(x139886475386727);
-Obj x139886475386823 = PRIM_EQ(Nil, x139886475386791);
-if (True == x139886475386823) {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = exp;
+Obj x140421012513671 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013561607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj fvs1 = x140421012513671;
+pushCont(co, 20, clofun7, 3, args, x140421013561607, fvs1);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = fvs1;
+__arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475568679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475568679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475568679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475568679;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label20:
 {
-Obj x139886475508967 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475464423 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475464423) {
-Obj x139886475464679 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475382791 = PRIM_EQ(symcontinuation, x139886475464679);
-if (True == x139886475382791) {
-Obj x139886475383047 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475383079 = PRIM_ISCONS(x139886475383047);
-if (True == x139886475383079) {
-Obj x139886475383367 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475383399 = PRIM_CAR(x139886475383367);
-Obj arg = x139886475383399;
-Obj x139886475383719 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475383751 = PRIM_CDR(x139886475383719);
-Obj x139886475383783 = PRIM_ISCONS(x139886475383751);
-if (True == x139886475383783) {
-Obj x139886475384167 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475384199 = PRIM_CDR(x139886475384167);
-Obj x139886475384231 = PRIM_CAR(x139886475384199);
-Obj body = x139886475384231;
-Obj x139886475384615 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475384647 = PRIM_CDR(x139886475384615);
-Obj x139886475384679 = PRIM_CDR(x139886475384647);
-Obj x139886475384711 = PRIM_EQ(Nil, x139886475384679);
-if (True == x139886475384711) {
-pushCont(co, 21, clofun7, 1, arg);
+Obj x140421012514247 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013561607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj x140421012514279 = makeCons(x140421012514247, Nil);
+Obj x140421012514311 = makeCons(args, x140421012514279);
+Obj x140421012514343 = makeCons(__symbolTable[94], x140421012514311);
+pushCont(co, 21, clofun7, 2, fvs1, x140421012514343);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = body;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = x140421013561607;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475508967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475508967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475508967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475508967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475508967;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label21:
 {
-Obj x139886475384871 = __arg1;
-Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012514535 = __arg1;
+Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012514343= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 22, clofun7, 1, x140421012514343);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = x139886475384871;
-__arg2 = arg;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421012514535;
+__arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10368,223 +9578,175 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj x139886475463367 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475463367) {
-Obj x139886475463623 = PRIM_CAR(closureRef(co, 0));
-Obj f = x139886475463623;
-Obj x139886475463815 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886475463815;
-Obj x139886475464135 = makeCons(f, args);
-PUSH_CONT_0(co, 23, clofun7);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = x139886475464135;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
+Obj x140421012514567 = __arg1;
+Obj x140421012514343= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012514599 = makeCons(x140421012514343, x140421012514567);
+Obj x140421012514663 = makeCons(__symbolTable[77], x140421012514599);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x140421012514663;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label23:
 {
-Obj x139886475464167 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = globalRef(symcora_47lib_47toc_35union);
-__arg2 = Nil;
-__arg3 = x139886475464167;
+Obj x140421013563143 = makeNative(26, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x140421013090407 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013090407) {
+Obj x140421013090791 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013090823 = PRIM_EQ(__symbolTable[91], x140421013090791);
+if (True == x140421013090823) {
+Obj x140421013091079 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013091111 = PRIM_ISCONS(x140421013091079);
+if (True == x140421013091111) {
+Obj x140421013091527 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013091559 = PRIM_CAR(x140421013091527);
+Obj a = x140421013091559;
+Obj x140421013092007 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013092039 = PRIM_CDR(x140421013092007);
+Obj x140421013092135 = PRIM_ISCONS(x140421013092039);
+if (True == x140421013092135) {
+Obj x140421013092551 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013092583 = PRIM_CDR(x140421013092551);
+Obj x140421013092615 = PRIM_CAR(x140421013092583);
+Obj b = x140421013092615;
+Obj x140421013093127 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093159 = PRIM_CDR(x140421013093127);
+Obj x140421013093191 = PRIM_CDR(x140421013093159);
+Obj x140421013093223 = PRIM_ISCONS(x140421013093191);
+if (True == x140421013093223) {
+Obj x140421013093703 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093735 = PRIM_CDR(x140421013093703);
+Obj x140421013093767 = PRIM_CDR(x140421013093735);
+Obj x140421013093831 = PRIM_CAR(x140421013093767);
+Obj c = x140421013093831;
+Obj x140421012992167 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012992199 = PRIM_CDR(x140421012992167);
+Obj x140421012992231 = PRIM_CDR(x140421012992199);
+Obj x140421012992263 = PRIM_CDR(x140421012992231);
+Obj x140421012992295 = PRIM_EQ(Nil, x140421012992263);
+if (True == x140421012992295) {
+pushCont(co, 24, clofun7, 2, c, a);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = closureRef(co, 1);
+__arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013563143;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label24:
 {
-Obj x139886475982567 = __arg1;
-Obj x139886475983975 = makeNative(25, clofun7, 0, 1, x139886475982567);
-Obj x139886475472199 = PRIM_ISCONS(x139886475982567);
-if (True == x139886475472199) {
-Obj x139886475472423 = PRIM_CAR(x139886475982567);
-Obj x139886475472455 = PRIM_EQ(sym_37const, x139886475472423);
-if (True == x139886475472455) {
-Obj x139886475472679 = PRIM_CDR(x139886475982567);
-Obj x139886475472711 = PRIM_ISCONS(x139886475472679);
-if (True == x139886475472711) {
-Obj x139886475460647 = PRIM_CDR(x139886475982567);
-Obj x139886475460711 = PRIM_CAR(x139886475460647);
-Obj x139886475460999 = PRIM_CDR(x139886475982567);
-Obj x139886475461031 = PRIM_CDR(x139886475460999);
-Obj x139886475461063 = PRIM_EQ(Nil, x139886475461031);
-if (True == x139886475461063) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475983975;
+Obj x140421012992775 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 25, clofun7, 2, x140421012992775, a);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = closureRef(co, 1);
+__arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475983975;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label25:
 {
-Obj x139886475567495 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475470535 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475470535) {
-Obj x139886475470791 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475470823 = PRIM_EQ(sym_37global, x139886475470791);
-if (True == x139886475470823) {
-Obj x139886475471079 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475471111 = PRIM_ISCONS(x139886475471079);
-if (True == x139886475471111) {
-Obj x139886475471367 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475471399 = PRIM_CAR(x139886475471367);
-Obj x139886475471719 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475471751 = PRIM_CDR(x139886475471719);
-Obj x139886475471783 = PRIM_EQ(Nil, x139886475471751);
-if (True == x139886475471783) {
+Obj x140421012992967 = __arg1;
+Obj x140421012992775= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421012993031 = makeCons(x140421012992967, Nil);
+Obj x140421012993063 = makeCons(x140421012992775, x140421012993031);
+Obj x140421012993095 = makeCons(a, x140421012993063);
+Obj x140421012993127 = makeCons(__symbolTable[91], x140421012993095);
 __nargs = 2;
-__arg1 = True;
+__arg1 = x140421012993127;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475567495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475567495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475567495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475567495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label26:
 {
-Obj x139886475570343 = makeNative(27, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475509703 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475509703) {
-Obj x139886475468999 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475469031 = PRIM_EQ(sym_37builtin, x139886475468999);
-if (True == x139886475469031) {
-Obj x139886475469351 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475469383 = PRIM_ISCONS(x139886475469351);
-if (True == x139886475469383) {
-Obj x139886475469639 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475469671 = PRIM_CAR(x139886475469639);
-Obj x139886475470023 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475470055 = PRIM_CDR(x139886475470023);
-Obj x139886475470087 = PRIM_EQ(Nil, x139886475470055);
-if (True == x139886475470087) {
+Obj x140421013108871 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013108871) {
+Obj x140421013109127 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140421013109127;
+Obj x140421013110087 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421013110087;
+pushCont(co, 27, clofun7, 2, f, args);
 __nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475570343;
+__arg0 = globalRef(__symbolTable[76]);
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 } else {
-__nargs = 1;
-__arg0 = x139886475570343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475570343;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475570343;
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10595,157 +9757,107 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x139886475469799 = makeNative(28, clofun7, 0, 1, closureRef(co, 0));
-Obj x139886475507975 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475507975) {
-Obj x139886475508231 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475508263 = PRIM_EQ(symquote, x139886475508231);
-if (True == x139886475508263) {
-Obj x139886475508519 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475508551 = PRIM_ISCONS(x139886475508519);
-if (True == x139886475508551) {
-Obj x139886475508807 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475508839 = PRIM_CAR(x139886475508807);
-Obj x139886475509191 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475509223 = PRIM_CDR(x139886475509191);
-Obj x139886475509255 = PRIM_EQ(Nil, x139886475509223);
-if (True == x139886475509255) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475469799;
+Obj x140421013110311 = __arg1;
+Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013110535 = makeCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421013110311;
+__arg2 = x140421013110535;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469799;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label28:
 {
-Obj x139886475461511 = makeNative(29, clofun7, 0, 0);
-Obj x139886475570919 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475570919) {
-Obj x139886475506119 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475506215 = PRIM_EQ(sym_37closure_45ref, x139886475506119);
-if (True == x139886475506215) {
-Obj x139886475506535 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475506631 = PRIM_ISCONS(x139886475506535);
-if (True == x139886475506631) {
-Obj x139886475507015 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475507047 = PRIM_CAR(x139886475507015);
-Obj x139886475507463 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475507495 = PRIM_CDR(x139886475507463);
-Obj x139886475507527 = PRIM_EQ(Nil, x139886475507495);
-if (True == x139886475507527) {
+Obj x140421013273959 = __arg1;
+Obj x140421013561671= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj pos = x140421013273959;
+Obj x140421013274119 = PRIM_EQ(MAKE_NUMBER(-1), pos);
+if (True == x140421013274119) {
 __nargs = 2;
-__arg1 = True;
+__arg1 = x140421013561671;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = x139886475461511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475461511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475461511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475461511;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421013106855 = makeCons(pos, Nil);
+Obj x140421013106887 = makeCons(__symbolTable[83], x140421013106855);
+__nargs = 2;
+__arg1 = x140421013106887;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label29:
 {
+Obj x140421013682919 = __arg1;
+pushCont(co, 30, clofun7, 1, x140421013682919);
 __nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(__symbolTable[84]);
+__arg1 = x140421013682919;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label30:
 {
-Obj x139886476186983 = __arg1;
-Obj x139886476187207 = __arg2;
-Obj x139886475567719 = PRIM_EQ(Nil, x139886476186983);
-if (True == x139886475567719) {
+Obj x140421011730183 = __arg1;
+Obj x140421013682919= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421011730183) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj x139886476147719 = makeNative(32, clofun7, 0, 2, x139886476186983, x139886476187207);
-Obj x139886475568935 = PRIM_ISCONS(x139886476186983);
-if (True == x139886475568935) {
-Obj x139886475569095 = PRIM_CAR(x139886476186983);
-Obj x = x139886475569095;
-Obj x139886475569255 = PRIM_CDR(x139886476186983);
-Obj y = x139886475569255;
-pushCont(co, 31, clofun7, 3, y, x139886476187207, x139886476147719);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = x;
-__arg2 = x139886476187207;
+Obj x140421011730343 = primIsSymbol(x140421013682919);
+if (True == x140421011730343) {
+Obj x140421011689479 = makeCons(x140421013682919, Nil);
+__nargs = 2;
+__arg1 = x140421011689479;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013683463 = makeNative(32, clofun7, 0, 1, x140421013682919);
+Obj x140421013393255 = PRIM_ISCONS(x140421013682919);
+if (True == x140421013393255) {
+Obj x140421013270663 = PRIM_CAR(x140421013682919);
+Obj x140421013270727 = PRIM_EQ(__symbolTable[94], x140421013270663);
+if (True == x140421013270727) {
+Obj x140421013270951 = PRIM_CDR(x140421013682919);
+Obj x140421013270983 = PRIM_ISCONS(x140421013270951);
+if (True == x140421013270983) {
+Obj x140421013271271 = PRIM_CDR(x140421013682919);
+Obj x140421013271303 = PRIM_CAR(x140421013271271);
+Obj args = x140421013271303;
+Obj x140421013271687 = PRIM_CDR(x140421013682919);
+Obj x140421013271719 = PRIM_CDR(x140421013271687);
+Obj x140421013271751 = PRIM_ISCONS(x140421013271719);
+if (True == x140421013271751) {
+Obj x140421013272103 = PRIM_CDR(x140421013682919);
+Obj x140421013272135 = PRIM_CDR(x140421013272103);
+Obj x140421013272167 = PRIM_CAR(x140421013272135);
+Obj body = x140421013272167;
+Obj x140421013272551 = PRIM_CDR(x140421013682919);
+Obj x140421013272615 = PRIM_CDR(x140421013272551);
+Obj x140421013272647 = PRIM_CDR(x140421013272615);
+Obj x140421013272679 = PRIM_EQ(Nil, x140421013272647);
+if (True == x140421013272679) {
+pushCont(co, 31, clofun7, 1, args);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10753,27 +9865,114 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476147719;
+__arg0 = x140421013683463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 }
 
 label31:
 {
-Obj x139886475569415 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476187207= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476147719= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139886475569415) {
+Obj x140421013272871 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = y;
-__arg2 = x139886476187207;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = x140421013272871;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label32:
+{
+Obj x140421013683975 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421013469063 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013469063) {
+Obj x140421013469415 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013469447 = PRIM_EQ(__symbolTable[92], x140421013469415);
+if (True == x140421013469447) {
+Obj x140421013469799 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013469831 = PRIM_ISCONS(x140421013469799);
+if (True == x140421013469831) {
+Obj x140421013470183 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013470215 = PRIM_CAR(x140421013470183);
+Obj x = x140421013470215;
+Obj x140421013470631 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013470759 = PRIM_CDR(x140421013470631);
+Obj x140421013470791 = PRIM_ISCONS(x140421013470759);
+if (True == x140421013470791) {
+Obj x140421013471207 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013389319 = PRIM_CDR(x140421013471207);
+Obj x140421013389351 = PRIM_CAR(x140421013389319);
+Obj y = x140421013389351;
+Obj x140421013389927 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013389959 = PRIM_CDR(x140421013389927);
+Obj x140421013389991 = PRIM_CDR(x140421013389959);
+Obj x140421013390023 = PRIM_ISCONS(x140421013389991);
+if (True == x140421013390023) {
+Obj x140421013390599 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013390631 = PRIM_CDR(x140421013390599);
+Obj x140421013390663 = PRIM_CDR(x140421013390631);
+Obj x140421013390695 = PRIM_CAR(x140421013390663);
+Obj z = x140421013390695;
+Obj x140421013391911 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013391943 = PRIM_CDR(x140421013391911);
+Obj x140421013391975 = PRIM_CDR(x140421013391943);
+Obj x140421013392007 = PRIM_CDR(x140421013391975);
+Obj x140421013392039 = PRIM_EQ(Nil, x140421013392007);
+if (True == x140421013392039) {
+Obj x140421013392519 = makeCons(z, Nil);
+Obj x140421013392551 = makeCons(y, x140421013392519);
+Obj x140421013392583 = makeCons(x, x140421013392551);
+PUSH_CONT_0(co, 33, clofun7);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = globalRef(__symbolTable[82]);
+__arg2 = x140421013392583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10781,37 +9980,52 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476147719;
+__arg0 = x140421013683975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label32:
-{
-Obj x139886475568039 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475568039) {
-Obj x139886475568263 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139886475568263;
-Obj x139886475568455 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139886475568455;
-pushCont(co, 33, clofun7, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = y;
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__nargs = 1;
+__arg0 = x140421013683975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683975;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683975;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10822,40 +10036,53 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj x139886475568647 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475568711 = makeCons(x, x139886475568647);
-__nargs = 2;
-__arg1 = x139886475568711;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013392615 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = globalRef(__symbolTable[86]);
+__arg2 = Nil;
+__arg3 = x140421013392615;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label34:
 {
-Obj x139886476186855 = __arg1;
-Obj x139886476186951 = __arg2;
-Obj x139886475598215 = PRIM_EQ(Nil, x139886476186855);
-if (True == x139886475598215) {
-__nargs = 2;
-__arg1 = x139886476186951;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886476147463 = makeNative(36, clofun7, 0, 2, x139886476186855, x139886476186951);
-Obj x139886475599367 = PRIM_ISCONS(x139886476186855);
-if (True == x139886475599367) {
-Obj x139886475599527 = PRIM_CAR(x139886476186855);
-Obj x = x139886475599527;
-Obj x139886475599687 = PRIM_CDR(x139886476186855);
-Obj y = x139886475599687;
-pushCont(co, 35, clofun7, 3, y, x139886476186951, x139886476147463);
+Obj x140421013623175 = makeNative(36, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421013563463 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013563463) {
+Obj x140421013563815 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013563847 = PRIM_EQ(__symbolTable[90], x140421013563815);
+if (True == x140421013563847) {
+Obj x140421013564167 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013564199 = PRIM_ISCONS(x140421013564167);
+if (True == x140421013564199) {
+Obj x140421013564487 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013564519 = PRIM_CAR(x140421013564487);
+Obj x = x140421013564519;
+Obj x140421013564935 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013564967 = PRIM_CDR(x140421013564935);
+Obj x140421013564999 = PRIM_ISCONS(x140421013564967);
+if (True == x140421013564999) {
+Obj x140421013565415 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013467207 = PRIM_CDR(x140421013565415);
+Obj x140421013467239 = PRIM_CAR(x140421013467207);
+Obj y = x140421013467239;
+Obj x140421013467719 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013467751 = PRIM_CDR(x140421013467719);
+Obj x140421013467783 = PRIM_CDR(x140421013467751);
+Obj x140421013467815 = PRIM_EQ(Nil, x140421013467783);
+if (True == x140421013467815) {
+Obj x140421013468295 = makeCons(y, Nil);
+Obj x140421013468327 = makeCons(x, x140421013468295);
+PUSH_CONT_0(co, 35, clofun7);
 __nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = x;
-__arg2 = x139886476186951;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = globalRef(__symbolTable[82]);
+__arg2 = x140421013468327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10863,27 +10090,108 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476147463;
+__arg0 = x140421013623175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013623175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label35:
 {
-Obj x139886475599847 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476186951= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476147463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139886475599847) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = y;
-__arg2 = x139886476186951;
+Obj x140421013468359 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = globalRef(__symbolTable[86]);
+__arg2 = Nil;
+__arg3 = x140421013468359;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label36:
+{
+Obj x140421013623719 = makeNative(40, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421013683175 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013683175) {
+Obj x140421013683559 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013683591 = PRIM_EQ(__symbolTable[91], x140421013683559);
+if (True == x140421013683591) {
+Obj x140421013683943 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013684039 = PRIM_ISCONS(x140421013683943);
+if (True == x140421013684039) {
+Obj x140421013623527 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013623559 = PRIM_CAR(x140421013623527);
+Obj a = x140421013623559;
+Obj x140421013624199 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013624231 = PRIM_CDR(x140421013624199);
+Obj x140421013624263 = PRIM_ISCONS(x140421013624231);
+if (True == x140421013624263) {
+Obj x140421013624839 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013624871 = PRIM_CDR(x140421013624839);
+Obj x140421013624903 = PRIM_CAR(x140421013624871);
+Obj b = x140421013624903;
+Obj x140421013625575 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013625607 = PRIM_CDR(x140421013625575);
+Obj x140421013625639 = PRIM_CDR(x140421013625607);
+Obj x140421013625671 = PRIM_ISCONS(x140421013625639);
+if (True == x140421013625671) {
+Obj x140421013626343 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013626407 = PRIM_CDR(x140421013626343);
+Obj x140421013626471 = PRIM_CDR(x140421013626407);
+Obj x140421013626535 = PRIM_CAR(x140421013626471);
+Obj c = x140421013626535;
+Obj x140421013561575 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013561639 = PRIM_CDR(x140421013561575);
+Obj x140421013561703 = PRIM_CDR(x140421013561639);
+Obj x140421013561735 = PRIM_CDR(x140421013561703);
+Obj x140421013561799 = PRIM_EQ(Nil, x140421013561735);
+if (True == x140421013561799) {
+pushCont(co, 37, clofun7, 2, c, a);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10891,37 +10199,52 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476147463;
+__arg0 = x140421013623719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label36:
-{
-Obj x139886475598535 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475598535) {
-Obj x139886475598727 = PRIM_CAR(closureRef(co, 0));
-Obj x = x139886475598727;
-Obj x139886475598919 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139886475598919;
-pushCont(co, 37, clofun7, 1, x);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = y;
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__nargs = 1;
+__arg0 = x140421013623719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623719;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623719;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10932,26 +10255,31 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj x139886475599111 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475599143 = makeCons(x, x139886475599111);
+Obj x140421013562119 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 38, clofun7, 2, a, x140421013562119);
 __nargs = 2;
-__arg1 = x139886475599143;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label38:
 {
-Obj x139886476080007 = __arg1;
-Obj x139886476080039 = __arg2;
-Obj x139886476080327 = __arg3;
-Obj x139886476103783 = makeNative(42, clofun7, 1, 3, x139886476080007, x139886476080327, x139886476080039);
-pushCont(co, 39, clofun7, 2, x139886476080327, x139886476103783);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35number_63);
-__arg1 = x139886476080327;
+Obj x140421013562311 = __arg1;
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013562119= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013562471 = makeCons(a, Nil);
+pushCont(co, 39, clofun7, 1, x140421013562119);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = x140421013562311;
+__arg2 = x140421013562471;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10961,62 +10289,66 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj x139886475597351 = __arg1;
-Obj x139886476080327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886475597351) {
-__nargs = 2;
-__arg0 = x139886476103783;
-__arg1 = True;
+Obj x140421013562503 = __arg1;
+Obj x140421013562119= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[86]);
+__arg1 = x140421013562119;
+__arg2 = x140421013562503;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj x139886475597511 = primIsString(x139886476080327);
-if (True == x139886475597511) {
-__nargs = 2;
-__arg0 = x139886476103783;
-__arg1 = True;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 40, clofun7, 2, x139886476080327, x139886476103783);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35boolean_63);
-__arg1 = x139886476080327;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label40:
 {
-Obj x139886475597671 = __arg1;
-Obj x139886476080327= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == x139886475597671) {
+Obj x140421013624359 = makeNative(41, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421011565831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011565831) {
+Obj x140421011566087 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011566119 = PRIM_EQ(__symbolTable[77], x140421011566087);
+if (True == x140421011566119) {
+Obj x140421011566375 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013680231 = PRIM_ISCONS(x140421011566375);
+if (True == x140421013680231) {
+Obj x140421013681447 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013681511 = PRIM_CAR(x140421013681447);
+Obj lam = x140421013681511;
+Obj x140421013682119 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013682151 = PRIM_CDR(x140421013682119);
+Obj more = x140421013682151;
+Obj x140421013682439 = makeCons(lam, more);
 __nargs = 2;
-__arg0 = x139886476103783;
-__arg1 = True;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = x140421013682439;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 41, clofun7, 1, x139886476103783);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x139886476080327;
+__nargs = 1;
+__arg0 = x140421013624359;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624359;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11027,21 +10359,60 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj x139886475597831 = __arg1;
-Obj x139886476103783= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886475597831) {
+Obj x140421013624775 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421011564071 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011564071) {
+Obj x140421011564327 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011564359 = PRIM_EQ(__symbolTable[78], x140421011564327);
+if (True == x140421011564359) {
+Obj x140421011564615 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011564647 = PRIM_ISCONS(x140421011564615);
+if (True == x140421011564647) {
+Obj x140421011564903 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011564935 = PRIM_CAR(x140421011564903);
+Obj x = x140421011564935;
+Obj x140421011565255 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011565287 = PRIM_CDR(x140421011565255);
+Obj x140421011565319 = PRIM_EQ(Nil, x140421011565287);
+if (True == x140421011565319) {
 __nargs = 2;
-__arg0 = x139886476103783;
-__arg1 = True;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = x139886476103783;
-__arg1 = False;
+__nargs = 1;
+__arg0 = x140421013624775;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624775;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624775;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624775;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11052,37 +10423,38 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj x139886476103815 = __arg1;
-if (True == x139886476103815) {
-Obj x139886475182695 = makeCons(closureRef(co, 1), Nil);
-Obj x139886475182727 = makeCons(sym_37const, x139886475182695);
-__nargs = 2;
-__arg1 = x139886475182727;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475567239 = makeNative(44, clofun7, 0, 3, closureRef(co, 1), closureRef(co, 0), closureRef(co, 2));
-Obj x139886475984263 = PRIM_ISCONS(closureRef(co, 1));
-if (True == x139886475984263) {
-Obj x139886475984519 = PRIM_CAR(closureRef(co, 1));
-Obj x139886475984583 = PRIM_EQ(symquote, x139886475984519);
-if (True == x139886475984583) {
-Obj x139886475984839 = PRIM_CDR(closureRef(co, 1));
-Obj x139886475984871 = PRIM_ISCONS(x139886475984839);
-if (True == x139886475984871) {
-Obj x139886475596007 = PRIM_CDR(closureRef(co, 1));
-Obj x139886475596039 = PRIM_CAR(x139886475596007);
-Obj x = x139886475596039;
-Obj x139886475596391 = PRIM_CDR(closureRef(co, 1));
-Obj x139886475596423 = PRIM_CDR(x139886475596391);
-Obj x139886475596455 = PRIM_EQ(Nil, x139886475596423);
-if (True == x139886475596455) {
-pushCont(co, 43, clofun7, 1, x);
+Obj x140421013625191 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421011630727 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011630727) {
+Obj x140421011630983 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011631015 = PRIM_EQ(__symbolTable[79], x140421011630983);
+if (True == x140421011631015) {
+Obj x140421011631271 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011631303 = PRIM_ISCONS(x140421011631271);
+if (True == x140421011631303) {
+Obj x140421011631559 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011631591 = PRIM_CAR(x140421011631559);
+Obj exp = x140421011631591;
+Obj x140421011631911 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011631943 = PRIM_CDR(x140421011631911);
+Obj x140421011631975 = PRIM_ISCONS(x140421011631943);
+if (True == x140421011631975) {
+Obj x140421011562663 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011562695 = PRIM_CDR(x140421011562663);
+Obj x140421011562727 = PRIM_CAR(x140421011562695);
+Obj cont = x140421011562727;
+Obj x140421011563111 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011563143 = PRIM_CDR(x140421011563111);
+Obj x140421011563175 = PRIM_CDR(x140421011563143);
+Obj x140421011563207 = PRIM_EQ(Nil, x140421011563175);
+if (True == x140421011563207) {
+Obj x140421011563495 = makeCons(cont, Nil);
+Obj x140421011563527 = makeCons(exp, x140421011563495);
+PUSH_CONT_0(co, 43, clofun7);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = x;
-__arg2 = closureRef(co, 2);
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = globalRef(__symbolTable[82]);
+__arg2 = x140421011563527;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11090,7 +10462,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475567239;
+__arg0 = x140421013625191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11099,7 +10471,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475567239;
+__arg0 = x140421013625191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11108,7 +10480,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475567239;
+__arg0 = x140421013625191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11117,74 +10489,60 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475567239;
+__arg0 = x140421013625191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013625191;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label43:
 {
-Obj x139886475596679 = __arg1;
-Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475596839 = makeCons(x, Nil);
-Obj x139886475596871 = makeCons(sym_37const, x139886475596839);
-__nargs = 2;
-__arg1 = x139886475596871;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421011563559 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = globalRef(__symbolTable[86]);
+__arg2 = Nil;
+__arg3 = x140421011563559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label44:
 {
-Obj x139886475183047 = primIsSymbol(closureRef(co, 0));
-if (True == x139886475183047) {
-PUSH_CONT_0(co, 18, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35elem_63);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139886475463303 = makeNative(47, clofun7, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886476083015 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476083015) {
-Obj x139886475980871 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475980903 = PRIM_EQ(symlambda, x139886475980871);
-if (True == x139886475980903) {
-Obj x139886475981191 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475981223 = PRIM_ISCONS(x139886475981191);
-if (True == x139886475981223) {
-Obj x139886475981543 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475981575 = PRIM_CAR(x139886475981543);
-Obj args = x139886475981575;
-Obj x139886475981895 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475981927 = PRIM_CDR(x139886475981895);
-Obj x139886475981959 = PRIM_ISCONS(x139886475981927);
-if (True == x139886475981959) {
-Obj x139886475982279 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475982311 = PRIM_CDR(x139886475982279);
-Obj x139886475982343 = PRIM_CAR(x139886475982311);
-Obj body = x139886475982343;
-Obj x139886475982759 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475982855 = PRIM_CDR(x139886475982759);
-Obj x139886475982919 = PRIM_CDR(x139886475982855);
-Obj x139886475982983 = PRIM_EQ(Nil, x139886475982919);
-if (True == x139886475982983) {
-pushCont(co, 45, clofun7, 2, body, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35append);
-__arg1 = args;
-__arg2 = closureRef(co, 1);
+Obj x140421013625735 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421011628967 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011628967) {
+Obj x140421011629223 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011629255 = PRIM_EQ(__symbolTable[80], x140421011629223);
+if (True == x140421011629255) {
+Obj x140421011629511 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011629543 = PRIM_ISCONS(x140421011629511);
+if (True == x140421011629543) {
+Obj x140421011629799 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011629831 = PRIM_CAR(x140421011629799);
+Obj exp = x140421011629831;
+Obj x140421011630151 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011630183 = PRIM_CDR(x140421011630151);
+Obj x140421011630215 = PRIM_EQ(Nil, x140421011630183);
+if (True == x140421011630215) {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11192,7 +10550,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475463303;
+__arg0 = x140421013625735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11201,7 +10559,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475463303;
+__arg0 = x140421013625735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11210,7 +10568,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475463303;
+__arg0 = x140421013625735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11219,150 +10577,136 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886475463303;
+__arg0 = x140421013625735;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475463303;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 }
 
 label45:
 {
-Obj x139886475983431 = __arg1;
-Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun7, 1, args);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139886475983431;
-__arg2 = closureRef(co, 2);
-__arg3 = body;
+Obj x140421013626183 = makeNative(47, clofun7, 0, 1, closureRef(co, 0));
+Obj x140421011691719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011691719) {
+Obj x140421011691975 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011692007 = PRIM_EQ(__symbolTable[81], x140421011691975);
+if (True == x140421011692007) {
+Obj x140421011692263 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011692295 = PRIM_ISCONS(x140421011692263);
+if (True == x140421011692295) {
+Obj x140421011692551 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011692583 = PRIM_CAR(x140421011692551);
+Obj arg = x140421011692583;
+Obj x140421011692903 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011692935 = PRIM_CDR(x140421011692903);
+Obj x140421011692967 = PRIM_ISCONS(x140421011692935);
+if (True == x140421011692967) {
+Obj x140421011693287 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011693319 = PRIM_CDR(x140421011693287);
+Obj x140421011693351 = PRIM_CAR(x140421011693319);
+Obj body = x140421011693351;
+Obj x140421011628199 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011628231 = PRIM_CDR(x140421011628199);
+Obj x140421011628263 = PRIM_CDR(x140421011628231);
+Obj x140421011628295 = PRIM_EQ(Nil, x140421011628263);
+if (True == x140421011628295) {
+pushCont(co, 46, clofun7, 1, arg);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[82]);
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013626183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label46:
 {
-Obj x139886475983495 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475983527 = makeCons(x139886475983495, Nil);
-Obj x139886475983559 = makeCons(args, x139886475983527);
-Obj x139886475983591 = makeCons(symlambda, x139886475983559);
-__nargs = 2;
-__arg1 = x139886475983591;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun7) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421011628455 = __arg1;
+Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = x140421011628455;
+__arg2 = arg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label47:
 {
-Obj x139886475386631 = makeNative(48, clofun7, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886476106919 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476106919) {
-Obj x139886476107175 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476107207 = PRIM_EQ(symif, x139886476107175);
-if (True == x139886476107207) {
-Obj x139886476107463 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476107495 = PRIM_ISCONS(x139886476107463);
-if (True == x139886476107495) {
-Obj x139886476079143 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476079175 = PRIM_CAR(x139886476079143);
-Obj x139886476079207 = PRIM_ISCONS(x139886476079175);
-if (True == x139886476079207) {
-Obj x139886476079591 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476079655 = PRIM_CAR(x139886476079591);
-Obj x139886476079687 = PRIM_CAR(x139886476079655);
-Obj x139886476079719 = PRIM_EQ(symif, x139886476079687);
-if (True == x139886476079719) {
-Obj x139886476080135 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476080167 = PRIM_CAR(x139886476080135);
-Obj x139886476080199 = PRIM_CDR(x139886476080167);
-Obj exp1 = x139886476080199;
-Obj x139886476080487 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476080519 = PRIM_CDR(x139886476080487);
-Obj exp2 = x139886476080519;
-Obj x139886476080679 = primGenSym();
-Obj f = x139886476080679;
-Obj x139886476080839 = primGenSym();
-Obj v = x139886476080839;
-Obj x139886476081511 = makeCons(v, Nil);
-Obj x139886476081831 = makeCons(v, exp2);
-Obj x139886476081863 = makeCons(symif, x139886476081831);
-Obj x139886476081895 = makeCons(x139886476081863, Nil);
-Obj x139886476081927 = makeCons(x139886476081511, x139886476081895);
-Obj x139886476081991 = makeCons(symlambda, x139886476081927);
-Obj x139886476082279 = makeCons(symif, exp1);
-Obj x139886476082311 = makeCons(x139886476082279, Nil);
-Obj x139886476082343 = makeCons(f, x139886476082311);
-Obj x139886476082375 = makeCons(x139886476082343, Nil);
-Obj x139886476082407 = makeCons(x139886476081991, x139886476082375);
-Obj x139886476082439 = makeCons(f, x139886476082407);
-Obj x139886476082471 = makeCons(symlet, x139886476082439);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = x139886476082471;
+Obj x140421011690823 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011690823) {
+Obj x140421011691015 = PRIM_CAR(closureRef(co, 0));
+Obj f = x140421011691015;
+Obj x140421011691207 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421011691207;
+Obj x140421011691431 = makeCons(f, args);
+PUSH_CONT_0(co, 48, clofun7);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = globalRef(__symbolTable[82]);
+__arg2 = x140421011691431;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139886475386631;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475386631;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475386631;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475386631;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475386631;
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11373,58 +10717,78 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj x139886476145895 = makeNative(1, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886476105543 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476105543) {
-Obj x139886476105799 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476105831 = PRIM_EQ(symif, x139886476105799);
-if (True == x139886476105831) {
-Obj x139886476106023 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886476106023;
-pushCont(co, 49, clofun7, 1, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
+Obj x140421011691463 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = globalRef(__symbolTable[86]);
+__arg2 = Nil;
+__arg3 = x140421011691463;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476145895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476145895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label49:
 {
-Obj x139886476106311 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-PUSH_CONT_0(co, 0, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886476106311;
-__arg2 = args;
+Obj x140421013680167 = __arg1;
+Obj x140421013680295 = makeNative(0, clofun8, 0, 1, x140421013680167);
+Obj x140421011728007 = PRIM_ISCONS(x140421013680167);
+if (True == x140421011728007) {
+Obj x140421011728231 = PRIM_CAR(x140421013680167);
+Obj x140421011728263 = PRIM_EQ(__symbolTable[101], x140421011728231);
+if (True == x140421011728263) {
+Obj x140421011728487 = PRIM_CDR(x140421013680167);
+Obj x140421011728519 = PRIM_ISCONS(x140421011728487);
+if (True == x140421011728519) {
+Obj x140421011728743 = PRIM_CDR(x140421013680167);
+Obj x140421011728775 = PRIM_CAR(x140421011728743);
+Obj x140421011729479 = PRIM_CDR(x140421013680167);
+Obj x140421011729511 = PRIM_CDR(x140421011729479);
+Obj x140421011729543 = PRIM_EQ(Nil, x140421011729511);
+if (True == x140421011729543) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun7) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013680295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680295;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680295;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680295;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -11443,62 +10807,95 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20, &&label21, &&label22, &&label23, &&label24, &&label25, &&label26, &&label27, &&label28, &&label29, &&label30, &&label31, &&label32, &&label33, &&label34, &&label35, &&label36, &&label37, &&label38, &&label39, &&label40, &&label41, &&label42, &&label43, &&label44, &&label45, &&label46, &&label47, &&label48, &&label49};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x139886476106343 = __arg1;
-Obj x139886476106375 = makeCons(symif, x139886476106343);
+Obj x140421013680743 = makeNative(1, clofun8, 0, 1, closureRef(co, 0));
+Obj x140421011726343 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011726343) {
+Obj x140421011726599 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011726631 = PRIM_EQ(__symbolTable[98], x140421011726599);
+if (True == x140421011726631) {
+Obj x140421011726887 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011726919 = PRIM_ISCONS(x140421011726887);
+if (True == x140421011726919) {
+Obj x140421011727175 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011727207 = PRIM_CAR(x140421011727175);
+Obj x140421011727527 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011727559 = PRIM_CDR(x140421011727527);
+Obj x140421011727591 = PRIM_EQ(Nil, x140421011727559);
+if (True == x140421011727591) {
 __nargs = 2;
-__arg1 = x139886476106375;
+__arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013680743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013680743;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj x139886476106823 = makeNative(4, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886476146087 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886476146087) {
-Obj x139886476146375 = PRIM_CAR(closureRef(co, 0));
-Obj x139886476146407 = PRIM_EQ(symdo, x139886476146375);
-if (True == x139886476146407) {
-Obj x139886476146695 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476146727 = PRIM_ISCONS(x139886476146695);
-if (True == x139886476146727) {
-Obj x139886476146983 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476147047 = PRIM_CAR(x139886476146983);
-Obj x = x139886476147047;
-Obj x139886476147431 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476147495 = PRIM_CDR(x139886476147431);
-Obj x139886476147559 = PRIM_ISCONS(x139886476147495);
-if (True == x139886476147559) {
-Obj x139886476147911 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476147943 = PRIM_CDR(x139886476147911);
-Obj x139886476147975 = PRIM_CAR(x139886476147943);
-Obj y = x139886476147975;
-Obj x139886476148519 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476148551 = PRIM_CDR(x139886476148519);
-Obj x139886476148583 = PRIM_CDR(x139886476148551);
-Obj x139886476148615 = PRIM_EQ(Nil, x139886476148583);
-if (True == x139886476148615) {
-pushCont(co, 2, clofun8, 1, y);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421013681255 = makeNative(2, clofun8, 0, 1, closureRef(co, 0));
+Obj x140421011769319 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011769319) {
+Obj x140421011769575 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011769607 = PRIM_EQ(__symbolTable[95], x140421011769575);
+if (True == x140421011769607) {
+Obj x140421011769863 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011770279 = PRIM_ISCONS(x140421011769863);
+if (True == x140421011770279) {
+Obj x140421011770535 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011770567 = PRIM_CAR(x140421011770535);
+Obj x140421011770887 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011770919 = PRIM_CDR(x140421011770887);
+Obj x140421011770951 = PRIM_EQ(Nil, x140421011770919);
+if (True == x140421011770951) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = x139886476106823;
+__arg0 = x140421013681255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11507,7 +10904,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476106823;
+__arg0 = x140421013681255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11516,7 +10913,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476106823;
+__arg0 = x140421013681255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11525,16 +10922,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = x139886476106823;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886476106823;
+__arg0 = x140421013681255;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11545,287 +10933,223 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj x139886476103943 = __arg1;
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 3, clofun8, 1, x139886476103943);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = y;
+Obj x140421013681703 = makeNative(3, clofun8, 0, 1, closureRef(co, 0));
+Obj x140421011767623 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421011767623) {
+Obj x140421011767879 = PRIM_CAR(closureRef(co, 0));
+Obj x140421011767911 = PRIM_EQ(__symbolTable[89], x140421011767879);
+if (True == x140421011767911) {
+Obj x140421011768167 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011768199 = PRIM_ISCONS(x140421011768167);
+if (True == x140421011768199) {
+Obj x140421011768455 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011768487 = PRIM_CAR(x140421011768455);
+Obj x140421011768807 = PRIM_CDR(closureRef(co, 0));
+Obj x140421011768839 = PRIM_CDR(x140421011768807);
+Obj x140421011768871 = PRIM_EQ(Nil, x140421011768839);
+if (True == x140421011768871) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013681703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681703;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681703;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013681703;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label3:
 {
-Obj x139886476104487 = __arg1;
-Obj x139886476103943= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886476104839 = makeCons(x139886476104487, Nil);
-Obj x139886476104871 = makeCons(x139886476103943, x139886476104839);
-Obj x139886476104903 = makeCons(symdo, x139886476104871);
+Obj x140421013682247 = makeNative(4, clofun8, 0, 0);
+Obj x140421012040359 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012040359) {
+Obj x140421012040615 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012040647 = PRIM_EQ(__symbolTable[83], x140421012040615);
+if (True == x140421012040647) {
+Obj x140421012040903 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012040935 = PRIM_ISCONS(x140421012040903);
+if (True == x140421012040935) {
+Obj x140421012041191 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012041223 = PRIM_CAR(x140421012041191);
+Obj x140421012041543 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012041575 = PRIM_CDR(x140421012041543);
+Obj x140421012041607 = PRIM_EQ(Nil, x140421012041575);
+if (True == x140421012041607) {
 __nargs = 2;
-__arg1 = x139886476104903;
+__arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013682247;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682247;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682247;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682247;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label4:
 {
-Obj x139886475982951 = makeNative(7, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886474652551 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886474652551) {
-Obj x139886474652807 = PRIM_CAR(closureRef(co, 0));
-Obj x139886474652839 = PRIM_EQ(symlet, x139886474652807);
-if (True == x139886474652839) {
-Obj x139886474653095 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474653127 = PRIM_ISCONS(x139886474653095);
-if (True == x139886474653127) {
-Obj x139886476186247 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476186279 = PRIM_CAR(x139886476186247);
-Obj a = x139886476186279;
-Obj x139886476186631 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476186695 = PRIM_CDR(x139886476186631);
-Obj x139886476186791 = PRIM_ISCONS(x139886476186695);
-if (True == x139886476186791) {
-Obj x139886476187463 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476187495 = PRIM_CDR(x139886476187463);
-Obj x139886476187655 = PRIM_CAR(x139886476187495);
-Obj b = x139886476187655;
-Obj x139886476188231 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476188263 = PRIM_CDR(x139886476188231);
-Obj x139886476188295 = PRIM_CDR(x139886476188263);
-Obj x139886476188327 = PRIM_ISCONS(x139886476188295);
-if (True == x139886476188327) {
-Obj x139886476188903 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476188935 = PRIM_CDR(x139886476188903);
-Obj x139886476188967 = PRIM_CDR(x139886476188935);
-Obj x139886476189031 = PRIM_CAR(x139886476188967);
-Obj c = x139886476189031;
-Obj x139886476189511 = PRIM_CDR(closureRef(co, 0));
-Obj x139886476189543 = PRIM_CDR(x139886476189511);
-Obj x139886476189575 = PRIM_CDR(x139886476189543);
-Obj x139886476189607 = PRIM_CDR(x139886476189575);
-Obj x139886476189639 = PRIM_EQ(Nil, x139886476189607);
-if (True == x139886476189639) {
-pushCont(co, 5, clofun8, 2, c, a);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475982951;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label5:
-{
-Obj x139886476144935 = __arg1;
-Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476145255 = makeCons(a, closureRef(co, 1));
-pushCont(co, 6, clofun8, 2, x139886476144935, a);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = x139886476145255;
-__arg2 = closureRef(co, 2);
-__arg3 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x139886476145319 = __arg1;
-Obj x139886476144935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886476145351 = makeCons(x139886476145319, Nil);
-Obj x139886476145383 = makeCons(x139886476144935, x139886476145351);
-Obj x139886476145415 = makeCons(a, x139886476145383);
-Obj x139886476145447 = makeCons(symlet, x139886476145415);
 __nargs = 2;
-__arg1 = x139886476145447;
+__arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
+label5:
+{
+Obj x140421013562759 = __arg1;
+Obj x140421013562791 = __arg2;
+Obj x140421012077831 = PRIM_EQ(Nil, x140421013562759);
+if (True == x140421012077831) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013563239 = makeNative(7, clofun8, 0, 2, x140421013562759, x140421013562791);
+Obj x140421012038631 = PRIM_ISCONS(x140421013562759);
+if (True == x140421012038631) {
+Obj x140421012038791 = PRIM_CAR(x140421013562759);
+Obj x = x140421012038791;
+Obj x140421012038951 = PRIM_CDR(x140421013562759);
+Obj y = x140421012038951;
+pushCont(co, 6, clofun8, 3, y, x140421013562791, x140421013563239);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[100]);
+__arg1 = x;
+__arg2 = x140421013562791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013563239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label6:
+{
+Obj x140421012039111 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013562791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013563239= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140421012039111) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = y;
+__arg2 = x140421013562791;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013563239;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
 label7:
 {
-Obj x139886475469191 = makeNative(8, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj x139886475126631 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475126631) {
-Obj x139886475126887 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475126919 = PRIM_ISCONS(x139886475126887);
-if (True == x139886475126919) {
-Obj x139886475127239 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475127271 = PRIM_CAR(x139886475127239);
-Obj x139886475127303 = PRIM_EQ(symlambda, x139886475127271);
-if (True == x139886475127303) {
-Obj x139886475127559 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475127591 = PRIM_CDR(x139886475127559);
-Obj exp1 = x139886475127591;
-Obj x139886475127847 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475127879 = PRIM_ISCONS(x139886475127847);
-if (True == x139886475127879) {
-Obj x139886475128199 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475128231 = PRIM_CAR(x139886475128199);
-Obj x139886475128263 = PRIM_ISCONS(x139886475128231);
-if (True == x139886475128263) {
-Obj x139886475128647 = PRIM_CDR(closureRef(co, 0));
-Obj x139886475128679 = PRIM_CAR(x139886475128647);
-Obj x139886475128711 = PRIM_CAR(x139886475128679);
-Obj x139886475128743 = PRIM_EQ(symif, x139886475128711);
-if (True == x139886475128743) {
-Obj x139886474649831 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474649863 = PRIM_CAR(x139886474649831);
-Obj x139886474649895 = PRIM_CDR(x139886474649863);
-Obj exp2 = x139886474649895;
-Obj x139886474650215 = PRIM_CDR(closureRef(co, 0));
-Obj x139886474650247 = PRIM_CDR(x139886474650215);
-Obj x139886474650279 = PRIM_EQ(Nil, x139886474650247);
-if (True == x139886474650279) {
-Obj x139886474650439 = primGenSym();
-Obj f = x139886474650439;
-Obj x139886474651431 = makeCons(symlambda, exp1);
-Obj x139886474651719 = makeCons(symif, exp2);
-Obj x139886474651751 = makeCons(x139886474651719, Nil);
-Obj x139886474651783 = makeCons(f, x139886474651751);
-Obj x139886474651815 = makeCons(x139886474651783, Nil);
-Obj x139886474651847 = makeCons(x139886474651431, x139886474651815);
-Obj x139886474651879 = makeCons(f, x139886474651847);
-Obj x139886474651911 = makeCons(symlet, x139886474651879);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = x139886474651911;
+Obj x140421012037799 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012037799) {
+Obj x140421012037991 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421012037991;
+Obj x140421012038183 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421012038183;
+pushCont(co, 8, clofun8, 1, x);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[85]);
+__arg1 = y;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475469191;
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11836,44 +11160,40 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj x139886475383335 = makeNative(16, clofun8, 0, 3, closureRef(co, 1), closureRef(co, 2), closureRef(co, 0));
-Obj x139886475185095 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475185095) {
-Obj x139886475185287 = PRIM_CAR(closureRef(co, 0));
-Obj op = x139886475185287;
-Obj x139886475185479 = PRIM_CDR(closureRef(co, 0));
-Obj args = x139886475185479;
-pushCont(co, 9, clofun8, 3, op, args, x139886475383335);
+Obj x140421012038375 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012038407 = makeCons(x, x140421012038375);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
-__arg1 = op;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475383335;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = x140421012038407;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj x139886475185639 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475383335= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == x139886475185639) {
-pushCont(co, 10, clofun8, 2, op, args);
+Obj x140421013561479 = __arg1;
+Obj x140421013561511 = __arg2;
+Obj x140421012075591 = PRIM_EQ(Nil, x140421013561479);
+if (True == x140421012075591) {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
-__arg1 = op;
+__arg1 = x140421013561511;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013561959 = makeNative(11, clofun8, 0, 2, x140421013561479, x140421013561511);
+Obj x140421012076743 = PRIM_ISCONS(x140421013561479);
+if (True == x140421012076743) {
+Obj x140421012076903 = PRIM_CAR(x140421013561479);
+Obj x = x140421012076903;
+Obj x140421012077063 = PRIM_CDR(x140421013561479);
+Obj y = x140421012077063;
+pushCont(co, 10, clofun8, 3, y, x140421013561511, x140421013561959);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[100]);
+__arg1 = x;
+__arg2 = x140421013561511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11881,62 +11201,56 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = x139886475383335;
+__arg0 = x140421013561959;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
 }
 }
 
 label10:
 {
-Obj x139886475185799 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj required = x139886475185799;
-pushCont(co, 11, clofun8, 3, required, op, args);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35length);
-__arg1 = args;
+Obj x140421012077223 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013561511= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013561959= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140421012077223) {
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[86]);
+__arg1 = y;
+__arg2 = x140421013561511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013561959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label11:
 {
-Obj x139886475185959 = __arg1;
-Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj provided = x139886475185959;
-Obj x139886475186119 = PRIM_EQ(required, provided);
-if (True == x139886475186119) {
-Obj x139886475124903 = makeCons(op, Nil);
-Obj x139886475124935 = makeCons(sym_37builtin, x139886475124903);
-pushCont(co, 14, clofun8, 2, args, x139886475124935);
+Obj x140421012075911 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012075911) {
+Obj x140421012076103 = PRIM_CAR(closureRef(co, 0));
+Obj x = x140421012076103;
+Obj x140421012076295 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421012076295;
+pushCont(co, 12, clofun8, 1, x);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj x139886475125383 = PRIM_GT(required, provided);
-if (True == x139886475125383) {
-Obj x139886475125607 = PRIM_SUB(required, provided);
-pushCont(co, 12, clofun8, 2, op, args);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139886475125607;
-__arg2 = Nil;
+__arg0 = globalRef(__symbolTable[86]);
+__arg1 = y;
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11944,48 +11258,38 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("primitive call mismatch");
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 }
 
 label12:
 {
-Obj x139886475125639 = __arg1;
-Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj tmp = x139886475125639;
-Obj x139886475126119 = makeCons(op, args);
-pushCont(co, 13, clofun8, 1, tmp);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35append);
-__arg1 = x139886475126119;
-__arg2 = tmp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421012076487 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012076519 = makeCons(x, x140421012076487);
+__nargs = 2;
+__arg1 = x140421012076519;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj x139886475126151 = __arg1;
-Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475126183 = makeCons(x139886475126151, Nil);
-Obj x139886475126215 = makeCons(tmp, x139886475126183);
-Obj x139886475126247 = makeCons(symlambda, x139886475126215);
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-__arg3 = x139886475126247;
+Obj x140421013681767 = __arg1;
+Obj x140421013681799 = __arg2;
+Obj x140421013681831 = __arg3;
+Obj x140421013467143 = makeNative(17, clofun8, 1, 3, x140421013681767, x140421013681831, x140421013681799);
+pushCont(co, 14, clofun8, 2, x140421013681831, x140421013467143);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[88]);
+__arg1 = x140421013681831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11995,38 +11299,192 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj x139886475125159 = __arg1;
-Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475124935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 15, clofun8, 1, x139886475124935);
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886475125159;
-__arg2 = args;
+Obj x140421012074727 = __arg1;
+Obj x140421013681831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013467143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421012074727) {
+__nargs = 2;
+__arg0 = x140421013467143;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj x140421012074887 = primIsString(x140421013681831);
+if (True == x140421012074887) {
+__nargs = 2;
+__arg0 = x140421013467143;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 15, clofun8, 2, x140421013681831, x140421013467143);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[87]);
+__arg1 = x140421013681831;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 
 label15:
 {
-Obj x139886475125191 = __arg1;
-Obj x139886475124935= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x139886475125223 = makeCons(x139886475124935, x139886475125191);
+Obj x140421012075047 = __arg1;
+Obj x140421013681831= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013467143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == x140421012075047) {
 __nargs = 2;
-__arg1 = x139886475125223;
+__arg0 = x140421013467143;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 16, clofun8, 1, x140421013467143);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = x140421013681831;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label16:
+{
+Obj x140421012075207 = __arg1;
+Obj x140421013467143= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421012075207) {
+__nargs = 2;
+__arg0 = x140421013467143;
+__arg1 = True;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = x140421013467143;
+__arg1 = False;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label17:
+{
+Obj x140421013467175 = __arg1;
+if (True == x140421013467175) {
+Obj x140421013272007 = makeCons(closureRef(co, 1), Nil);
+Obj x140421013272039 = makeCons(__symbolTable[101], x140421013272007);
+__nargs = 2;
+__arg1 = x140421013272039;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013682375 = makeNative(19, clofun8, 0, 3, closureRef(co, 1), closureRef(co, 0), closureRef(co, 2));
+Obj x140421012097191 = PRIM_ISCONS(closureRef(co, 1));
+if (True == x140421012097191) {
+Obj x140421012097447 = PRIM_CAR(closureRef(co, 1));
+Obj x140421012097479 = PRIM_EQ(__symbolTable[89], x140421012097447);
+if (True == x140421012097479) {
+Obj x140421012097735 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012097767 = PRIM_ISCONS(x140421012097735);
+if (True == x140421012097767) {
+Obj x140421012098023 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012098055 = PRIM_CAR(x140421012098023);
+Obj x = x140421012098055;
+Obj x140421012098375 = PRIM_CDR(closureRef(co, 1));
+Obj x140421012098407 = PRIM_CDR(x140421012098375);
+Obj x140421012098439 = PRIM_EQ(Nil, x140421012098407);
+if (True == x140421012098439) {
+pushCont(co, 18, clofun8, 1, x);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[99]);
+__arg1 = x;
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013682375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013682375;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label18:
+{
+Obj x140421012098631 = __arg1;
+Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012098791 = makeCons(x, Nil);
+Obj x140421012098823 = makeCons(__symbolTable[101], x140421012098791);
+__nargs = 2;
+__arg1 = x140421012098823;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label19:
 {
-PUSH_CONT_0(co, 17, clofun8);
+Obj x140421013272359 = primIsSymbol(closureRef(co, 0));
+if (True == x140421013272359) {
+PUSH_CONT_0(co, 43, clofun8);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35parse);
+__arg0 = globalRef(__symbolTable[100]);
 __arg1 = closureRef(co, 0);
 __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
@@ -12034,37 +11492,81 @@ struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj x139886475184871 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(symcora_47init_35map);
-__arg1 = x139886475184871;
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj x139886475183271 = __arg1;
-if (True == x139886475183271) {
-__nargs = 2;
-__arg1 = closureRef(co, 0);
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 } else {
-PUSH_CONT_0(co, 19, clofun8);
+Obj x140421013683367 = makeNative(22, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421012122695 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012122695) {
+Obj x140421012122951 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012122983 = PRIM_EQ(__symbolTable[94], x140421012122951);
+if (True == x140421012122983) {
+Obj x140421012123239 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012123271 = PRIM_ISCONS(x140421012123239);
+if (True == x140421012123271) {
+Obj x140421012123527 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012123559 = PRIM_CAR(x140421012123527);
+Obj args = x140421012123559;
+Obj x140421012095207 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012095239 = PRIM_CDR(x140421012095207);
+Obj x140421012095271 = PRIM_ISCONS(x140421012095239);
+if (True == x140421012095271) {
+Obj x140421012095591 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012095623 = PRIM_CDR(x140421012095591);
+Obj x140421012095655 = PRIM_CAR(x140421012095623);
+Obj body = x140421012095655;
+Obj x140421012096039 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012096071 = PRIM_CDR(x140421012096039);
+Obj x140421012096103 = PRIM_CDR(x140421012096071);
+Obj x140421012096135 = PRIM_EQ(Nil, x140421012096103);
+if (True == x140421012096135) {
+pushCont(co, 20, clofun8, 2, body, args);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 2);
+__arg0 = globalRef(__symbolTable[93]);
+__arg1 = args;
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013683367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013683367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12072,90 +11574,173 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
-
-label19:
-{
-Obj x139886475183527 = __arg1;
-Obj x139886475183719 = makeCons(closureRef(co, 0), Nil);
-Obj x139886475183751 = makeCons(sym_37global, x139886475183719);
-__nargs = 2;
-__arg1 = x139886475183751;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj x139886476187591 = __arg1;
-Obj x139886476187623 = __arg2;
-Obj x139886475194023 = PRIM_EQ(MAKE_NUMBER(0), x139886476187591);
-if (True == x139886475194023) {
-__nargs = 2;
-__arg1 = x139886476187623;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475194183 = PRIM_SUB(x139886476187591, MAKE_NUMBER(1));
-Obj x139886475194343 = primGenSym();
-Obj x139886475182087 = makeCons(x139886475194343, x139886476187623);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = x139886475194183;
-__arg2 = x139886475182087;
+Obj x140421012096519 = __arg1;
+Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 21, clofun8, 1, args);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = x140421012096519;
+__arg2 = closureRef(co, 2);
+__arg3 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label21:
 {
-Obj x = __arg1;
-PUSH_CONT_0(co, 22, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj x140421012096583 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012096615 = makeCons(x140421012096583, Nil);
+Obj x140421012096647 = makeCons(args, x140421012096615);
+Obj x140421012096679 = makeCons(__symbolTable[94], x140421012096647);
+__nargs = 2;
+__arg1 = x140421012096679;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label22:
 {
-Obj x139886475193415 = __arg1;
-Obj find = x139886475193415;
-pushCont(co, 23, clofun8, 1, find);
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = find;
+Obj x140421013684071 = makeNative(23, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421012392807 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012392807) {
+Obj x140421012393063 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012393095 = PRIM_EQ(__symbolTable[92], x140421012393063);
+if (True == x140421012393095) {
+Obj x140421012393351 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012393383 = PRIM_ISCONS(x140421012393351);
+if (True == x140421012393383) {
+Obj x140421012393703 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012393735 = PRIM_CAR(x140421012393703);
+Obj x140421012393767 = PRIM_ISCONS(x140421012393735);
+if (True == x140421012393767) {
+Obj x140421012119719 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012119751 = PRIM_CAR(x140421012119719);
+Obj x140421012119783 = PRIM_CAR(x140421012119751);
+Obj x140421012119815 = PRIM_EQ(__symbolTable[92], x140421012119783);
+if (True == x140421012119815) {
+Obj x140421012120135 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012120167 = PRIM_CAR(x140421012120135);
+Obj x140421012120199 = PRIM_CDR(x140421012120167);
+Obj exp1 = x140421012120199;
+Obj x140421012120455 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012120487 = PRIM_CDR(x140421012120455);
+Obj exp2 = x140421012120487;
+Obj x140421012120647 = primGenSym();
+Obj f = x140421012120647;
+Obj x140421012120807 = primGenSym();
+Obj v = x140421012120807;
+Obj x140421012121351 = makeCons(v, Nil);
+Obj x140421012121575 = makeCons(v, exp2);
+Obj x140421012121607 = makeCons(__symbolTable[92], x140421012121575);
+Obj x140421012121639 = makeCons(x140421012121607, Nil);
+Obj x140421012121671 = makeCons(x140421012121351, x140421012121639);
+Obj x140421012121703 = makeCons(__symbolTable[94], x140421012121671);
+Obj x140421012121991 = makeCons(__symbolTable[92], exp1);
+Obj x140421012122023 = makeCons(x140421012121991, Nil);
+Obj x140421012122055 = makeCons(f, x140421012122023);
+Obj x140421012122087 = makeCons(x140421012122055, Nil);
+Obj x140421012122119 = makeCons(x140421012121703, x140421012122087);
+Obj x140421012122151 = makeCons(f, x140421012122119);
+Obj x140421012122183 = makeCons(__symbolTable[91], x140421012122151);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x140421012122183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013684071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = x140421013684071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013684071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
 label23:
 {
-Obj x139886475193575 = __arg1;
-Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886475193575) {
-__nargs = 2;
-__arg1 = makeCString("ERROR");
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj x140421013623303 = makeNative(26, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421012391655 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012391655) {
+Obj x140421012391911 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012391943 = PRIM_EQ(__symbolTable[92], x140421012391911);
+if (True == x140421012391943) {
+Obj x140421012392135 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421012392135;
+pushCont(co, 24, clofun8, 1, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35cadr);
-__arg1 = find;
+__nargs = 1;
+__arg0 = x140421013623303;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12166,12 +11751,13 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj x = __arg1;
+Obj x140421012392423 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 25, clofun8);
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421012392423;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12181,33 +11767,92 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj x139886475192807 = __arg1;
-Obj find = x139886475192807;
-pushCont(co, 26, clofun8, 1, find);
+Obj x140421012392455 = __arg1;
+Obj x140421012392487 = makeCons(__symbolTable[92], x140421012392455);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = find;
+__arg1 = x140421012392487;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label26:
+{
+Obj x140421013623783 = makeNative(29, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421012515399 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012515399) {
+Obj x140421012515655 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012515687 = PRIM_EQ(__symbolTable[90], x140421012515655);
+if (True == x140421012515687) {
+Obj x140421012515943 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012515975 = PRIM_ISCONS(x140421012515943);
+if (True == x140421012515975) {
+Obj x140421012516231 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012516263 = PRIM_CAR(x140421012516231);
+Obj x = x140421012516263;
+Obj x140421012516583 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012516615 = PRIM_CDR(x140421012516583);
+Obj x140421012516647 = PRIM_ISCONS(x140421012516615);
+if (True == x140421012516647) {
+Obj x140421012389991 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012390023 = PRIM_CDR(x140421012389991);
+Obj x140421012390055 = PRIM_CAR(x140421012390023);
+Obj y = x140421012390055;
+Obj x140421012390439 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012390471 = PRIM_CDR(x140421012390439);
+Obj x140421012390503 = PRIM_CDR(x140421012390471);
+Obj x140421012390535 = PRIM_EQ(Nil, x140421012390503);
+if (True == x140421012390535) {
+pushCont(co, 27, clofun8, 1, y);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013623783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label26:
-{
-Obj x139886475192967 = __arg1;
-Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == x139886475192967) {
-__nargs = 2;
-__arg1 = makeCString("ERROR");
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47init_35caddr);
-__arg1 = find;
+__nargs = 1;
+__arg0 = x140421013623783;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623783;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623783;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013623783;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12218,12 +11863,14 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj x = __arg1;
-PUSH_CONT_0(co, 28, clofun8);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
-__arg1 = x;
-__arg2 = globalRef(symcora_47lib_47toc_35_42builtin_45prims_42);
+Obj x140421012390823 = __arg1;
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 28, clofun8, 1, x140421012390823);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12233,169 +11880,60 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj x139886475192359 = __arg1;
-PUSH_CONT_0(co, 29, clofun8);
+Obj x140421012391047 = __arg1;
+Obj x140421012390823= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421012391079 = makeCons(x140421012391047, Nil);
+Obj x140421012391111 = makeCons(x140421012390823, x140421012391079);
+Obj x140421012391143 = makeCons(__symbolTable[90], x140421012391111);
 __nargs = 2;
-__arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = x139886475192359;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = x140421012391143;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label29:
 {
-Obj x139886475192391 = __arg1;
-Obj x139886475192423 = primNot(x139886475192391);
-__nargs = 2;
-__arg1 = x139886475192423;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label30:
-{
-Obj x139886475244711 = __arg1;
-Obj x139886475244743 = __arg2;
-Obj x139886475270311 = PRIM_EQ(Nil, x139886475244743);
-if (True == x139886475270311) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475270471 = PRIM_ISCONS(x139886475244743);
-if (True == x139886475270471) {
-Obj x139886475270631 = PRIM_CAR(x139886475244743);
-Obj hd = x139886475270631;
-Obj x139886475270791 = PRIM_CDR(x139886475244743);
-Obj tl = x139886475270791;
-pushCont(co, 31, clofun8, 2, x139886475244711, tl);
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35index);
-__arg1 = x139886475244711;
-__arg2 = hd;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label31:
-{
-Obj x139886475271015 = __arg1;
-Obj x139886475244711= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x139886475271047 = PRIM_LT(x139886475271015, MAKE_NUMBER(0));
-if (True == x139886475271047) {
-__nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
-__arg1 = x139886475244711;
-__arg2 = tl;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label32:
-{
-Obj x = __arg1;
-Obj l = __arg2;
+Obj x140421013624487 = makeNative(32, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421012994119 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421012994119) {
+Obj x140421012994439 = PRIM_CAR(closureRef(co, 0));
+Obj x140421012994471 = PRIM_EQ(__symbolTable[91], x140421012994439);
+if (True == x140421012994471) {
+Obj x140421012994727 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012994759 = PRIM_ISCONS(x140421012994727);
+if (True == x140421012994759) {
+Obj x140421012995015 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012995047 = PRIM_CAR(x140421012995015);
+Obj a = x140421012995047;
+Obj x140421012995367 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012995399 = PRIM_CDR(x140421012995367);
+Obj x140421012995431 = PRIM_ISCONS(x140421012995399);
+if (True == x140421012995431) {
+Obj x140421012995751 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012995783 = PRIM_CDR(x140421012995751);
+Obj x140421012995815 = PRIM_CAR(x140421012995783);
+Obj b = x140421012995815;
+Obj x140421012512871 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012512903 = PRIM_CDR(x140421012512871);
+Obj x140421012512935 = PRIM_CDR(x140421012512903);
+Obj x140421012512967 = PRIM_ISCONS(x140421012512935);
+if (True == x140421012512967) {
+Obj x140421012513351 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012513383 = PRIM_CDR(x140421012513351);
+Obj x140421012513415 = PRIM_CDR(x140421012513383);
+Obj x140421012513447 = PRIM_CAR(x140421012513415);
+Obj c = x140421012513447;
+Obj x140421012513895 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012513927 = PRIM_CDR(x140421012513895);
+Obj x140421012513959 = PRIM_CDR(x140421012513927);
+Obj x140421012513991 = PRIM_CDR(x140421012513959);
+Obj x140421012514023 = PRIM_EQ(Nil, x140421012513991);
+if (True == x140421012514023) {
+pushCont(co, 30, clofun8, 2, c, a);
 __nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = MAKE_NUMBER(0);
-__arg2 = x;
-__arg3 = l;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label33:
-{
-Obj x139886475463879 = __arg1;
-Obj x139886475463911 = __arg2;
-Obj x139886475463975 = __arg3;
-Obj x139886475333415 = PRIM_EQ(Nil, x139886475463975);
-if (True == x139886475333415) {
-__nargs = 2;
-__arg1 = MAKE_NUMBER(-1);
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475330311 = makeNative(34, clofun8, 0, 3, x139886475463975, x139886475463879, x139886475463911);
-Obj x139886475269031 = PRIM_ISCONS(x139886475463975);
-if (True == x139886475269031) {
-Obj x139886475269191 = PRIM_CAR(x139886475463975);
-Obj a = x139886475269191;
-Obj x139886475269351 = PRIM_CDR(x139886475463975);
-Obj x139886475269511 = PRIM_EQ(x139886475463911, a);
-if (True == x139886475269511) {
-__nargs = 2;
-__arg1 = x139886475463879;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886475330311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = x139886475330311;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label34:
-{
-Obj x139886475268199 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475268199) {
-Obj x139886475268391 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475268583 = PRIM_CDR(closureRef(co, 0));
-Obj b = x139886475268583;
-Obj x139886475268775 = PRIM_ADD(closureRef(co, 1), MAKE_NUMBER(1));
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = x139886475268775;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = b;
 co->ctx.frees = __arg0;
@@ -12404,9 +11942,264 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013624487;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label30:
+{
+Obj x140421012514375 = __arg1;
+Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421012514631 = makeCons(a, closureRef(co, 1));
+pushCont(co, 31, clofun8, 2, x140421012514375, a);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = x140421012514631;
+__arg2 = closureRef(co, 2);
+__arg3 = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label31:
+{
+Obj x140421012514695 = __arg1;
+Obj x140421012514375= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421012514727 = makeCons(x140421012514695, Nil);
+Obj x140421012514759 = makeCons(x140421012514375, x140421012514727);
+Obj x140421012514791 = makeCons(a, x140421012514759);
+Obj x140421012514823 = makeCons(__symbolTable[91], x140421012514791);
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
+__arg1 = x140421012514823;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label32:
+{
+Obj x140421013625287 = makeNative(33, clofun8, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj x140421013091719 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013091719) {
+Obj x140421013092071 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013092103 = PRIM_ISCONS(x140421013092071);
+if (True == x140421013092103) {
+Obj x140421013092423 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013092455 = PRIM_CAR(x140421013092423);
+Obj x140421013092487 = PRIM_EQ(__symbolTable[94], x140421013092455);
+if (True == x140421013092487) {
+Obj x140421013092743 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013092775 = PRIM_CDR(x140421013092743);
+Obj exp1 = x140421013092775;
+Obj x140421013093031 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093063 = PRIM_ISCONS(x140421013093031);
+if (True == x140421013093063) {
+Obj x140421013093383 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093415 = PRIM_CAR(x140421013093383);
+Obj x140421013093447 = PRIM_ISCONS(x140421013093415);
+if (True == x140421013093447) {
+Obj x140421013093863 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013093895 = PRIM_CAR(x140421013093863);
+Obj x140421013093991 = PRIM_CAR(x140421013093895);
+Obj x140421013094023 = PRIM_EQ(__symbolTable[92], x140421013093991);
+if (True == x140421013094023) {
+Obj x140421013094343 = PRIM_CDR(closureRef(co, 0));
+Obj x140421013094375 = PRIM_CAR(x140421013094343);
+Obj x140421012992007 = PRIM_CDR(x140421013094375);
+Obj exp2 = x140421012992007;
+Obj x140421012992327 = PRIM_CDR(closureRef(co, 0));
+Obj x140421012992359 = PRIM_CDR(x140421012992327);
+Obj x140421012992391 = PRIM_EQ(Nil, x140421012992359);
+if (True == x140421012992391) {
+Obj x140421012992583 = primGenSym();
+Obj f = x140421012992583;
+Obj x140421012992999 = makeCons(__symbolTable[94], exp1);
+Obj x140421012993287 = makeCons(__symbolTable[92], exp2);
+Obj x140421012993319 = makeCons(x140421012993287, Nil);
+Obj x140421012993351 = makeCons(f, x140421012993319);
+Obj x140421012993383 = makeCons(x140421012993351, Nil);
+Obj x140421012993415 = makeCons(x140421012992999, x140421012993383);
+Obj x140421012993447 = makeCons(f, x140421012993415);
+Obj x140421012993479 = makeCons(__symbolTable[91], x140421012993447);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x140421012993479;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013625287;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label33:
+{
+Obj x140421013626087 = makeNative(41, clofun8, 0, 3, closureRef(co, 1), closureRef(co, 2), closureRef(co, 0));
+Obj x140421013107111 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013107111) {
+Obj x140421013107943 = PRIM_CAR(closureRef(co, 0));
+Obj op = x140421013107943;
+Obj x140421013108647 = PRIM_CDR(closureRef(co, 0));
+Obj args = x140421013108647;
+pushCont(co, 34, clofun8, 3, op, args, x140421013626087);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[109]);
+__arg1 = op;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label34:
+{
+Obj x140421013108935 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013626087= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == x140421013108935) {
+pushCont(co, 35, clofun8, 2, op, args);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[105]);
+__arg1 = op;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013626087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12417,150 +12210,695 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj x139886475982791 = __arg1;
-Obj x139886475982823 = __arg2;
-Obj x139886475982887 = __arg3;
-Obj x139886475332295 = PRIM_EQ(Nil, x139886475982887);
-if (True == x139886475332295) {
+Obj x140421013109095 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj required = x140421013109095;
+pushCont(co, 36, clofun8, 3, required, op, args);
 __nargs = 2;
-__arg1 = x139886475982823;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886475332455 = PRIM_ISCONS(x139886475982887);
-if (True == x139886475332455) {
-Obj x139886475332615 = PRIM_CAR(x139886475982887);
-Obj x = x139886475332615;
-Obj x139886475332775 = PRIM_CDR(x139886475982887);
-Obj y = x139886475332775;
-pushCont(co, 36, clofun8, 2, x139886475982791, y);
-__nargs = 3;
-__arg0 = x139886475982791;
-__arg1 = x139886475982823;
-__arg2 = x;
+__arg0 = globalRef(__symbolTable[96]);
+__arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 label36:
 {
-Obj x139886475332935 = __arg1;
-Obj x139886475982791= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-__nargs = 4;
-__arg0 = globalRef(symcora_47lib_47toc_35foldl);
-__arg1 = x139886475982791;
-__arg2 = x139886475332935;
-__arg3 = y;
+Obj x140421013109895 = __arg1;
+Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj provided = x140421013109895;
+Obj x140421013110151 = PRIM_EQ(required, provided);
+if (True == x140421013110151) {
+Obj x140421013110439 = makeCons(op, Nil);
+Obj x140421013110471 = makeCons(__symbolTable[95], x140421013110439);
+pushCont(co, 39, clofun8, 2, args, x140421013110471);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj x140421013090439 = PRIM_GT(required, provided);
+if (True == x140421013090439) {
+Obj x140421013090695 = PRIM_SUB(required, provided);
+pushCont(co, 37, clofun8, 2, op, args);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[103]);
+__arg1 = x140421013090695;
+__arg2 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("primitive call mismatch");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label37:
 {
-Obj x139886476186887 = __arg1;
-Obj x139886476186919 = __arg2;
-Obj x139886475386759 = PRIM_EQ(Nil, x139886476186919);
-if (True == x139886475386759) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj x139886476147015 = makeNative(38, clofun8, 0, 2, x139886476186919, x139886476186887);
-Obj x139886475330503 = PRIM_ISCONS(x139886476186919);
-if (True == x139886475330503) {
-Obj x139886475330727 = PRIM_CAR(x139886476186919);
-Obj x139886475330759 = PRIM_ISCONS(x139886475330727);
-if (True == x139886475330759) {
-Obj x139886475330983 = PRIM_CAR(x139886476186919);
-Obj x139886475331015 = PRIM_CAR(x139886475330983);
-Obj x = x139886475331015;
-Obj x139886475331271 = PRIM_CAR(x139886476186919);
-Obj x139886475331303 = PRIM_CDR(x139886475331271);
-Obj y = x139886475331303;
-Obj x139886475331463 = PRIM_CDR(x139886476186919);
-Obj x139886475331623 = PRIM_EQ(x139886476186887, x);
-if (True == x139886475331623) {
-Obj x139886475331719 = makeCons(x, y);
-__nargs = 2;
-__arg1 = x139886475331719;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != clofun8) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = x139886476147015;
+Obj x140421013090727 = __arg1;
+Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj tmp = x140421013090727;
+Obj x140421013091207 = makeCons(op, args);
+pushCont(co, 38, clofun8, 1, tmp);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[93]);
+__arg1 = x140421013091207;
+__arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = x139886476147015;
+
+label38:
+{
+Obj x140421013091239 = __arg1;
+Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013091271 = makeCons(x140421013091239, Nil);
+Obj x140421013091303 = makeCons(tmp, x140421013091271);
+Obj x140421013091335 = makeCons(__symbolTable[94], x140421013091303);
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+__arg3 = x140421013091335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = x139886476147015;
+
+label39:
+{
+Obj x140421013110695 = __arg1;
+Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013110471= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 40, clofun8, 1, x140421013110471);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421013110695;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label40:
+{
+Obj x140421013110727 = __arg1;
+Obj x140421013110471= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj x140421013110759 = makeCons(x140421013110471, x140421013110727);
+__nargs = 2;
+__arg1 = x140421013110759;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label41:
+{
+PUSH_CONT_0(co, 42, clofun8);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[102]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label42:
+{
+Obj x140421013274183 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[97]);
+__arg1 = x140421013274183;
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label43:
+{
+Obj x140421013272583 = __arg1;
+if (True == x140421013272583) {
+__nargs = 2;
+__arg1 = closureRef(co, 0);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+PUSH_CONT_0(co, 44, clofun8);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[99]);
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label44:
+{
+Obj x140421013272839 = __arg1;
+Obj x140421013273031 = makeCons(closureRef(co, 0), Nil);
+Obj x140421013273063 = makeCons(__symbolTable[98], x140421013273031);
+__nargs = 2;
+__arg1 = x140421013273063;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label45:
+{
+Obj x140421013680967 = __arg1;
+Obj x140421013680999 = __arg2;
+Obj x140421013271047 = PRIM_EQ(MAKE_NUMBER(0), x140421013680967);
+if (True == x140421013271047) {
+__nargs = 2;
+__arg1 = x140421013680999;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013271207 = PRIM_SUB(x140421013680967, MAKE_NUMBER(1));
+Obj x140421013271367 = primGenSym();
+Obj x140421013271399 = makeCons(x140421013271367, x140421013680999);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[103]);
+__arg1 = x140421013271207;
+__arg2 = x140421013271399;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label46:
+{
+Obj x = __arg1;
+PUSH_CONT_0(co, 47, clofun8);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[133]);
+__arg1 = x;
+__arg2 = globalRef(__symbolTable[127]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label47:
+{
+Obj x140421013393319 = __arg1;
+Obj find = x140421013393319;
+pushCont(co, 48, clofun8, 1, find);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label48:
+{
+Obj x140421013270599 = __arg1;
+Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421013270599) {
+__nargs = 2;
+__arg1 = makeCString("ERROR");
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun8) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[104]);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label49:
+{
+Obj x = __arg1;
+PUSH_CONT_0(co, 0, clofun9);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[133]);
+__arg1 = x;
+__arg2 = globalRef(__symbolTable[127]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+static void clofun9(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj x140421013392711 = __arg1;
+Obj find = x140421013392711;
+pushCont(co, 1, clofun9, 1, find);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj x140421013392871 = __arg1;
+Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == x140421013392871) {
+__nargs = 2;
+__arg1 = makeCString("ERROR");
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[106]);
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj x = __arg1;
+PUSH_CONT_0(co, 3, clofun9);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[133]);
+__arg1 = x;
+__arg2 = globalRef(__symbolTable[127]);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj x140421013392263 = __arg1;
+PUSH_CONT_0(co, 4, clofun9);
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[108]);
+__arg1 = x140421013392263;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj x140421013392295 = __arg1;
+Obj x140421013392327 = primNot(x140421013392295);
+__nargs = 2;
+__arg1 = x140421013392327;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj x140421012994215 = __arg1;
+Obj x140421012994279 = __arg2;
+Obj x140421013564423 = PRIM_EQ(Nil, x140421012994279);
+if (True == x140421013564423) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013564583 = PRIM_ISCONS(x140421012994279);
+if (True == x140421013564583) {
+Obj x140421013564743 = PRIM_CAR(x140421012994279);
+Obj hd = x140421013564743;
+Obj x140421013564903 = PRIM_CDR(x140421012994279);
+Obj tl = x140421013564903;
+pushCont(co, 6, clofun9, 2, x140421012994215, tl);
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[129]);
+__arg1 = x140421012994215;
+__arg2 = hd;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label38:
+label6:
 {
-Obj x139886475329735 = PRIM_ISCONS(closureRef(co, 0));
-if (True == x139886475329735) {
-Obj x139886475329927 = PRIM_CAR(closureRef(co, 0));
-Obj x139886475330151 = PRIM_CDR(closureRef(co, 0));
-Obj y = x139886475330151;
+Obj x140421013565127 = __arg1;
+Obj x140421012994215= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj x140421013565159 = PRIM_LT(x140421013565127, MAKE_NUMBER(0));
+if (True == x140421013565159) {
 __nargs = 3;
-__arg0 = globalRef(symcora_47lib_47toc_35assq);
+__arg0 = globalRef(__symbolTable[128]);
+__arg1 = x140421012994215;
+__arg2 = tl;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label7:
+{
+Obj x = __arg1;
+Obj l = __arg2;
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[130]);
+__arg1 = MAKE_NUMBER(0);
+__arg2 = x;
+__arg3 = l;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj x140421013093799 = __arg1;
+Obj x140421013093927 = __arg2;
+Obj x140421013093959 = __arg3;
+Obj x140421013561351 = PRIM_EQ(Nil, x140421013093959);
+if (True == x140421013561351) {
+__nargs = 2;
+__arg1 = MAKE_NUMBER(-1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421012992519 = makeNative(9, clofun9, 0, 3, x140421013093959, x140421013093799, x140421013093927);
+Obj x140421013562919 = PRIM_ISCONS(x140421013093959);
+if (True == x140421013562919) {
+Obj x140421013563175 = PRIM_CAR(x140421013093959);
+Obj a = x140421013563175;
+Obj x140421013563399 = PRIM_CDR(x140421013093959);
+Obj x140421013563591 = PRIM_EQ(x140421013093927, a);
+if (True == x140421013563591) {
+__nargs = 2;
+__arg1 = x140421013093799;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421012992519;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421012992519;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label9:
+{
+Obj x140421013561831 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013561831) {
+Obj x140421013562151 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013562343 = PRIM_CDR(closureRef(co, 0));
+Obj b = x140421013562343;
+Obj x140421013562567 = PRIM_ADD(closureRef(co, 1), MAKE_NUMBER(1));
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[130]);
+__arg1 = x140421013562567;
+__arg2 = closureRef(co, 2);
+__arg3 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label10:
+{
+Obj x140421013091815 = __arg1;
+Obj x140421013091879 = __arg2;
+Obj x140421013091943 = __arg3;
+Obj x140421013625479 = PRIM_EQ(Nil, x140421013091943);
+if (True == x140421013625479) {
+__nargs = 2;
+__arg1 = x140421013091879;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013625703 = PRIM_ISCONS(x140421013091943);
+if (True == x140421013625703) {
+Obj x140421013625927 = PRIM_CAR(x140421013091943);
+Obj x = x140421013625927;
+Obj x140421013626151 = PRIM_CDR(x140421013091943);
+Obj y = x140421013626151;
+pushCont(co, 11, clofun9, 2, x140421013091815, y);
+__nargs = 3;
+__arg0 = x140421013091815;
+__arg1 = x140421013091879;
+__arg2 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(__symbolTable[132]);
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label11:
+{
+Obj x140421013626375 = __arg1;
+Obj x140421013091815= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+__nargs = 4;
+__arg0 = globalRef(__symbolTable[131]);
+__arg1 = x140421013091815;
+__arg2 = x140421013626375;
+__arg3 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj x140421013110375 = __arg1;
+Obj x140421013110407 = __arg2;
+Obj x140421013682535 = PRIM_EQ(Nil, x140421013110407);
+if (True == x140421013682535) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj x140421013090567 = makeNative(13, clofun9, 0, 2, x140421013110407, x140421013110375);
+Obj x140421013684103 = PRIM_ISCONS(x140421013110407);
+if (True == x140421013684103) {
+Obj x140421013623399 = PRIM_CAR(x140421013110407);
+Obj x140421013623431 = PRIM_ISCONS(x140421013623399);
+if (True == x140421013623431) {
+Obj x140421013623847 = PRIM_CAR(x140421013110407);
+Obj x140421013623879 = PRIM_CAR(x140421013623847);
+Obj x = x140421013623879;
+Obj x140421013624135 = PRIM_CAR(x140421013110407);
+Obj x140421013624167 = PRIM_CDR(x140421013624135);
+Obj y = x140421013624167;
+Obj x140421013624327 = PRIM_CDR(x140421013110407);
+Obj x140421013624615 = PRIM_EQ(x140421013110375, x);
+if (True == x140421013624615) {
+Obj x140421013624711 = makeCons(x, y);
+__nargs = 2;
+__arg1 = x140421013624711;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun9) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = x140421013090567;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013090567;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = x140421013090567;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label13:
+{
+Obj x140421013683079 = PRIM_ISCONS(closureRef(co, 0));
+if (True == x140421013683079) {
+Obj x140421013683399 = PRIM_CAR(closureRef(co, 0));
+Obj x140421013683623 = PRIM_CDR(closureRef(co, 0));
+Obj y = x140421013683623;
+__nargs = 3;
+__arg0 = globalRef(__symbolTable[133]);
 __arg1 = closureRef(co, 1);
 __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
-__arg0 = globalRef(symcora_47lib_47toc_35error);
+__arg0 = globalRef(__symbolTable[132]);
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -212,18 +212,18 @@
 	(k tmp)]))
 
   (func generate-call-list
-	self w i [] => ()
-	self w i [x . more] => (begin
-				 (if (not (> i 3))
-				     (begin (generate-str w "__arg")
-					    (generate-num w i))
-				     (begin (generate-str w "co->args[")
-					    (generate-num w i)
-					    (generate-str w "]")))
-				 (generate-str w " = ")
-				 (generate-inst self () w x)
-				 (generate-str w ";\n")
-				 (generate-call-list self w (+ i 1) more)))
+	globals self w i [] => ()
+	globals self w i [x . more] => (begin
+					(if (not (> i 3))
+					    (begin ( generate-str w "__arg")
+						   (generate-num w i))
+					    (begin (generate-str w "co->args[")
+						   (generate-num w i)
+						   (generate-str w "]")))
+					(generate-str w " = ")
+					(generate-inst globals self () w x)
+					(generate-str w ";\n")
+					(generate-call-list globals self w (+ i 1) more)))
 
   (defun add-symbol-to-list (sym globals)
     (let val (value globals)
@@ -231,139 +231,149 @@
 	  ()
 	  (set globals (cons sym val)))))
 
-  (defun generate-inst (self env1 w x1)
-    (begin
+  (defun generate-inst (globals self env1 w x1)
+    (let generate-inst-h (gensym) 
+	 (begin
 
-     (func generate-inst-h
-	   x env => (generate-sym w x) where (symbol? x)
-	   ['%global x] env => (begin
-				(generate-str w "globalRef(sym")
-				(generate-sym w x)
-				(generate-str w ")"))
-	   ['%closure-ref idx] env => (begin
-				       (generate-str w "closureRef(co, ")
-				       (generate-num w idx)
-				       (generate-str w ")"))
-	   ['%stack-ref idx] env => (begin
-				     (generate-str w "stackRef(co, ")
-				     (generate-num w idx)
-				     (generate-str w ")"))
-	   ['%const x] env => (cond
-				((symbol? x) (begin
-					      (generate-str w "sym")
-					      (generate-sym w x)))
-				((number? x) (begin
-					      (generate-str w "MAKE_NUMBER(")
-					      (generate-num w x)
-					      (generate-str w ")")))
-				((string? x) (begin
-					      (generate-str w "makeCString(\"")
-					      (generate-str w (escape-str x))
-					      (generate-str w "\")")))
-				((= x ()) (generate-str w "Nil"))
-				((= x true) (generate-str w "True"))
-				((= x false) (generate-str w "False")))
-	   ['let a b c] env => (let idx (index a env)
-				    (begin
-				     (if (< idx 0) (generate-str w "Obj ") ())
-				     (generate-sym w a)
-				     (generate-str w " = ")
-				     (generate-inst-h b env)
-				     (generate-str w ";\n")
-				     (generate-inst-h c (cons a env))))
-	   [['%builtin f] . args] env => (begin
-					  (generate-str w (builtin->name f))
-					  (if (= f 'set)
-					      (generate-str w "(co, ")
-					      (generate-str w "("))
-					  (generate-inst-list self env w args)
+	  (set generate-inst-h
+	       (lambda (x2 env)
+		 (if (symbol? x2)
+		     (generate-sym w x2)
+		     (match x2
+			    ['%global x] (begin
+					  (generate-str w "globalRef(sym")
+					  (generate-sym w x)
 					  (generate-str w ")"))
-	   ['if a b c] env => (begin
-			       (generate-str w "if (True == ")
-			       (generate-inst-h a env)
-			       (generate-str w ") {\n")
-			       (generate-inst-h b env)
-			       (generate-str w "} else {\n")
-			       (generate-inst-h c env)
-			       (generate-str w "}\n"))
-	   ['%closure label nargs . frees] env => (begin
-						   (generate-str w "makeNative(")
-						   (generate-num w (mod (- (car self) label) *mod-num*))
-						   (generate-str w ", ")
-						   (generate-group-name w label (car self))
-						   (generate-str w ", ")
-						   (generate-num w nargs)
-						   (generate-str w ", ")
-						   (generate-num w (length frees))
-						   (if (not (null? frees))
-						       (begin
-							(generate-str w ", ")
-							(generate-inst-list self env w frees))
-						       ())
-						   (generate-str w ")"))
-	   ['do a b] env => (begin
-			     (generate-inst-h a env)
-			     (generate-str w ";\n")
-			     (generate-inst-h b env))
-	   ['return x] env => (begin
-			       (generate-str w "__nargs = 2;\n")
-			       (generate-str w "__arg1 = ")
-			       (generate-inst-h x env)
-			       (generate-str w ";\n")
-			       (generate-str w "co->ctx = co->callstack.data[--co->callstack.len];\n")
-			       (generate-str w "if (co->ctx.pc.func != ")
-			       (generate-group-name w (cdr self) (car self))
-			       (generate-str w ") { goto fail; }\n")
-			       (generate-str w "goto *jumpTable[co->ctx.pc.label];\n"))
-	   ['tailcall exp] env => (generate-inst-h exp env)
-	   ['call exp cont] env => (begin
-				    (generate-cont self w cont)
-				    (generate-inst-h exp env))
-	   [f . args] env => (begin
-			      (generate-str w "__nargs = ")
-			      (generate-num w (+ 1 (length args)))
-			      (generate-str w ";\n")
-			      (generate-call-list self w 0 [f . args])
-			      (generate-str w "co->ctx.frees = __arg0;\n")
-			      (generate-str w "struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n")
-			      (generate-str w "if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n")
-			      (generate-str w "if (ps.func != ")
-			      (generate-group-name w (cdr self) (car self))
-			      (generate-str w ") { co->ctx.pc = ps; goto fail; };\n")
-			      (generate-str w "goto *jumpTable[ps.label];\n")))
+			    ['%closure-ref idx] (begin
+						 (generate-str w "closureRef(co, ")
+						 (generate-num w idx)
+						 (generate-str w ")"))
+			    ['%stack-ref idx] (begin
+					       (generate-str w "stackRef(co, ")
+					       (generate-num w idx)
+					       (generate-str w ")"))
+			    ['%const x] (cond
+					  ((symbol? x) (begin
+							(generate-str w "sym")
+							(generate-sym w x)))
+					  ((number? x) (begin
+							(generate-str w "MAKE_NUMBER(")
+							(generate-num w x)
+							(generate-str w ")")))
+					  ((string? x) (begin
+							(generate-str w "makeCString(\"")
+							(generate-str w (escape-str x))
+							(generate-str w "\")")))
+					  ((= x ()) (generate-str w "Nil"))
+					  ((= x true) (generate-str w "True"))
+					  ((= x false) (generate-str w "False")))
+			    ['let a b c] (let idx (index a env)
+					      (begin
+					       (if (< idx 0) (generate-str w "Obj ") ())
+					       (generate-sym w a)
+					       (generate-str w " = ")
+					       ((value generate-inst-h) b env)
+					       (generate-str w ";\n")
+					       ((value generate-inst-h) c (cons a env))))
+			    [['%builtin f] . args] (begin
+						    (generate-str w (builtin->name f))
+						    (if (= f 'set)
+							(generate-str w "(co, ")
+							(generate-str w "("))
+						    (generate-inst-list globals self env w args)
+						    (generate-str w ")"))
+			    ['if a b c] (begin
+					 (generate-str w "if (True == ")
+					 ((value generate-inst-h) a env)
+					 (generate-str w ") {\n")
+					 ((value generate-inst-h) b env)
+					 (generate-str w "} else {\n")
+					 ((value generate-inst-h) c env)
+					 (generate-str w "}\n"))
+			    ['%closure label nargs . frees] (begin
+							     (generate-str w "makeNative(")
+							     (generate-num w (mod (- (car self) label) *mod-num*))
+							     (generate-str w ", ")
+							     (generate-group-name w label (car self))
+							     (generate-str w ", ")
+							     (generate-num w nargs)
+							     (generate-str w ", ")
+							     (generate-num w (length frees))
+							     (if (not (null? frees))
+								 (begin
+								  (generate-str w ", ")
+								  (generate-inst-list globals self env w frees))
+								 ())
+							     (generate-str w ")"))
+			    ['do a b] (begin
+				       ((value generate-inst-h) a env)
+				       (generate-str w ";\n")
+				       ((value generate-inst-h) b env))
+			    ['return x] (begin
+					 (generate-str w "__nargs = 2;\n")
+					 (generate-str w "__arg1 = ")
+					 ((value generate-inst-h) x env)
+					 (generate-str w ";\n")
+					 (generate-str w "co->ctx = co->callstack.data[--co->callstack.len];\n")
+					 (generate-str w "if (co->ctx.pc.func != ")
+					 (generate-group-name w (cdr self) (car self))
+					 (generate-str w ") { goto fail; }\n")
+					 (generate-str w "goto *jumpTable[co->ctx.pc.label];\n"))
+			    ['tailcall exp] ((value generate-inst-h) exp env)
+			    ['call exp cont] (begin
+					      (generate-cont globals self env w cont)
+					      ((value generate-inst-h) exp env))
+			    [f . args] (begin
+					(generate-str w "__nargs = ")
+					(generate-num w (+ 1 (length args)))
+					(generate-str w ";\n")
+					(generate-call-list globals self w 0 [f . args])
+					(generate-str w "co->ctx.frees = __arg0;\n")
+					(generate-str w "struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n")
+					(generate-str w "if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n")
+					(generate-str w "if (ps.func != ")
+					(generate-group-name w (cdr self) (car self))
+					(generate-str w ") { co->ctx.pc = ps; goto fail; };\n")
+					(generate-str w "goto *jumpTable[ps.label];\n"))))))
 
-     (generate-inst-h x1 env1)))
+	  ((value generate-inst-h) x1 env1))))
+
+  (defun generate-inst-list (globals self env w l)
+    (let generate-inst-list-h (gensym)
+	 (begin
+	  
+	  (set generate-inst-list-h
+	       (lambda (x)
+		 (match x
+			[] ()
+			[a . b] (begin
+				 (generate-inst globals self env w a)
+				 (if (not (null? b))
+				     (generate-str w ", ")
+				     ())
+				 ((value generate-inst-list-h) b)))))
+
+	  ((value generate-inst-list-h) l))))
 
   (func generate-cont
-	self w ['%continuation label . stacks] => (begin
-						    (if (= stacks ())
-							(generate-str w "PUSH_CONT_0(co, ")
-							(generate-str w "pushCont(co, "))
-						    (generate-num w (mod (- (car self) label) *mod-num*))
-						    (generate-str w ", ")
-						    (generate-group-name w label (car self))
-						    (if (= stacks ())
-							()
-							(begin
-							  (generate-str w ", ")
-							  (generate-num w (length stacks))
-							  (for-each (lambda (x)
-								      (begin
-									(generate-str w ", ")
-									(generate-inst self () w x)))
-								    stacks)))
-						    (generate-str w ");\n")))
-
-  (func generate-inst-list-h
-	self env fn w [] => ()
-	self env fn w [a . b] => (begin (fn self env w a)
-					(if (not (null? b))
-					    (generate-str w ", ")
-					    ())
-					(generate-inst-list-h self env fn w b)))
-
-  (defun generate-inst-list (self env w l)
-    (generate-inst-list-h self env generate-inst w l))
+	globals self env w ['%continuation label . stacks] => (begin
+							       (if (= stacks ())
+								   (generate-str w "PUSH_CONT_0(co, ")
+								   (generate-str w "pushCont(co, "))
+							       (generate-num w (mod (- (car self) label) *mod-num*))
+							       (generate-str w ", ")
+							       (generate-group-name w label (car self))
+							       (if (= stacks ())
+								   ()
+								   (begin
+								    (generate-str w ", ")
+								    (generate-num w (length stacks))
+								    (for-each (lambda (x)
+										(begin
+										 (generate-str w ", ")
+										 (generate-inst globals self () w x)))
+									      stacks)))
+							       (generate-str w ");\n")))
 
   (def *mod-num* 50)
 
@@ -383,7 +393,7 @@
   (defun local-from-params (w i var)
     (begin
       (generate-str w "Obj ")
-      (generate-inst 'ignore () w var)
+      (generate-inst () 'ignore () w var)
       (if (< i 4)
 	  (begin (generate-str w " = __arg")
 		 (generate-num w i)
@@ -395,7 +405,7 @@
   (defun local-from-cont (w i var)
     (begin
       (generate-str w "Obj ")
-      (generate-inst 'ignore () w var)
+      (generate-inst () 'ignore () w var)
       (generate-str w  "= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + ")
       (generate-num w i)
       (generate-str w "];\n")))
@@ -407,17 +417,17 @@
 			      (generate-call-args-reverse fn w (+ idx 1) b)))
 
   (func code-gen-toplevel
-	w [label ['lambda params actives body]] maxid => (begin
-							   (generate-str w "label")
-							   (generate-num w (mod (- maxid label) *mod-num*))
-							   (generate-str w ":\n{\n")
-							   (generate-call-args-reverse local-from-params w 1 params)
-							   (generate-call-args-reverse local-from-cont w 0 actives)
-							   (generate-inst (cons maxid label) params w body)
-							   (generate-str w "}\n\n"))
-	w other maxid =>  (begin (display "wrong format of toplevel\n")
-				 (display other)
-				 (display "\n")))
+	w [label ['lambda params actives body]] maxid globals => (begin
+								  (generate-str w "label")
+								  (generate-num w (mod (- maxid label) *mod-num*))
+								  (generate-str w ":\n{\n")
+								  (generate-call-args-reverse local-from-params w 1 params)
+								  (generate-call-args-reverse local-from-cont w 0 actives)
+								  (generate-inst globals (cons maxid label) params w body)
+								  (generate-str w "}\n\n"))
+	w other maxid globals =>  (begin (display "wrong format of toplevel\n")
+					 (display other)
+					 (display "\n")))
 
   (defun parse-pass (globals exp)
     (parse [] globals exp))
@@ -474,7 +484,7 @@
 		(generate-jumptable to (+ i 1) n)))
      (true ())))
 
-  (defun generate-toplevel-group (to group maxid)
+  (defun generate-toplevel-group (to group maxid globals)
     (begin
       (code-gen-func-declare to (caar group) maxid)
       (generate-str to "{\n")
@@ -490,7 +500,7 @@
       (generate-str to "};\n\n")
       (generate-str to "goto *jumpTable[co->ctx.pc.label];\n\n")
 
-      (for-each (lambda (x) (code-gen-toplevel to x maxid)) group)
+      (for-each (lambda (x) (code-gen-toplevel to x maxid globals)) group)
 
       (generate-str to "fail:\n")
       (generate-str to "co->nargs = __nargs;\n")
@@ -532,7 +542,7 @@
 		    (generate-str to "\");\n")
 		    (+ acc 1)))
 	     0 globals)
-      (generate-str to "clofun0(co);\n}\n")))
+      (generate-str to "clofun0(co);\n}\n\n")))
 
   (defun generate-c (to bc globals)
     (let groups (group-by-mod-h [] 0 [] bc)
@@ -548,7 +558,7 @@
 	(generate-str to "\n\n")
 	(generate-entry to (value globals))
 	(for-each (lambda (group)
-		    (generate-toplevel-group to group maxid))
+		    (generate-toplevel-group to group maxid globals))
 		  groups))))
 
   (func handle-import-eagerly

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -231,115 +231,108 @@
 	  ()
 	  (set globals (cons sym val)))))
 
-  (defun generate-inst (self env w x1)
-    (if (symbol? x1)
-	(generate-sym w x1)
-	(match x1
-	  ['%global x] (begin
-			 (generate-str w "globalRef(sym")
-			 (generate-sym w x)
-			 (generate-str w ")"))
-	  ['%closure-ref idx] (begin
-				(generate-str w "closureRef(co, ")
-				(generate-num w idx)
-				(generate-str w ")"))
-	  ['%stack-ref idx] (begin
-			      (generate-str w "stackRef(co, ")
-			      (generate-num w idx)
-			      (generate-str w ")"))
-	  ['%const x] (cond
-		       ((symbol? x) (begin
-				      (generate-str w "sym")
-				      (generate-sym w x)))
-		       ((number? x) (begin
-				      (generate-str w "MAKE_NUMBER(")
-				      (generate-num w x)
-				      (generate-str w ")")))
-		       ((string? x) (begin
-				      (generate-str w "makeCString(\"")
-				      (generate-str w (escape-str x))
-				      (generate-str w "\")")))
-		       ((= x ()) (generate-str w "Nil"))
-		       ((= x true) (generate-str w "True"))
-		       ((= x false) (generate-str w "False")))
-	  ['let a b c] (let idx (index a env)
-			 (begin
-			   (if (< idx 0) (generate-str w "Obj ") ())
-			   (generate-sym w a)
-			   (generate-str w " = ")
-			   (generate-inst self env w b)
-			   (generate-str w ";\n")
-			   (generate-inst self (cons a env) w c)))
-	  [['%builtin f] . args] (begin
-				   (generate-str w (builtin->name f))
-				   (if (= f 'set)
-				       (generate-str w "(co, ")
-				       (generate-str w "("))
-				   (generate-inst-list self env w args)
-				   (generate-str w ")"))
-	  ['if a b c] (begin
-			(generate-str w "if (True == ")
-			(generate-inst self env w a)
-			(generate-str w ") {\n")
-			(generate-inst self env w b)
-			(generate-str w "} else {\n")
-			(generate-inst self env w c)
-			(generate-str w "}\n"))
-	  ['%closure label nargs . frees] (begin
-					    (generate-str w "makeNative(")
-					    (generate-num w (mod (- (car self) label) *mod-num*))
-					    (generate-str w ", ")
-					    (generate-group-name w label (car self))
-					    (generate-str w ", ")
-					    (generate-num w nargs)
-					    (generate-str w ", ")
-					    (generate-num w (length frees))
-					    (if (not (null? frees))
-						(begin
-						  (generate-str w ", ")
-						  (generate-inst-list self env w frees))
-						())
-					    (generate-str w ")"))
-	  ['do a b] (begin
-		      (generate-inst self env w a)
-		      (generate-str w ";\n")
-		      (generate-inst self env w b))
-	  ['return x] (begin
-			(generate-str w "__nargs = 2;\n")
-			(generate-str w "__arg1 = ")
-			(generate-inst self env w x)
-			(generate-str w ";\n")
-			(generate-str w "co->ctx = co->callstack.data[--co->callstack.len];\n")
-			(generate-str w "if (co->ctx.pc.func != ")
-			(generate-group-name w (cdr self) (car self))
-			(generate-str w ") { goto fail; }\n")
-			(generate-str w "goto *jumpTable[co->ctx.pc.label];\n"))
-	  ['tailcall exp] (generate-inst self env w exp)
-	  ['call exp cont] (begin
-			     (generate-cont self w cont)
-			     (generate-inst self env w exp))
-	  [f . args] (begin
-		       (generate-str w "__nargs = ")
-		       (generate-num w (+ 1 (length args)))
-		       (generate-str w ";\n")
-		       (generate-call-list self w 0 [f . args])
-		       (generate-str w "co->ctx.frees = __arg0;\n")
-		       (generate-str w "struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n")
-		       (generate-str w "if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n")
-		       (generate-str w "if (ps.func != ")
-		       (generate-group-name w (cdr self) (car self))
-		       (generate-str w ") { co->ctx.pc = ps; goto fail; };\n")
-		       (generate-str w "goto *jumpTable[ps.label];\n")))))
+  (defun generate-inst (self env1 w x1)
+    (begin
 
-  ;; (func .generate-call-args
-  ;;       env w idx [] => ()
-  ;;       env w idx [a . b] => (begin
-  ;; 			    (generate-str w "co->args[")
-  ;; 			    (generate-num w idx)
-  ;; 			    (generate-str w "] = ")
-  ;; 			    (generate-inst env w a)
-  ;; 			    (generate-str w ";\n")
-  ;; 			    (.generate-call-args env w (+ idx 1) b)))
+     (func generate-inst-h
+	   x env => (generate-sym w x) where (symbol? x)
+	   ['%global x] env => (begin
+				(generate-str w "globalRef(sym")
+				(generate-sym w x)
+				(generate-str w ")"))
+	   ['%closure-ref idx] env => (begin
+				       (generate-str w "closureRef(co, ")
+				       (generate-num w idx)
+				       (generate-str w ")"))
+	   ['%stack-ref idx] env => (begin
+				     (generate-str w "stackRef(co, ")
+				     (generate-num w idx)
+				     (generate-str w ")"))
+	   ['%const x] env => (cond
+				((symbol? x) (begin
+					      (generate-str w "sym")
+					      (generate-sym w x)))
+				((number? x) (begin
+					      (generate-str w "MAKE_NUMBER(")
+					      (generate-num w x)
+					      (generate-str w ")")))
+				((string? x) (begin
+					      (generate-str w "makeCString(\"")
+					      (generate-str w (escape-str x))
+					      (generate-str w "\")")))
+				((= x ()) (generate-str w "Nil"))
+				((= x true) (generate-str w "True"))
+				((= x false) (generate-str w "False")))
+	   ['let a b c] env => (let idx (index a env)
+				    (begin
+				     (if (< idx 0) (generate-str w "Obj ") ())
+				     (generate-sym w a)
+				     (generate-str w " = ")
+				     (generate-inst-h b env)
+				     (generate-str w ";\n")
+				     (generate-inst-h c (cons a env))))
+	   [['%builtin f] . args] env => (begin
+					  (generate-str w (builtin->name f))
+					  (if (= f 'set)
+					      (generate-str w "(co, ")
+					      (generate-str w "("))
+					  (generate-inst-list self env w args)
+					  (generate-str w ")"))
+	   ['if a b c] env => (begin
+			       (generate-str w "if (True == ")
+			       (generate-inst-h a env)
+			       (generate-str w ") {\n")
+			       (generate-inst-h b env)
+			       (generate-str w "} else {\n")
+			       (generate-inst-h c env)
+			       (generate-str w "}\n"))
+	   ['%closure label nargs . frees] env => (begin
+						   (generate-str w "makeNative(")
+						   (generate-num w (mod (- (car self) label) *mod-num*))
+						   (generate-str w ", ")
+						   (generate-group-name w label (car self))
+						   (generate-str w ", ")
+						   (generate-num w nargs)
+						   (generate-str w ", ")
+						   (generate-num w (length frees))
+						   (if (not (null? frees))
+						       (begin
+							(generate-str w ", ")
+							(generate-inst-list self env w frees))
+						       ())
+						   (generate-str w ")"))
+	   ['do a b] env => (begin
+			     (generate-inst-h a env)
+			     (generate-str w ";\n")
+			     (generate-inst-h b env))
+	   ['return x] env => (begin
+			       (generate-str w "__nargs = 2;\n")
+			       (generate-str w "__arg1 = ")
+			       (generate-inst-h x env)
+			       (generate-str w ";\n")
+			       (generate-str w "co->ctx = co->callstack.data[--co->callstack.len];\n")
+			       (generate-str w "if (co->ctx.pc.func != ")
+			       (generate-group-name w (cdr self) (car self))
+			       (generate-str w ") { goto fail; }\n")
+			       (generate-str w "goto *jumpTable[co->ctx.pc.label];\n"))
+	   ['tailcall exp] env => (generate-inst-h exp env)
+	   ['call exp cont] env => (begin
+				    (generate-cont self w cont)
+				    (generate-inst-h exp env))
+	   [f . args] env => (begin
+			      (generate-str w "__nargs = ")
+			      (generate-num w (+ 1 (length args)))
+			      (generate-str w ";\n")
+			      (generate-call-list self w 0 [f . args])
+			      (generate-str w "co->ctx.frees = __arg0;\n")
+			      (generate-str w "struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n")
+			      (generate-str w "if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n")
+			      (generate-str w "if (ps.func != ")
+			      (generate-group-name w (cdr self) (car self))
+			      (generate-str w ") { co->ctx.pc = ps; goto fail; };\n")
+			      (generate-str w "goto *jumpTable[ps.label];\n")))
+
+     (generate-inst-h x1 env1)))
 
   (func generate-cont
 	self w ['%continuation label . stacks] => (begin
@@ -518,19 +511,27 @@
 
   (defun generate-entry (to globals)
     (begin
-      (for-each (lambda (sym)
-		  (begin
-		    (generate-str to "static Obj sym")
-		    (generate-sym to sym)
-		    (generate-str to ";\n"))) globals)
+     (generate-str to "__global static Obj* __symbolTable;\n\n")
+      ;; (for-each (lambda (sym)
+      ;; 		  (begin
+      ;; 		    (generate-str to "static Obj sym")
+      ;; 		    (generate-sym to sym)
+      ;; 		    (generate-str to ";\n"))) globals)
       (generate-str to "void entry(struct Cora *co) {\n")
-      (for-each (lambda (sym)
+      (generate-str to "__symbolTable = (Obj*)malloc(sizeof(Obj) * ")
+      (generate-num to (length globals))
+      (generate-str to ");\n")
+      (foldl (lambda (acc sym)
 		  (begin
-		    (generate-str to "sym")
-		    (generate-sym to sym)
-		    (generate-str to " = intern(\"")
+		   (generate-str to "__symbolTable[")
+		   (generate-num to acc)
+		    ;; (generate-str to "sym")
+		    ;; (generate-sym to sym)
+		    (generate-str to "] = intern(\"")
 		    (generate-str to (symbol->string sym))
-		    (generate-str to "\");\n"))) globals)
+		    (generate-str to "\");\n")
+		    (+ acc 1)))
+	     0 globals)
       (generate-str to "clofun0(co);\n}\n")))
 
   (defun generate-c (to bc globals)

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -231,6 +231,15 @@
 	  ()
 	  (set globals (cons sym val)))))
 
+  (defun symbol-offset-h (idx sym globals)
+    (cond
+      ((null? globals) -1)
+      ((= sym (car globals)) idx)
+      (true (symbol-offset-h (+ idx 1) sym (cdr globals)))))
+
+  (defun symbol-offset (sym globals)
+    (symbol-offset-h 0 sym globals))
+
   (defun generate-inst (globals self env1 w x1)
     (let generate-inst-h (gensym) 
 	 (begin
@@ -241,9 +250,9 @@
 		     (generate-sym w x2)
 		     (match x2
 			    ['%global x] (begin
-					  (generate-str w "globalRef(sym")
-					  (generate-sym w x)
-					  (generate-str w ")"))
+					  (generate-str w "globalRef(__symbolTable[")
+					  (generate-num w (symbol-offset x globals))
+					  (generate-str w "])"))
 			    ['%closure-ref idx] (begin
 						 (generate-str w "closureRef(co, ")
 						 (generate-num w idx)
@@ -254,8 +263,9 @@
 					       (generate-str w ")"))
 			    ['%const x] (cond
 					  ((symbol? x) (begin
-							(generate-str w "sym")
-							(generate-sym w x)))
+							(generate-str w "__symbolTable[")
+							(generate-num w (symbol-offset x globals))
+							(generate-str w "]")))
 					  ((number? x) (begin
 							(generate-str w "MAKE_NUMBER(")
 							(generate-num w x)
@@ -521,7 +531,7 @@
 
   (defun generate-entry (to globals)
     (begin
-     (generate-str to "__global static Obj* __symbolTable;\n\n")
+     (generate-str to "static __thread Obj* __symbolTable;\n\n")
       ;; (for-each (lambda (sym)
       ;; 		  (begin
       ;; 		    (generate-str to "static Obj sym")
@@ -556,7 +566,7 @@
 		      (generate-str to ";\n")))
 		  groups)
 	(generate-str to "\n\n")
-	(generate-entry to (value globals))
+	(generate-entry to globals)
 	(for-each (lambda (group)
 		    (generate-toplevel-group to group maxid globals))
 		  groups))))
@@ -630,7 +640,7 @@
 		    (compile globals))
 	  (let stream (open-output-file to)
 	    (begin
-	      (generate-c stream bc globals)
+	      (generate-c stream bc (value globals))
 	      (close-output-file stream)))))))
 
   )

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,10 @@ ifeq ("${ENABLE_ASAN}", "1")
 	CFLAGS += -fsanitize=address
 endif
 
+ifeq ("${ENABLE_TSAN}", "1")
+	LD_FLAG = -ltsan -lcora -ldl
+endif
+
 all: libcora.so
 
 # test: reader_test bootstrap_test
@@ -26,12 +30,6 @@ gc.test: gc_test.o libcora.a
 
 gc_test: gc.test
 	./gc.test
-
-# eval_test: eval.test
-# 	./eval.test
-
-# eval.test: eval_test.o libcora.a
-# 	$(CC) -o $@ $^ -ldl
 
 # bootstrap_test:bootstrap.test
 # 	./bootstrap.test

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -139,7 +139,7 @@ coraGet(struct Cora *co, int idx) {
 }
 
 extern __thread struct trieNode *gRoot;
-struct Cora *gCo;
+ __thread struct Cora *gCo;
 
 static struct Cora *
 coraNew() {
@@ -163,6 +163,7 @@ coraGCFunc(struct GC *gc, struct Cora *co) {
 	TRACE_SCOPE("coraGCFunc");
 	// The globals
 	for (struct trieNode * p = co->globals; p != gRoot; p = p->next) {
+		assert(p->owner == co);
 		gcMark(gc, p->value, 0);
 	}
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -980,6 +980,19 @@ coraInit(uintptr_t * mark) {
 	return co;
 }
 
+void
+coraExit(struct Cora *co) {
+	// TODO
+	// release GC
+	// release event loop
+	// release scheduler
+	// release packages
+	// release symbol table
+
+	// release cora struct
+	free(co);
+}
+
 #ifdef ForTest
 
 extern void entry(struct Cora *co);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -138,7 +138,7 @@ coraGet(struct Cora *co, int idx) {
 	return co->args[idx];
 }
 
-extern struct trieNode gRoot;
+extern __thread struct trieNode *gRoot;
 struct Cora *gCo;
 
 static struct Cora *
@@ -151,7 +151,7 @@ coraNew() {
 	co->callstack.len = 0;
 	co->callstack.cap = 64;
 
-	co->globals = &gRoot;
+	co->globals = gRoot;
 
 	gCo = co;
 
@@ -162,7 +162,7 @@ static void
 coraGCFunc(struct GC *gc, struct Cora *co) {
 	TRACE_SCOPE("coraGCFunc");
 	// The globals
-	for (struct trieNode * p = co->globals; p != &gRoot; p = p->next) {
+	for (struct trieNode * p = co->globals; p != gRoot; p = p->next) {
 		gcMark(gc, p->value, 0);
 	}
 
@@ -921,8 +921,6 @@ registerAPI(struct Cora *co, struct registerModule *m, str pkg) {
 	}
 }
 
-static bool initialized = false;
-
 struct Cora *
 coraInit(uintptr_t * mark) {
 	gcInit(mark);
@@ -931,55 +929,52 @@ coraInit(uintptr_t * mark) {
 	symBackQuote = intern("backquote");
 	symUnQuote = intern("unquote");
 	struct Cora *co = coraNew();
-	if (!initialized) {
-		primSet(co, intern("symbol->string"),
-			makeNative(0, symbolToString, 1, 0));
-		primSet(co, intern("intern"),
-			makeNative(0, builtinIntern, 1, 0));
-		primSet(co, intern("number?"),
-			makeNative(0, builtinIsNumber, 1, 0));
-		primSet(co, intern("read-file-as-sexp"),
-			makeNative(0, builtinReadFileAsSexp, 1, 0));
-		primSet(co, intern("string-append"),
-			makeNative(0, builtinStringAppend, 2, 0));
-		primSet(co, intern("value"),
-			makeNative(0, builtinValue, 1, 0));
-		primSet(co, intern("value-or"),
-			makeNative(0, builtinValueOr, 2, 0));
-		primSet(co, intern("apply"),
-			makeNative(0, builtinApply, 2, 0));
-		primSet(co, intern("load-so"),
-			makeNative(0, builtinLoadSo, 2, 0));
-		primSet(co, intern("import"),
-			makeNative(0, builtinImport, 1, 0));
-		primSet(co, intern("load"), makeNative(0, builtinLoad, 1, 0));
-		primSet(co, intern("vector"),
-			makeNative(0, builtinVector, 1, 0));
-		primSet(co, intern("vector?"),
-			makeNative(0, builtinIsVector, 1, 0));
-		primSet(co, intern("vector-set!"),
-			makeNative(0, builtinVectorSet, 3, 0));
-		primSet(co, intern("vector-ref"),
-			makeNative(0, builtinVectorRef, 2, 0));
-		primSet(co, intern("vector-length"),
-			makeNative(0, builtinVectorLength, 1, 0));
-		primSet(co, intern("bytes"),
-			makeNative(0, builtinBytes, 1, 0));
-		primSet(co, intern("bytes-length"),
-			makeNative(0, builtinBytesLength, 1, 0));
-		primSet(co, intern("try"),
-			makeNative(0, builtinTryCatch, 2, 0));
-		primSet(co, intern("throw"),
-			makeNative(0, builtinThrow, 1, 0));
-		primSet(co, intern("cora/init#*imported*"), Nil);
-		primSet(co, intern("symbol-cooked?"),
-			makeNative(0, builtinSymbolCooked, 1, 0));
-		primSet(co, intern("cora/lib/eval#make-closure-for-eval"),
-			makeNative(0, makeClosureForEval, 3, 0));
-		primSet(co, intern("cora/lib/sys#vm-symbol-for-tls"),
-			makeNative(0, vmSymbolForTLS, 0, 0));
-		initialized = true;
-	}
+	primSet(co, intern("symbol->string"),
+		makeNative(0, symbolToString, 1, 0));
+	primSet(co, intern("intern"),
+		makeNative(0, builtinIntern, 1, 0));
+	primSet(co, intern("number?"),
+		makeNative(0, builtinIsNumber, 1, 0));
+	primSet(co, intern("read-file-as-sexp"),
+		makeNative(0, builtinReadFileAsSexp, 1, 0));
+	primSet(co, intern("string-append"),
+		makeNative(0, builtinStringAppend, 2, 0));
+	primSet(co, intern("value"),
+		makeNative(0, builtinValue, 1, 0));
+	primSet(co, intern("value-or"),
+		makeNative(0, builtinValueOr, 2, 0));
+	primSet(co, intern("apply"),
+		makeNative(0, builtinApply, 2, 0));
+	primSet(co, intern("load-so"),
+		makeNative(0, builtinLoadSo, 2, 0));
+	primSet(co, intern("import"),
+		makeNative(0, builtinImport, 1, 0));
+	primSet(co, intern("load"), makeNative(0, builtinLoad, 1, 0));
+	primSet(co, intern("vector"),
+		makeNative(0, builtinVector, 1, 0));
+	primSet(co, intern("vector?"),
+		makeNative(0, builtinIsVector, 1, 0));
+	primSet(co, intern("vector-set!"),
+		makeNative(0, builtinVectorSet, 3, 0));
+	primSet(co, intern("vector-ref"),
+		makeNative(0, builtinVectorRef, 2, 0));
+	primSet(co, intern("vector-length"),
+		makeNative(0, builtinVectorLength, 1, 0));
+	primSet(co, intern("bytes"),
+		makeNative(0, builtinBytes, 1, 0));
+	primSet(co, intern("bytes-length"),
+		makeNative(0, builtinBytesLength, 1, 0));
+	primSet(co, intern("try"),
+		makeNative(0, builtinTryCatch, 2, 0));
+	primSet(co, intern("throw"),
+		makeNative(0, builtinThrow, 1, 0));
+	primSet(co, intern("cora/init#*imported*"), Nil);
+	primSet(co, intern("symbol-cooked?"),
+		makeNative(0, builtinSymbolCooked, 1, 0));
+	primSet(co, intern("cora/lib/eval#make-closure-for-eval"),
+		makeNative(0, makeClosureForEval, 3, 0));
+	primSet(co, intern("cora/lib/sys#vm-symbol-for-tls"),
+		makeNative(0, vmSymbolForTLS, 0, 0));
 	primSet(co, primVMSymbolForTLS(co), Nil);
 	return co;
 }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -22,7 +22,6 @@ void trampoline(struct Cora *co, int label, basicBlock pc);
 void coraDispatch(struct Cora *co);
 void coraReturn(struct Cora *co, Obj val);
 Obj coraGet(struct Cora *co, int i);
-/* void coraCall(struct Cora *co, int nargs, ...); */
 
 void pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...);
 Obj closureRef(struct Cora *co, int idx);
@@ -60,6 +59,7 @@ void registerAPI(struct Cora *co, struct registerModule* m, str pkg);
 
 
 struct Cora* coraInit(uintptr_t *mark);
+void coraExit(struct Cora *co);
 
 static inline void
 growCallStack(struct callStack *cs) {

--- a/src/types.c
+++ b/src/types.c
@@ -172,12 +172,12 @@ static void
 bytesGCFunc(struct GC *gc, void *f) {
 }
 
-struct trieNode gRoot = { };
+__thread struct trieNode *gRoot;
 
 Obj
 makeSymbol(const char *s) {
 	const char *old = s;
-	struct trieNode *p = &gRoot;
+	struct trieNode *p = gRoot;
 	for (; *s; s++) {
 		int offset = *s;
 		if (p->child[offset] == NULL) {
@@ -462,6 +462,8 @@ symbolGCFunc(struct GC *gc, void *f) {
 
 void
 typesInit() {
+	gRoot = malloc(sizeof(struct trieNode));
+	memset(gRoot, 0, sizeof(struct trieNode));
 	gcRegistForType(scmHeadCons, consGCFunc);
 	gcRegistForType(scmHeadBytes, bytesGCFunc);
 	gcRegistForType(scmHeadVector, vectorGCFunc);

--- a/src/types.c
+++ b/src/types.c
@@ -173,6 +173,7 @@ bytesGCFunc(struct GC *gc, void *f) {
 }
 
 __thread struct trieNode *gRoot;
+extern  __thread struct Cora *gCo;
 
 Obj
 makeSymbol(const char *s) {
@@ -193,6 +194,10 @@ makeSymbol(const char *s) {
 		strcpy(tmp, old);
 		p->sym = tmp;
 		p->value = Undef;
+	} else {
+		if (p->value != Undef) {
+			assert(p->owner == gCo);
+		}
 	}
 
 	return (Obj) (p) | TAG_SYMBOL;

--- a/test/parallel/main.cora
+++ b/test/parallel/main.cora
@@ -1,0 +1,27 @@
+(import "cora/lib/io")
+(import "cora/lib/async")
+(import "cora/lib/cml")
+(import "cora/lib/parallel")
+
+(display "2222222\n")
+
+(defun client ()
+  (let mb (mailbox-resolve "test")
+       (client-h 99 mb)))
+
+(defun client-h (i mb)
+  (if (= i 0)
+      ()
+      (begin
+       (mailbox-send mb "ping")
+       (display "send a ping\n")
+       (client-h (- i 1) mb))))
+
+(display "333333\n")
+
+(cml-entry (lambda ()
+	      (let mb (mailbox-make)
+		   (begin
+		    (mailbox-publish "test" mb)
+		    (new-proc "test/parallel/recv.cora")
+		    (client)))))

--- a/test/parallel/recv.cora
+++ b/test/parallel/recv.cora
@@ -1,0 +1,22 @@
+(import "cora/lib/cml")
+(import "cora/lib/io")
+(import "cora/lib/parallel")
+
+(defun server (mb)
+  (begin
+   (display "run server here\n")
+   (perform
+    (wrap (mailbox-recv mb)
+	  (lambda (v)
+	    (begin
+	     (display "server recv:")
+	     (display v)
+	     (display "\n"))))
+    )
+   (server mb)))
+
+(cml-entry (lambda ()
+	     (begin
+	      (display "befor run client\n")
+	      (let mb (mailbox-resolve "test")
+		   (server mb)))))


### PR DESCRIPTION
The current design is every cora VM has its symbols, share nothing.
For `import` operation, each cora VM will load the package once if it's not loaded.

The package init function `entry` will be called, but for .so file, the dynamic linking object just increase reference by 1
It means that for every global or static C variable, there is only ONE instance
The old generated C file can not work among multiple cora VMs
// only one copy for symxxx, it cann't be used on multiple cora VMs 
Obj symxxx = intern("xxx");  