### PR TITLE
src: add __FILE__ __LINE__ to pushCont to get debug info for callstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ cora.bin: libcora main.o init.so
 	$(CC) main.o -Lsrc $(LD_FLAG) -o $@
 
 clean:
-	rm -f *.o *.so *.bin
+	rm -f *.o *.so *.bin test/*.so
 	make clean -C src
 	make clean -C lib
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 COMPILE.c = $(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 
 clean:
-	rm -rf *.o *.so toc/internal.so
+	rm -rf *.o *.so toc/internal.so parallel/internal.so
 
 json.so: json.c
 	gcc -shared -o json.so -g json.c -fPIC -I../src -L../src -lcora -ljansson

--- a/main.c
+++ b/main.c
@@ -84,16 +84,16 @@ shebang(struct Cora *co, int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
 	uintptr_t dummy;
 	struct Cora* co = coraInit(&dummy);
-	co->args[1] = makeCString("cora/init");
 	co->nargs = 2;
+	co->args[1] = makeCString("cora/init");
 	trampoline(co, 0, builtinImport);
   
-	co->args[1] = makeCString("cora/lib/toc");
 	co->nargs = 2;
+	co->args[1] = makeCString("cora/lib/toc");
 	trampoline(co, 0, builtinImport);
 
-	co->args[1] = makeCString("cora/lib/eval");
 	co->nargs = 2;
+	co->args[1] = makeCString("cora/lib/eval");
 	trampoline(co, 0, builtinImport);
 
 	if (argc == 1) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -14,7 +14,7 @@
 const int INIT_STACK_SIZE = 254;
 
 void
-pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...) {
+pushContRaw(char* file, int line, struct Cora *co, int label, basicBlock cb, int nstack, ...) {
 	struct callStack *cs = &co->callstack;
 	if (unlikely(cs->len >= cs->cap)) {
 		growCallStack(cs);
@@ -24,6 +24,8 @@ pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...) {
 	addr->frees = co->ctx.frees;
 	addr->pc.func = cb;
 	addr->pc.label = label;
+	addr->debugFile = file;
+	addr->debugLine = line;
 
 	// Use segment stack
 	if (unlikely(co->ctx.stk.pos + nstack >= INIT_STACK_SIZE)) {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -23,7 +23,11 @@ void coraDispatch(struct Cora *co);
 void coraReturn(struct Cora *co, Obj val);
 Obj coraGet(struct Cora *co, int i);
 
-void pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...);
+void pushContRaw(char* file, int line, struct Cora *co, int label, basicBlock cb, int nstack, ...);
+
+#define pushCont(co, label, cb, nstack, ...) \
+	pushContRaw(__FILE__, __LINE__, (co), (label), (cb), (nstack), ##__VA_ARGS__)
+
 Obj closureRef(struct Cora *co, int idx);
 
 Obj primEQ(Obj x, Obj y);
@@ -90,6 +94,8 @@ growCallStack(struct callStack *cs) {
     __addr->pc.func = (cb);				\
     __addr->pc.label = (lbl);				\
     __addr->stk = (co)->ctx.stk;			\
+    __addr->debugFile = __FILE__;			\
+    __addr->debugLine = __LINE__;			\
   } while (0)
 
 #define PRIM_CAR(obj) ((Obj)(((struct scmCons*)(ptr(obj)))->car))

--- a/src/types.h
+++ b/src/types.h
@@ -129,13 +129,13 @@ struct pcState {
 };
 
 struct scmNative {
-  scmHead head;
-  struct pcState code;
-  // required is the argument number of the nativeFunc.
-  int required;
-  // captured is the size of the data, it's immutable after makeNative.
-  int captured;
-  Obj data[];
+	scmHead head;
+	struct pcState code;
+	// required is the argument number of the nativeFunc.
+	int required;
+	// captured is the size of the data, it's immutable after makeNative.
+	int captured;
+	Obj data[];
 };
 
 Obj makeNative(int label, basicBlock fn, int required, int captured, ...);
@@ -153,9 +153,12 @@ struct stackState {
 };
 
 struct frame {
-  struct stackState stk;
-  struct pcState pc;
-  Obj frees;
+	struct stackState stk;
+	struct pcState pc;
+	Obj frees;
+	// For debugging
+	char *debugFile;
+	int debugLine;
 };
 
 struct callStack {


### PR DESCRIPTION
See, debugFile and debugLine:

```
(gdb) p co->callstack 
$18 = {data = 0x5555559bb440, len = 6, cap = 256}
(gdb) p co->callstack .data[5]
$19 = {stk = {stack = 140737282813959, base = 3, pos = 6}, pc = {func = 0x7ffff3bb38e2 <clofun8>, label = 34}, 
  frees = 140737284896967, debugFile = 0x7ffff3bc3a93 "toc.c", debugLine = 12164}
(gdb) p co->callstack .data[4]
$20 = {stk = {stack = 140737282813959, base = 2, pos = 3}, pc = {func = 0x7ffff3bb38e2 <clofun8>, label = 27}, 
  frees = 140737284896391, debugFile = 0x7ffff3bc3a93 "toc.c", debugLine = 11806}
(gdb) p co->callstack .data[3]
$21 = {stk = {stack = 140737282813959, base = 2, pos = 3}, pc = {func = 0x7ffff3b768c5 <clofun2>, label = 14}, 
  frees = 140737282844511, debugFile = 0x7ffff3bc3a93 "toc.c", debugLine = 2827}
(gdb) p co->callstack .data[2]
$22 = {stk = {stack = 140737282813959, base = 0, pos = 2}, pc = {func = 0x7ffff3b63e88 <clofun0>, label = 9}, 
  frees = 140737282845031, debugFile = 0x7ffff3bc3a93 "toc.c", debugLine = 421}
(gdb) p co->callstack .data[1]
$23 = {stk = {stack = 140737282813959, base = 0, pos = 0}, pc = {func = 0x0, label = 0}, frees = 140737282818455, 
  debugFile = 0x7ffff7ec2854 "runtime.c", debugLine = 181}
```